### PR TITLE
 Add Docker support for backend (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,43 @@ You connect a Stellar wallet. You mint a remittance NFT that holds your payment 
 5. Approve it in the admin view.
 6. Repay it.
 7. Watch your score respond and your NFT unlock.
+
+## Running with Docker
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- A `.env` file inside `backend/` (see below)
+
+### Environment variables
+
+Create `backend/.env` with at minimum:
+
+```
+PORT=3001
+```
+
+Add any other variables your app needs (e.g. API keys) to this file. It is already gitignored.
+
+### Local development
+
+From the **repo root**:
+
+```bash
+docker compose up --build
+```
+
+This starts the backend on **http://localhost:3001** with source files mounted for hot-reload.
+To stop: `Ctrl-C`, then `docker compose down`.
+
+### Production image
+
+Build and run the optimised production image directly:
+
+```bash
+# From the backend/ directory
+docker build -t remitlend-backend .
+docker run --env-file .env -p 3001:3001 remitlend-backend
+```
+
+The multistage build compiles TypeScript in a `builder` stage, then copies only the compiled `dist/` and production `node_modules` into the final image — keeping it lean and running as a non-root user.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,33 @@
+# Builder Stage
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install all dependencies including devDependencies needed for tsc
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and compile
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# Production Stage
+FROM node:22-alpine AS production
+
+WORKDIR /app
+
+# Install only production dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy compiled output from builder
+COPY --from=builder /app/dist ./dist
+
+# Non-root user for security
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon --exec ts-node --esm src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,8 +2,8 @@
   // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
     // File Layout
-    // "rootDir": "./src",
-    // "outDir": "./dist",
+    "rootDir": "./src",
+    "outDir": "./dist",
 
     // Environment Settings
     // See also https://aka.ms/tsconfig/module

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      target: builder       
+    command: npm run dev
+    ports:
+      - "3001:3001"
+    env_file:
+      - ./backend/.env
+    volumes:
+      - ./backend/src:/app/src  
+    restart: unless-stopped


### PR DESCRIPTION
## Overview

Containerized the backend for consistent, reproducible deployments.

## Changes
1. backend/Dockerfile
      -  Multistage build: builder stage compiles TypeScript, production stage runs only compiled output + prod deps as a non-root user
2. docker-compose.yml
     - Local dev setup; mounts src/ for hot-reload via npm run dev
3. backend/.dockerignore
     - Excludes node_modules, dist, .env, and logs from build context
4. backend/tsconfig.json
     - Enabled rootDir/outDir so tsc emits to dist/
5. backend/package.json
      - Added build, start, and dev scripts
6. README.md
     - Added Running with Docker section covering local dev and production image usage


Closes #14 