### PR TITLE
setup React Query with QueryClientProvider and custom hooks

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -68,7 +70,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1515,6 +1516,59 @@
         "tailwindcss": "4.2.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
+      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.93.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.20",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1563,7 +1617,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1623,7 +1676,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2136,7 +2188,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2423,7 +2474,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2491,7 +2541,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3059,7 +3108,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5442,7 +5490,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5452,7 +5499,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6141,7 +6187,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6304,7 +6349,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6580,7 +6624,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/frontend/src/app/components/providers/QueryProvider.tsx
+++ b/frontend/src/app/components/providers/QueryProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * components/providers/QueryProvider.tsx
+ *
+ * Wraps the application with TanStack Query's QueryClientProvider.
+ * Must be a client component since QueryClient is browser-side state.
+ *
+ * Usage: wrap your root layout children with <QueryProvider>
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState, type ReactNode } from "react";
+
+interface QueryProviderProps {
+  children: ReactNode;
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  /**
+   * useState ensures a new QueryClient is created per component instance
+   * (not shared across requests in SSR environments).
+   */
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // Data is considered fresh for 60 seconds — avoids unnecessary refetches
+            staleTime: 60 * 1000,
+            // Retry failed requests once before showing an error
+            retry: 1,
+            // Refetch when the browser window regains focus
+            refetchOnWindowFocus: true,
+          },
+          mutations: {
+            // Retry failed mutations once
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {/* DevTools only render in development */}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -1,0 +1,258 @@
+/**
+ * hooks/useApi.ts
+ *
+ * Custom hooks for data fetching using TanStack Query.
+ * Each hook wraps a specific API endpoint with caching,
+ * loading states, and error handling built in.
+ *
+ * Base URL is read from NEXT_PUBLIC_API_URL environment variable.
+ */
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type UseQueryOptions,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+/**
+ * Centralised query key factory.
+ * Using structured keys makes targeted cache invalidation easy.
+ *
+ * Usage:
+ *   queryKeys.loans.all()       → ["loans"]
+ *   queryKeys.loans.detail(id)  → ["loans", id]
+ */
+export const queryKeys = {
+  loans: {
+    all: () => ["loans"] as const,
+    detail: (id: string) => ["loans", id] as const,
+  },
+  remittances: {
+    all: () => ["remittances"] as const,
+    detail: (id: string) => ["remittances", id] as const,
+  },
+  user: {
+    profile: () => ["user", "profile"] as const,
+    balance: () => ["user", "balance"] as const,
+  },
+} as const;
+
+// ─── Base fetch helper ────────────────────────────────────────────────────────
+
+/**
+ * Thin fetch wrapper that:
+ * - Prepends the API base URL
+ * - Sets JSON Content-Type
+ * - Throws a descriptive error on non-2xx responses
+ */
+async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const headers = new Headers(options.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(`${API_URL}${path}`, { ...options, headers });
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ message: response.statusText }));
+    throw new Error(
+      error.message ?? `Request failed with status ${response.status}`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface Loan {
+  id: string;
+  amount: number;
+  currency: string;
+  interestRate: number;
+  termDays: number;
+  status: "pending" | "active" | "repaid" | "defaulted";
+  borrowerId: string;
+  createdAt: string;
+}
+
+export interface Remittance {
+  id: string;
+  amount: number;
+  fromCurrency: string;
+  toCurrency: string;
+  recipientAddress: string;
+  status: "pending" | "processing" | "completed" | "failed";
+  createdAt: string;
+}
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  walletAddress?: string;
+  kycVerified: boolean;
+}
+
+export interface UserBalance {
+  available: number;
+  locked: number;
+  currency: string;
+}
+
+// ─── Loan hooks ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetches all loans.
+ * Data is cached for 60s (inherits QueryClient default staleTime).
+ */
+export function useLoans(
+  options?: Omit<UseQueryOptions<Loan[]>, "queryKey" | "queryFn">,
+) {
+  return useQuery<Loan[]>({
+    queryKey: queryKeys.loans.all(),
+    queryFn: () => apiFetch<Loan[]>("/loans"),
+    ...options,
+  });
+}
+
+/**
+ * Fetches a single loan by ID.
+ * Only runs when a valid id is provided.
+ */
+export function useLoan(
+  id: string | undefined,
+  options?: Omit<UseQueryOptions<Loan>, "queryKey" | "queryFn">,
+) {
+  return useQuery<Loan>({
+    queryKey: queryKeys.loans.detail(id ?? ""),
+    queryFn: () => apiFetch<Loan>(`/loans/${id}`),
+    enabled: !!id,
+    ...options,
+  });
+}
+
+/**
+ * Creates a new loan application.
+ * Automatically invalidates the loans list cache on success.
+ */
+export function useCreateLoan(
+  options?: UseMutationOptions<
+    Loan,
+    Error,
+    Omit<Loan, "id" | "createdAt" | "status">
+  >,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Loan, Error, Omit<Loan, "id" | "createdAt" | "status">>({
+    mutationFn: (data) =>
+      apiFetch<Loan>("/loans", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      // Invalidate the loans list so it refetches with the new entry
+      queryClient.invalidateQueries({ queryKey: queryKeys.loans.all() });
+    },
+    ...options,
+  });
+}
+
+// ─── Remittance hooks ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches all remittances.
+ */
+export function useRemittances(
+  options?: Omit<UseQueryOptions<Remittance[]>, "queryKey" | "queryFn">,
+) {
+  return useQuery<Remittance[]>({
+    queryKey: queryKeys.remittances.all(),
+    queryFn: () => apiFetch<Remittance[]>("/remittances"),
+    ...options,
+  });
+}
+
+/**
+ * Fetches a single remittance by ID.
+ */
+export function useRemittance(
+  id: string | undefined,
+  options?: Omit<UseQueryOptions<Remittance>, "queryKey" | "queryFn">,
+) {
+  return useQuery<Remittance>({
+    queryKey: queryKeys.remittances.detail(id ?? ""),
+    queryFn: () => apiFetch<Remittance>(`/remittances/${id}`),
+    enabled: !!id,
+    ...options,
+  });
+}
+
+/**
+ * Creates a new remittance.
+ * Invalidates the remittances list cache on success.
+ */
+export function useCreateRemittance(
+  options?: UseMutationOptions<
+    Remittance,
+    Error,
+    Omit<Remittance, "id" | "createdAt" | "status">
+  >,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Remittance,
+    Error,
+    Omit<Remittance, "id" | "createdAt" | "status">
+  >({
+    mutationFn: (data) =>
+      apiFetch<Remittance>("/remittances", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.remittances.all() });
+    },
+    ...options,
+  });
+}
+
+// ─── User hooks ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the current user's profile.
+ */
+export function useUserProfile(
+  options?: Omit<UseQueryOptions<UserProfile>, "queryKey" | "queryFn">,
+) {
+  return useQuery<UserProfile>({
+    queryKey: queryKeys.user.profile(),
+    queryFn: () => apiFetch<UserProfile>("/user/profile"),
+    ...options,
+  });
+}
+
+/**
+ * Fetches the current user's wallet balance.
+ */
+export function useUserBalance(
+  options?: Omit<UseQueryOptions<UserBalance>, "queryKey" | "queryFn">,
+) {
+  return useQuery<UserBalance>({
+    queryKey: queryKeys.user.balance(),
+    queryFn: () => apiFetch<UserBalance>("/user/balance"),
+    ...options,
+  });
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { QueryProvider } from "@/app/components/providers/QueryProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -14,12 +15,21 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "RemitLend - Borderless P2P Lending & Remittance",
-  description: "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
-  keywords: ["P2P Lending", "Remittance", "Blockchain", "DeFi", "Global Payments", "Borderless Finance"],
+  description:
+    "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
+  keywords: [
+    "P2P Lending",
+    "Remittance",
+    "Blockchain",
+    "DeFi",
+    "Global Payments",
+    "Borderless Finance",
+  ],
   authors: [{ name: "RemitLend Team" }],
   openGraph: {
     title: "RemitLend - Borderless P2P Lending & Remittance",
-    description: "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
+    description:
+      "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
     url: "https://remitlend.com",
     siteName: "RemitLend",
     images: [
@@ -36,7 +46,8 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "RemitLend - Borderless P2P Lending & Remittance",
-    description: "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
+    description:
+      "Global peer-to-peer lending and instant remittances powered by blockchain technology. Send money and grow your wealth across borders.",
     images: ["/og-image.png"],
     creator: "@remitlend",
   },
@@ -53,7 +64,8 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        {/* QueryProvider wraps the entire app so any component can use React Query hooks */}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
closes #44

What was added:
. @tanstack/react-query and @tanstack/react-query-devtools installed as dependencies.
. app/components/providers/QueryProvider.tsx — configures QueryClient with sensible defaults (60s staleTime, 1 retry, refetch  on window focus) and wraps children with QueryClientProvider. DevTools only render in development.
. app/hooks/useApi.ts — custom hooks for all API calls:
useLoans / useLoan / useCreateLoan
useRemittances / useRemittance / useCreateRemittance
useUserProfile / useUserBalance

*Includes a centralised queryKeys factory for structured cache invalidation and a base apiFetch helper that handles errors and   headers.
. app/layout.tsx — updated to wrap the entire app with QueryProvider so any component can use React Query hooks.

Files changed:
frontend/app/layout.tsx
frontend/app/components/providers/QueryProvider.tsx — new file
frontend/app/hooks/useApi.ts — new file
frontend/package.json — TanStack Query dependencies added

Acceptance criteria met:
. TanStack Query installed
. QueryClientProvider configured and wrapping the app
. Custom hooks created for API calls
. DevTools confirmed working in browser

How to test:
Run npm run dev in the frontend folder
Open http://localhost:3000
Click the TanStack icon in the bottom left corner
Confirm React Query DevTools panel opens showing Queries and Mutations tabs