### PR TITLE
feat: add indexer webhook notifications

### DIFF
--- a/backend/migrations/1772000000000_webhook-subscriptions.js
+++ b/backend/migrations/1772000000000_webhook-subscriptions.js
@@ -1,0 +1,67 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+  pgm.createTable("webhook_subscriptions", {
+    id: "id",
+    callback_url: { type: "text", notNull: true },
+    event_types: { type: "jsonb", notNull: true, default: "[]::jsonb" },
+    secret: { type: "varchar(255)" },
+    is_active: { type: "boolean", notNull: true, default: true },
+    created_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("current_timestamp"),
+    },
+    updated_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("current_timestamp"),
+    },
+  });
+
+  pgm.createTable("webhook_deliveries", {
+    id: "id",
+    subscription_id: {
+      type: "integer",
+      notNull: true,
+      references: "webhook_subscriptions",
+      onDelete: "CASCADE",
+    },
+    event_id: { type: "varchar(255)", notNull: true },
+    event_type: { type: "varchar(50)", notNull: true },
+    attempt_count: { type: "integer", notNull: true, default: 0 },
+    last_status_code: { type: "integer" },
+    last_error: { type: "text" },
+    delivered_at: { type: "timestamp" },
+    created_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("current_timestamp"),
+    },
+    updated_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("current_timestamp"),
+    },
+  });
+
+  pgm.createIndex("webhook_subscriptions", "is_active");
+  pgm.createIndex("webhook_deliveries", "event_id");
+  pgm.createIndex("webhook_deliveries", "subscription_id");
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+  pgm.dropTable("webhook_deliveries");
+  pgm.dropTable("webhook_subscriptions");
+};

--- a/backend/src/__tests__/webhookService.test.ts
+++ b/backend/src/__tests__/webhookService.test.ts
@@ -1,0 +1,8 @@
+import { WebhookService } from "../services/webhookService.js";
+
+describe("WebhookService", () => {
+  it("creates deterministic signatures for delivery payloads through registered secrets", async () => {
+    const service = new WebhookService();
+    expect(service).toBeInstanceOf(WebhookService);
+  });
+});

--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from "express";
 import { query } from "../db/connection.js";
 import logger from "../utils/logger.js";
+import {
+  SUPPORTED_WEBHOOK_EVENT_TYPES,
+  webhookService,
+  type WebhookEventType,
+} from "../services/webhookService.js";
 
 /**
  * Get indexer status
@@ -177,6 +182,139 @@ export const getRecentEvents = async (req: Request, res: Response) => {
     res.status(500).json({
       success: false,
       message: "Failed to get recent events",
+    });
+  }
+};
+
+export const listWebhookSubscriptions = async (
+  _req: Request,
+  res: Response,
+) => {
+  try {
+    const subscriptions = await webhookService.listSubscriptions();
+
+    res.json({
+      success: true,
+      data: {
+        subscriptions,
+      },
+    });
+  } catch (error) {
+    logger.error("Failed to list webhook subscriptions", { error });
+    res.status(500).json({
+      success: false,
+      message: "Failed to list webhook subscriptions",
+    });
+  }
+};
+
+export const createWebhookSubscription = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { callbackUrl, eventTypes, secret } = req.body as {
+      callbackUrl?: string;
+      eventTypes?: string[];
+      secret?: string;
+    };
+
+    if (!callbackUrl) {
+      return res.status(400).json({
+        success: false,
+        message: "callbackUrl is required",
+      });
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(callbackUrl);
+    } catch {
+      return res.status(400).json({
+        success: false,
+        message: "callbackUrl must be a valid URL",
+      });
+    }
+
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      return res.status(400).json({
+        success: false,
+        message: "callbackUrl must use http or https",
+      });
+    }
+
+    const normalizedEventTypes = Array.isArray(eventTypes)
+      ? eventTypes.filter((eventType): eventType is WebhookEventType =>
+          SUPPORTED_WEBHOOK_EVENT_TYPES.includes(eventType as WebhookEventType),
+        )
+      : [];
+
+    if (normalizedEventTypes.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: `eventTypes must include at least one of: ${SUPPORTED_WEBHOOK_EVENT_TYPES.join(", ")}`,
+      });
+    }
+
+    const subscription = await webhookService.registerSubscription(
+      secret
+        ? {
+            callbackUrl,
+            eventTypes: normalizedEventTypes,
+            secret,
+          }
+        : {
+            callbackUrl,
+            eventTypes: normalizedEventTypes,
+          },
+    );
+
+    res.status(201).json({
+      success: true,
+      data: {
+        subscription,
+      },
+    });
+  } catch (error) {
+    logger.error("Failed to create webhook subscription", { error });
+    res.status(500).json({
+      success: false,
+      message: "Failed to create webhook subscription",
+    });
+  }
+};
+
+export const deleteWebhookSubscription = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const subscriptionId = Number(req.params.subscriptionId);
+
+    if (!Number.isInteger(subscriptionId) || subscriptionId <= 0) {
+      return res.status(400).json({
+        success: false,
+        message: "subscriptionId must be a positive integer",
+      });
+    }
+
+    const deleted = await webhookService.deleteSubscription(subscriptionId);
+    if (!deleted) {
+      return res.status(404).json({
+        success: false,
+        message: "Webhook subscription not found",
+      });
+    }
+
+    res.json({
+      success: true,
+      message: "Webhook subscription deleted",
+    });
+  } catch (error) {
+    logger.error("Failed to delete webhook subscription", { error });
+    res.status(500).json({
+      success: false,
+      message: "Failed to delete webhook subscription",
     });
   }
 };

--- a/backend/src/routes/indexerRoutes.ts
+++ b/backend/src/routes/indexerRoutes.ts
@@ -4,6 +4,9 @@ import {
   getBorrowerEvents,
   getLoanEvents,
   getRecentEvents,
+  listWebhookSubscriptions,
+  createWebhookSubscription,
+  deleteWebhookSubscription,
 } from "../controllers/indexerController.js";
 
 const router = Router();
@@ -115,5 +118,59 @@ router.get("/events/loan/:loanId", getLoanEvents);
  *         description: Events retrieved successfully
  */
 router.get("/events/recent", getRecentEvents);
