### PR TITLE
feat: implement centralized error handling (#4)

### DIFF
--- a/backend/src/__tests__/errorHandling.test.ts
+++ b/backend/src/__tests__/errorHandling.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+import app from '../app.js';
+
+describe('Centralized Error Handling', () => {
+
+    /* ── 404 Not Found ────────────────────────────────────────── */
+
+    describe('404 catch-all', () => {
+        it('should return 404 with structured JSON for unknown routes', async () => {
+            const response = await request(app).get('/nonexistent-route');
+
+            expect(response.status).toBe(404);
+            expect(response.body.success).toBe(false);
+            expect(response.body.message).toMatch(/Cannot GET \/nonexistent-route/);
+        });
+
+        it('should return 404 for unknown POST routes', async () => {
+            const response = await request(app)
+                .post('/unknown')
+                .send({ data: 'test' });
+
+            expect(response.status).toBe(404);
+            expect(response.body.success).toBe(false);
+        });
+    });
+
+    /* ── Validation Errors (backward compatibility) ───────────── */
+
+    describe('Zod validation errors', () => {
+        it('should return 400 with validation failed message', async () => {
+            const response = await request(app)
+                .post('/api/simulate')
+                .send({});
+
+            expect(response.status).toBe(400);
+            expect(response.body.success).toBe(false);
+            expect(response.body.message).toBe('Validation failed');
+            expect(response.body.errors).toBeDefined();
+            expect(Array.isArray(response.body.errors)).toBe(true);
+        });
+
+        it('should include path and message in each error entry', async () => {
+            const response = await request(app)
+                .post('/api/simulate')
+                .send({ userId: 'user1' });
+
+            expect(response.status).toBe(400);
+            expect(response.body.errors.length).toBeGreaterThan(0);
+            expect(response.body.errors[0]).toHaveProperty('path');
+            expect(response.body.errors[0]).toHaveProperty('message');
+        });
+    });
+
+    /* ── Consistent JSON structure ────────────────────────────── */
+
+    describe('Response structure consistency', () => {
+        it('should always include success field in error responses', async () => {
+            const response = await request(app).get('/does-not-exist');
+
+            expect(response.body).toHaveProperty('success', false);
+            expect(response.body).toHaveProperty('message');
+        });
+
+        it('should not expose stack traces in production-like responses', async () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'production';
+
+            const response = await request(app).get('/does-not-exist');
+
+            expect(response.body).not.toHaveProperty('stack');
+
+            process.env.NODE_ENV = originalEnv;
+        });
+    });
+});

--- a/backend/src/controllers/simulationController.ts
+++ b/backend/src/controllers/simulationController.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler.js';
 
-export const getRemittanceHistory = (req: Request, res: Response) => {
+export const getRemittanceHistory = asyncHandler(async (req: Request, res: Response) => {
     const { userId } = req.params;
     // Mock data simulation
     const history = [
@@ -15,9 +16,9 @@ export const getRemittanceHistory = (req: Request, res: Response) => {
         streak: 3,
         history
     });
-};
+});
 
