### PR TITLE
Api security

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
+        "helmet": "^8.1.0",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.18.0",
         "swagger-jsdoc": "^6.2.8",
@@ -6031,6 +6032,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hermes-estree": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
+    "helmet": "^8.1.0",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.18.0",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import express, {
 } from "express";
 import cors from "cors";
 import compression from "compression";
+import helmet from "helmet";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -19,6 +20,30 @@ import { asyncHandler } from "./middleware/asyncHandler.js";
 import { AppError } from "./errors/AppError.js";
 
 const app = express();
+
+const isProduction = process.env.NODE_ENV === "production";
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        "default-src": ["'self'"],
+        "script-src": ["'self'", "'unsafe-inline'"],
+        "style-src": ["'self'", "https:", "'unsafe-inline'"],
+        "img-src": ["'self'", "data:", "https:"],
+        "font-src": ["'self'", "https:", "data:"],
+        "frame-ancestors": ["'self'"],
+      },
+    },
+    strictTransportSecurity: isProduction
+      ? {
+          maxAge: 31536000,
+          includeSubDomains: true,
+          preload: true,
+        }
+      : false,
+  }),
+);
 
 const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
   ? process.env.CORS_ALLOWED_ORIGINS.split(",").map((origin) => origin.trim())


### PR DESCRIPTION
## Description
Enhance API security by setting secure HTTP headers via Helmet.
Closes #37 
## Changes
- **Installed** `helmet` in the backend.
- **Applied** Helmet middleware globally (first in the middleware chain) so all responses get security headers.
- **Content-Security-Policy (CSP):** Configured directives for default-src, script-src, style-src, img-src, font-src, and frame-ancestors. Allows Swagger UI at `/api/docs` while restricting sources.
- **Strict-Transport-Security (HSTS):** Enabled in production only with `max-age=31536000`, `includeSubDomains`, and `preload`. Disabled in development to avoid forcing HTTPS on localhost.
- Other Helmet defaults remain in place (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, etc.) to protect against XSS, clickjacking, and MIME sniffing.

## Testing
- Backend TypeScript build passes.
- HSTS is off in development so local HTTP still works.