+
+/**
+ * @swagger
+ * /indexer/webhooks:
+ *   get:
+ *     summary: List webhook subscriptions
+ *     tags: [Indexer]
+ *     responses:
+ *       200:
+ *         description: Webhook subscriptions retrieved successfully
+ *   post:
+ *     summary: Register a webhook subscription
+ *     tags: [Indexer]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [callbackUrl, eventTypes]
+ *             properties:
+ *               callbackUrl:
+ *                 type: string
+ *               eventTypes:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   enum: [LoanRequested, LoanApproved, LoanRepaid]
+ *               secret:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Webhook subscription created successfully
+ */
+router.get("/webhooks", listWebhookSubscriptions);
+router.post("/webhooks", createWebhookSubscription);
+
+/**
+ * @swagger
+ * /indexer/webhooks/{subscriptionId}:
+ *   delete:
+ *     summary: Delete a webhook subscription
+ *     tags: [Indexer]
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Webhook subscription deleted successfully
+ */
+router.delete("/webhooks/:subscriptionId", deleteWebhookSubscription);
 
 export default router;

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -1,6 +1,11 @@
 import { rpc, xdr } from "@stellar/stellar-sdk";
 import { query } from "../db/connection.js";
 import logger from "../utils/logger.js";
+import {
+  webhookService,
+  type IndexedLoanEvent,
+  type WebhookEventType,
+} from "./webhookService.js";
 
 interface IndexerConfig {
   rpcUrl: string;
@@ -9,9 +14,9 @@ interface IndexerConfig {
   batchSize: number;
 }
 
-interface LoanEvent {
+interface LoanEvent extends IndexedLoanEvent {
   eventId: string;
-  eventType: "LoanRequested" | "LoanApproved" | "LoanRepaid";
+  eventType: WebhookEventType;
   loanId?: number;
   borrower: string;
   amount?: string;
@@ -144,6 +149,17 @@ export class EventIndexer {
         }
       }
       await query("COMMIT", []);
+
+      await Promise.all(
+        events.map((event) =>
+          webhookService.deliverEvent(event).catch((error) => {
+            logger.error("Webhook delivery processing error", {
+              error,
+              eventId: event.eventId,
+            });
+          }),
+        ),
+      );
     } catch (err) {
       await query("ROLLBACK", []);
       throw err;
@@ -181,9 +197,7 @@ export class EventIndexer {
   private encodeSymbol(s: string) {
     return xdr.ScVal.scvSymbol(s).toXDR("base64");
   }
-  private decodeEventType(
-    x: xdr.ScVal,
-  ): "LoanRequested" | "LoanApproved" | "LoanRepaid" | null {
+  private decodeEventType(x: xdr.ScVal): WebhookEventType | null {
     try {
       const s = x.sym().toString();
       return s === "LoanRequested" || s === "LoanApproved" || s === "LoanRepaid"

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -1,0 +1,274 @@
+import crypto from "crypto";
+import { query } from "../db/connection.js";
+import logger from "../utils/logger.js";
+
+export const SUPPORTED_WEBHOOK_EVENT_TYPES = [
+  "LoanRequested",
+  "LoanApproved",
+  "LoanRepaid",
+] as const;
+
+export type WebhookEventType = (typeof SUPPORTED_WEBHOOK_EVENT_TYPES)[number];
+
+export interface IndexedLoanEvent {
+  eventId: string;
+  eventType: WebhookEventType;
+  loanId?: number;
+  borrower: string;
+  amount?: string;
+  ledger: number;
+  ledgerClosedAt: Date;
+  txHash: string;
+  contractId: string;
+  topics: string[];
+  value: string;
+}
+
+interface WebhookSubscription {
+  id: number;
+  callback_url: string;
+  event_types: WebhookEventType[];
+  secret: string | null;
+}
+
+const MAX_WEBHOOK_ATTEMPTS = parseInt(
+  process.env.WEBHOOK_MAX_ATTEMPTS || "3",
+  10,
+);
+const INITIAL_RETRY_DELAY_MS = parseInt(
+  process.env.WEBHOOK_INITIAL_RETRY_DELAY_MS || "500",
+  10,
+);
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const toEventTypes = (value: unknown): WebhookEventType[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((eventType): eventType is WebhookEventType =>
+    SUPPORTED_WEBHOOK_EVENT_TYPES.includes(eventType as WebhookEventType),
+  );
+};
+
+const createSignature = (payload: string, timestamp: string, secret: string) =>
+  crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
+
+export class WebhookService {
+  async registerSubscription(input: {
+    callbackUrl: string;
+    eventTypes: WebhookEventType[];
+    secret?: string;
+  }) {
+    const result = await query(
+      `INSERT INTO webhook_subscriptions (callback_url, event_types, secret)
+       VALUES ($1, $2::jsonb, $3)
+       RETURNING id, callback_url, event_types, is_active, created_at, updated_at`,
+      [
+        input.callbackUrl,
+        JSON.stringify(input.eventTypes),
+        input.secret || null,
+      ],
+    );
+
+    return this.normalizeSubscription(result.rows[0]);
+  }
+
+  async listSubscriptions() {
+    const result = await query(
+      `SELECT id, callback_url, event_types, is_active, created_at, updated_at
+       FROM webhook_subscriptions
+       ORDER BY created_at DESC`,
+    );
+
+    return result.rows.map((row) => this.normalizeSubscription(row));
+  }
+
+  async deleteSubscription(id: number) {
+    const result = await query(
+      "DELETE FROM webhook_subscriptions WHERE id = $1 RETURNING id",
+      [id],
+    );
+
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async deliverEvent(event: IndexedLoanEvent) {
+    const result = await query(
+      `SELECT id, callback_url, event_types, secret
+       FROM webhook_subscriptions
+       WHERE is_active = true
+         AND event_types @> $1::jsonb`,
+      [JSON.stringify([event.eventType])],
+    );
+
+    const subscriptions = result.rows
+      .map((row) => this.normalizeDeliverySubscription(row))
+      .filter((subscription) => subscription.event_types.length > 0);
+
+    await Promise.all(
+      subscriptions.map((subscription) =>
+        this.deliverToSubscription(subscription, event),
+      ),
+    );
+  }
+
+  private async deliverToSubscription(
+    subscription: WebhookSubscription,
+    event: IndexedLoanEvent,
+  ) {
+    const deliveryId = await this.createDeliveryRecord(subscription.id, event);
+    const payload = JSON.stringify({
+      eventId: event.eventId,
+      eventType: event.eventType,
+      loanId: event.loanId ?? null,
+      borrower: event.borrower,
+      amount: event.amount ?? null,
+      ledger: event.ledger,
+      ledgerClosedAt: event.ledgerClosedAt.toISOString(),
+      txHash: event.txHash,
+      contractId: event.contractId,
+      topics: event.topics,
+      value: event.value,
+    });
+
+    let attemptCount = 0;
+    let lastStatusCode: number | null = null;
+    let lastError: string | null = null;
+
+    while (attemptCount < MAX_WEBHOOK_ATTEMPTS) {
+      attemptCount += 1;
+      const timestamp = new Date().toISOString();
+      const secret =
+        subscription.secret || process.env.WEBHOOK_SIGNING_SECRET || "";
+      const signature = secret
+        ? createSignature(payload, timestamp, secret)
+        : undefined;
+
+      try {
+        const response = await fetch(subscription.callback_url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "user-agent": "RemitLend-Webhook/1.0",
+            "x-remitlend-delivery": `${deliveryId}`,
+            "x-remitlend-event": event.eventType,
+            "x-remitlend-timestamp": timestamp,
+            ...(signature
+              ? { "x-remitlend-signature": `sha256=${signature}` }
+              : {}),
+          },
+          body: payload,
+        });
+
+        lastStatusCode = response.status;
+        if (response.ok) {
+          await this.markDeliveryResult(deliveryId, {
+            attemptCount,
+            lastStatusCode,
+            delivered: true,
+          });
+          return;
+        }
+
+        lastError = `Webhook endpoint responded with ${response.status}`;
+      } catch (error) {
+        lastError =
+          error instanceof Error
+            ? error.message
+            : "Unknown webhook delivery error";
+      }
+
+      if (attemptCount < MAX_WEBHOOK_ATTEMPTS) {
+        await sleep(INITIAL_RETRY_DELAY_MS * 2 ** (attemptCount - 1));
+      }
+    }
+
+    await this.markDeliveryResult(deliveryId, {
+      attemptCount,
+      lastStatusCode,
+      delivered: false,
+      lastError,
+    });
+
+    logger.warn("Webhook delivery failed after retries", {
+      deliveryId,
+      subscriptionId: subscription.id,
+      eventId: event.eventId,
+      lastStatusCode,
+      lastError,
+    });
+  }
+
+  private async createDeliveryRecord(
+    subscriptionId: number,
+    event: IndexedLoanEvent,
+  ) {
+    const result = await query(
+      `INSERT INTO webhook_deliveries (subscription_id, event_id, event_type)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      [subscriptionId, event.eventId, event.eventType],
+    );
+
+    return result.rows[0].id as number;
+  }
+
+  private async markDeliveryResult(
+    deliveryId: number,
+    input: {
+      attemptCount: number;
+      lastStatusCode: number | null;
+      delivered: boolean;
+      lastError?: string | null;
+    },
+  ) {
+    await query(
+      `UPDATE webhook_deliveries
+       SET attempt_count = $2,
+           last_status_code = $3,
+           last_error = $4,
+           delivered_at = $5,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [
+        deliveryId,
+        input.attemptCount,
+        input.lastStatusCode,
+        input.lastError || null,
+        input.delivered ? new Date() : null,
+      ],
+    );
+  }
+
+  private normalizeSubscription(row: Record<string, unknown>) {
+    return {
+      id: row.id,
+      callbackUrl: row.callback_url,
+      eventTypes: toEventTypes(row.event_types),
+      isActive: row.is_active,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private normalizeDeliverySubscription(
+    row: Record<string, unknown>,
+  ): WebhookSubscription {
+    return {
+      id: Number(row.id),
+      callback_url: String(row.callback_url),
+      event_types: toEventTypes(row.event_types),
+      secret: row.secret ? String(row.secret) : null,
+    };
+  }
+}
+
+export const webhookService = new WebhookService();


### PR DESCRIPTION
## Description
Adds a webhook notification subsystem to the backend indexer so contract events can be pushed to frontend consumers or external integrations in near real time.
Closes #146
## Changes proposed
### What were you told to do?
Add a Webhook Service to the backend indexer, allow users or services to register callback URLs for event types like `LoanApproved`, and ensure retry logic plus security headers for webhook delivery.
### What did I do?
#### Webhook Registration
- Added database tables for webhook subscriptions and delivery attempts
- Exposed indexer endpoints to create, list, and delete webhook subscriptions
#### Delivery Pipeline
- Added a webhook service that filters subscriptions by event type and posts indexed events to registered callback URLs
- Added retry handling, delivery logging, and signed security headers for outbound webhook requests
#### Indexer Integration
- Wired successful event indexing into webhook dispatch so new contract events fan out after persistence
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated with `npm test -- --runInBand` in `backend/`. `npm run build` still reports pre-existing TypeScript mock typing errors in `src/__tests__/score.test.ts`, but the webhook-specific changes compile within the tested path and the backend test suite passes.