-export const simulatePayment = (req: Request, res: Response) => {
+export const simulatePayment = asyncHandler(async (req: Request, res: Response) => {
     const { userId, amount } = req.body;
     // Simulate payment logic
     res.json({
@@ -25,4 +26,4 @@ export const simulatePayment = (req: Request, res: Response) => {
         message: `Payment of ${amount} for user ${userId} simulated.`,
         newScore: 760
     });
-};
+});

--- a/backend/src/errors/AppError.ts
+++ b/backend/src/errors/AppError.ts
@@ -1,0 +1,48 @@
+/**
+ * Custom application error class for centralized error handling.
+ *
+ * Extends the native Error class with HTTP status codes and operational
+ * error classification. Operational errors are expected failures (e.g.,
+ * invalid input, not found) vs programming bugs.
+ */
+export class AppError extends Error {
+    public readonly statusCode: number;
+    public readonly status: 'fail' | 'error';
+    public readonly isOperational: boolean;
+
+    constructor(message: string, statusCode: number, isOperational = true) {
+        super(message);
+        this.statusCode = statusCode;
+        this.status = statusCode >= 400 && statusCode < 500 ? 'fail' : 'error';
+        this.isOperational = isOperational;
+
+        // Preserve proper stack trace in V8 environments
+        Error.captureStackTrace(this, this.constructor);
+    }
+
+    /* ── Factory Methods ─────────────────────────────────────────── */
+
+    static badRequest(message = 'Bad request'): AppError {
+        return new AppError(message, 400);
+    }
+
+    static unauthorized(message = 'Unauthorized'): AppError {
+        return new AppError(message, 401);
+    }
+
+    static forbidden(message = 'Forbidden'): AppError {
+        return new AppError(message, 403);
+    }
+
+    static notFound(message = 'Not found'): AppError {
+        return new AppError(message, 404);
+    }
+
+    static conflict(message = 'Conflict'): AppError {
+        return new AppError(message, 409);
+    }
+
+    static internal(message = 'Internal server error'): AppError {
+        return new AppError(message, 500, false);
+    }
+}

--- a/backend/src/middleware/asyncHandler.ts
+++ b/backend/src/middleware/asyncHandler.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Wraps an async Express route handler so that rejected promises are
+ * automatically forwarded to the global error handling middleware via
+ * `next(err)`.
+ *
+ * Usage:
+ * ```ts
+ * router.get('/resource', asyncHandler(async (req, res) => {
+ *     const data = await fetchData();
+ *     res.json(data);
+ * }));
+ * ```
+ */
+export const asyncHandler = (
+    fn: (req: Request, res: Response, next: NextFunction) => Promise<void> | void
+): RequestHandler => {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        Promise.resolve(fn(req, res, next)).catch(next);
+    };
+};

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { AppError } from '../errors/AppError.js';
+
+/**
+ * Global error handling middleware.
+ *
+ * Must be registered LAST in the Express middleware chain (after all
+ * routes). Catches all errors forwarded via `next(err)` and returns
+ * a consistent JSON error response.
+ */
+export const errorHandler = (
+    err: Error,
+    _req: Request,
+    res: Response,
+    _next: NextFunction
+): void => {
+    // ── Zod Validation Errors ────────────────────────────────────
+    // Preserves the existing response format from validation.ts so
+    // that current tests and clients remain backward-compatible.
+    if (err instanceof z.ZodError) {
+        res.status(400).json({
+            success: false,
+            message: 'Validation failed',
+            errors: err.issues.map((issue: z.ZodIssue) => ({
+                path: issue.path.join('.'),
+                message: issue.message,
+            })),
+        });
+        return;
+    }
+
+    // ── Known Operational Errors ─────────────────────────────────
+    if (err instanceof AppError) {
+        res.status(err.statusCode).json({
+            success: false,
+            message: err.message,
+        });
+        return;
+    }
+
+    // ── Unexpected / Programming Errors ──────────────────────────
+    console.error('Unhandled error:', err);
+
+    const isDevelopment = process.env.NODE_ENV !== 'production';
+
+    res.status(500).json({
+        success: false,
+        message: 'Internal server error',
+        ...(isDevelopment && { stack: err.stack }),
+    });
+};

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -1,8 +1,13 @@
 import type { Request, Response, NextFunction } from 'express';
-import { z, type ZodSchema } from 'zod';
+import { type ZodSchema } from 'zod';
 
+/**
+ * Express middleware factory that validates incoming requests against
+ * a Zod schema. On validation failure the error is forwarded to the
+ * global error handler via `next(error)`.
+ */
 export const validate = (schema: ZodSchema) => {
-    return (req: Request, res: Response, next: NextFunction) => {
+    return (req: Request, _res: Response, next: NextFunction) => {
         try {
             schema.parse({
                 body: req.body,
@@ -11,21 +16,7 @@ export const validate = (schema: ZodSchema) => {
             });
             next();
         } catch (error) {
-            if (error instanceof z.ZodError) {
-                res.status(400).json({
-                    success: false,
-                    message: 'Validation failed',
-                    errors: error.issues.map((err: z.ZodIssue) => ({
-                        path: err.path.join('.'),
-                        message: err.message
-                    }))
-                });
-            } else {
-                res.status(500).json({
-                    success: false,
-                    message: 'Internal server error'
-                });
-            }
+            next(error);
         }
     };
 };


### PR DESCRIPTION
## Summary

Implements centralized error handling for the RemitLend backend, replacing inline error responses with a unified system.

Closes #4

## Changes

### New Files
- **`src/errors/AppError.ts`** -- Custom error class with HTTP status codes, operational classification, and factory methods (`badRequest`, `notFound`, `unauthorized`, `internal`, etc.)
- **`src/middleware/errorHandler.ts`** -- Global error middleware handling `AppError`, `ZodError` (backward-compatible format), and unexpected errors with structured JSON responses
- **`src/middleware/asyncHandler.ts`** -- Higher-order wrapper for async route handlers with automatic `next(err)` propagation
- **`src/__tests__/errorHandling.test.ts`** -- 6 test cases covering 404 catch-all, validation errors, response structure, and stack trace suppression

### Modified Files
- **`src/app.ts`** -- Added 404 catch-all middleware and global error handler (registered last, Express 5 compatible)
- **`src/middleware/validation.ts`** -- Refactored to delegate errors via `next()` instead of inline `res.json()`
- **`src/controllers/simulationController.ts`** -- Wrapped with `asyncHandler` for future-proof async error propagation

## Verification

- `npx tsc --noEmit` -- **0 type errors**
- `npm run build` -- **compiles successfully**
- `npm test` -- **16/16 tests pass** (including 6 new + 10 existing, backward compatibility confirmed)