### PR TITLE
test(frontend): setup E2E testing with Playwright

### DIFF
--- a/frontend/e2e/landing-page.spec.ts
+++ b/frontend/e2e/landing-page.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing Page', () => {
+  test('should load the landing page successfully', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(/remitlend|Next/i);
+
+    await expect(page.locator('main')).toBeVisible();
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  });
+
+  test('should display main content elements', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('link', { name: /templates/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /learning/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /deploy/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /documentation/i })).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
@@ -19,6 +21,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Add Playwright as E2E testing framework for the frontend
- Configure Playwright with base URL (http://localhost:3000) and test environment
- Add test for landing page load scenario with content verification

Closes #34