### PR TITLE
feat: configure CORS with allowed origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,7 +6,23 @@ import { swaggerSpec } from "./config/swagger.js";
 
 const app = express();
 
-app.use(cors());
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
+    ? process.env.CORS_ALLOWED_ORIGINS.split(',').map(origin => origin.trim())
+    : [];
+
+const corsOptions: cors.CorsOptions = {
+    origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+            return callback(null, true);
+        }
+        return callback(new Error('Not allowed by CORS'));
+    },
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    credentials: true,
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.get('/', (req: Request, res: Response) => {


### PR DESCRIPTION
Configure CORS properly to allow requests only from trusted origins.
- Update cors options in app.ts
- specific allowable origins via environment variables

closes #17 