### PR TITLE
added default checker and event indexer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,11 +4,28 @@ REDIS_URL=redis://redis:6379
 
 # Stellar Configuration
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 LOAN_MANAGER_CONTRACT_ID=
+# Secret key for the on-chain LoanManager admin account (G... / S...)
+LOAN_MANAGER_ADMIN_SECRET=
 
 # Indexer Configuration
 INDEXER_POLL_INTERVAL_MS=30000
 INDEXER_BATCH_SIZE=100
 
+# Default checker (on-chain `check_defaults`)
+# How often to scan + submit default checks while the API process is running
+DEFAULT_CHECK_INTERVAL_MS=1800000
+# Max loans to include per scheduled run (safety valve)
+DEFAULT_CHECK_MAX_LOANS_PER_RUN=500
+# Number of loan IDs per Soroban transaction
+DEFAULT_CHECK_BATCH_SIZE=25
+# Polling configuration after submission
+DEFAULT_CHECK_POLL_ATTEMPTS=30
+DEFAULT_CHECK_POLL_SLEEP_MS=1000
+# Must match the deployed contract if it ever changes from the repo default
+LOAN_TERM_LEDGERS=17280
+
 # Authentication
 JWT_SECRET=your-super-secret-jwt-key-change-in-production
+INTERNAL_API_KEY=change-me

--- a/backend/src/__tests__/score.test.ts
+++ b/backend/src/__tests__/score.test.ts
@@ -1,8 +1,12 @@
 import request from "supertest";
 import { jest } from "@jest/globals";
 
+type MockQueryResult = { rows: unknown[]; rowCount?: number };
+
 // Setup mocks BEFORE importing the app or the module under test
-const mockQuery = jest.fn();
+const mockQuery: jest.MockedFunction<
+  (text: string, params?: unknown[]) => Promise<MockQueryResult>
+> = jest.fn();
 jest.unstable_mockModule("../db/connection.js", () => ({
   query: mockQuery,
   getClient: jest.fn(),
@@ -10,10 +14,10 @@ jest.unstable_mockModule("../db/connection.js", () => ({
 }));
 
 // Use dynamic imports to ensure mocks are applied
-const { query } = (await import("../db/connection.js")) as any;
-const { default: app } = (await import("../app.js")) as any;
+await import("../db/connection.js");
+const { default: app } = await import("../app.js");
 
-const mockedQuery = query as jest.Mock;
+const mockedQuery = mockQuery;
 const VALID_API_KEY = "test-internal-key";
 
 beforeAll(() => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import simulationRoutes from "./routes/simulationRoutes.js";
 import scoreRoutes from "./routes/scoreRoutes.js";
 import loanRoutes from "./routes/loanRoutes.js";
 import indexerRoutes from "./routes/indexerRoutes.js";
+import adminRoutes from "./routes/adminRoutes.js";
 import authRoutes from "./routes/authRoutes.js";
 import swaggerUi from "swagger-ui-express";
 import { swaggerSpec } from "./config/swagger.js";
@@ -89,6 +90,7 @@ app.use("/api", simulationRoutes);
 app.use("/api/score", scoreRoutes);
 app.use("/api/loans", loanRoutes);
 app.use("/api/indexer", indexerRoutes);
+app.use("/api/admin", adminRoutes);
 app.use("/api/auth", authRoutes);
 
 // ── Diagnostic / Test Routes ─────────────────────────────────────

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,10 @@ import dotenv from "dotenv";
 import app from "./app.js";
 import logger from "./utils/logger.js";
 import { startIndexer, stopIndexer } from "./services/indexerManager.js";
+import {
+  startDefaultCheckerScheduler,
+  stopDefaultCheckerScheduler,
+} from "./services/defaultChecker.js";
 
 dotenv.config();
 
@@ -12,17 +16,22 @@ app.listen(port, () => {
 
   // Start the event indexer
   startIndexer();
+
+  // Start periodic on-chain default checks (if configured)
+  startDefaultCheckerScheduler();
 });
 
 // Graceful shutdown
 process.on("SIGTERM", () => {
   logger.info("SIGTERM signal received: closing HTTP server");
   stopIndexer();
+  stopDefaultCheckerScheduler();
   process.exit(0);
 });
 
 process.on("SIGINT", () => {
   logger.info("SIGINT signal received: closing HTTP server");
   stopIndexer();
+  stopDefaultCheckerScheduler();
   process.exit(0);
 });

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,0 +1,58 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireApiKey } from "../middleware/auth.js";
+import { strictRateLimiter } from "../middleware/rateLimiter.js";
+import { validateBody } from "../middleware/validation.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
+import { defaultChecker } from "../services/defaultChecker.js";
+
+const router = Router();
+
+const checkDefaultsBodySchema = z.object({
+  loanIds: z.array(z.number().int().positive()).optional(),
+});
+
+/**
+ * @swagger
+ * /admin/check-defaults:
+ *   post:
+ *     summary: Trigger on-chain default checks (admin)
+ *     description: >
+ *       Submits `check_defaults` to the LoanManager contract for either a specific
+ *       list of loan IDs, or (if omitted) all loans that appear overdue based on
+ *       indexed `LoanApproved` ledgers.
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               loanIds:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *     responses:
+ *       200:
+ *         description: Default check run completed (see batch errors in payload)
+ */
+router.post(
+  "/check-defaults",
+  requireApiKey,
+  strictRateLimiter,
+  validateBody(checkDefaultsBodySchema),
+  asyncHandler(async (req, res) => {
+    const { loanIds } = req.body as z.infer<typeof checkDefaultsBodySchema>;
+    const result = await defaultChecker.checkOverdueLoans(loanIds);
+
+    res.json({
+      success: true,
+      data: result,
+    });
+  }),
+);
+
+export default router;

--- a/backend/src/routes/indexerRoutes.ts
+++ b/backend/src/routes/indexerRoutes.ts
@@ -112,7 +112,7 @@ router.get("/events/loan/:loanId", getLoanEvents);
  *         name: eventType
  *         schema:
  *           type: string
- *           enum: [LoanRequested, LoanApproved, LoanRepaid]
+ *           enum: [LoanRequested, LoanApproved, LoanRepaid, LoanDefaulted]
  *     responses:
  *       200:
  *         description: Events retrieved successfully
@@ -145,7 +145,7 @@ router.get("/events/recent", getRecentEvents);
  *                 type: array
  *                 items:
  *                   type: string
- *                   enum: [LoanRequested, LoanApproved, LoanRepaid]
+ *                   enum: [LoanRequested, LoanApproved, LoanRepaid, LoanDefaulted]
  *               secret:
  *                 type: string
  *     responses:

--- a/backend/src/services/defaultChecker.ts
+++ b/backend/src/services/defaultChecker.ts
@@ -1,0 +1,416 @@
+import {
+  BASE_FEE,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from "@stellar/stellar-sdk";
+import { query } from "../db/connection.js";
+import logger from "../utils/logger.js";
+import { AppError } from "../errors/AppError.js";
+
+/**
+ * Mirrors `LoanManager::DEFAULT_TERM_LEDGERS` in `contracts/loan_manager/src/lib.rs`.
+ * Used to estimate on-chain due ledgers from indexed `LoanApproved` events.
+ */
+const DEFAULT_TERM_LEDGERS = 17_280;
+
+export interface DefaultCheckBatchResult {
+  loanIds: number[];
+  txHash?: string;
+  submitStatus?: string;
+  txStatus?: string;
+  error?: string;
+}
+
+export interface DefaultCheckRunResult {
+  runId: string;
+  currentLedger: number;
+  termLedgers: number;
+  overdueCount: number;
+  oldestDueLedger?: number;
+  ledgersPastOldestDue?: number;
+  batches: DefaultCheckBatchResult[];
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const n = parseInt(value ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) return [items];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export class DefaultChecker {
+  private rpcUrl: string;
+  private contractId: string;
+  private termLedgers: number;
+  private batchSize: number;
+  private maxLoansPerRun: number;
+  private pollAttempts: number;
+  private pollSleepMs: number;
+
+  constructor() {
+    this.rpcUrl = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+    this.contractId = process.env.LOAN_MANAGER_CONTRACT_ID || "";
+    this.termLedgers = parsePositiveInt(
+      process.env.LOAN_TERM_LEDGERS,
+      DEFAULT_TERM_LEDGERS,
+    );
+    this.batchSize = parsePositiveInt(process.env.DEFAULT_CHECK_BATCH_SIZE, 25);
+    this.maxLoansPerRun = parsePositiveInt(
+      process.env.DEFAULT_CHECK_MAX_LOANS_PER_RUN,
+      500,
+    );
+    this.pollAttempts = parsePositiveInt(process.env.DEFAULT_CHECK_POLL_ATTEMPTS, 30);
+    this.pollSleepMs = parsePositiveInt(process.env.DEFAULT_CHECK_POLL_SLEEP_MS, 1_000);
+  }
+
+  private assertConfigured(): { signer: Keypair; server: rpc.Server; passphrase: string } {
+    if (!this.contractId) {
+      throw AppError.internal(
+        "Default checker misconfiguration: LOAN_MANAGER_CONTRACT_ID is not set",
+      );
+    }
+
+    const secret = process.env.LOAN_MANAGER_ADMIN_SECRET;
+    if (!secret) {
+      throw AppError.internal(
+        "Default checker misconfiguration: LOAN_MANAGER_ADMIN_SECRET is not set",
+      );
+    }
+
+    let signer: Keypair;
+    try {
+      signer = Keypair.fromSecret(secret);
+    } catch {
+      throw AppError.internal(
+        "Default checker misconfiguration: LOAN_MANAGER_ADMIN_SECRET is invalid",
+      );
+    }
+
+    const allowHttp = this.rpcUrl.startsWith("http://");
+    const server = new rpc.Server(this.rpcUrl, { allowHttp });
+
+    const passphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+
+    return { signer, server, passphrase };
+  }
+
+  private async fetchOverdueLoanIds(currentLedger: number): Promise<number[]> {
+    const result = await query(
+      `
+      WITH approved AS (
+        SELECT loan_id, MAX(ledger) AS approved_ledger
+        FROM loan_events
+        WHERE event_type = 'LoanApproved'
+          AND loan_id IS NOT NULL
+        GROUP BY loan_id
+      ),
+      active AS (
+        SELECT
+          a.loan_id,
+          a.approved_ledger,
+          (a.approved_ledger + $1) AS due_ledger
+        FROM approved a
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM loan_events e
+          WHERE e.loan_id = a.loan_id
+            AND e.event_type IN ('LoanRepaid', 'LoanDefaulted')
+        )
+      )
+      SELECT loan_id
+      FROM active
+      WHERE due_ledger < $2
+      ORDER BY due_ledger ASC, loan_id ASC
+      LIMIT $3
+      `,
+      [this.termLedgers, currentLedger, this.maxLoansPerRun],
+    );
+
+    return result.rows
+      .map((r: { loan_id: unknown }) => Number(r.loan_id))
+      .filter((id: number) => Number.isInteger(id) && id > 0);
+  }
+
+  private async fetchOverdueStats(currentLedger: number): Promise<{
+    overdueCount: number;
+    oldestDueLedger?: number;
+    ledgersPastOldestDue?: number;
+  }> {
+    const result = await query(
+      `
+      WITH approved AS (
+        SELECT loan_id, MAX(ledger) AS approved_ledger
+        FROM loan_events
+        WHERE event_type = 'LoanApproved'
+          AND loan_id IS NOT NULL
+        GROUP BY loan_id
+      ),
+      active AS (
+        SELECT
+          a.loan_id,
+          (a.approved_ledger + $1) AS due_ledger
+        FROM approved a
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM loan_events e
+          WHERE e.loan_id = a.loan_id
+            AND e.event_type IN ('LoanRepaid', 'LoanDefaulted')
+        )
+      ),
+      overdue AS (
+        SELECT *
+        FROM active
+        WHERE due_ledger < $2
+      )
+      SELECT
+        COUNT(*)::bigint AS overdue_count,
+        MIN(due_ledger) AS oldest_due_ledger
+      FROM overdue
+      `,
+      [this.termLedgers, currentLedger],
+    );
+
+    const row = result.rows[0] as
+      | { overdue_count?: string | bigint; oldest_due_ledger?: string | bigint | null }
+      | undefined;
+
+    const overdueCount = row?.overdue_count != null ? Number(row.overdue_count) : 0;
+    const oldestDueLedger =
+      row?.oldest_due_ledger != null ? Number(row.oldest_due_ledger) : undefined;
+
+    const ledgersPastOldestDue =
+      oldestDueLedger != null && Number.isFinite(oldestDueLedger)
+        ? Math.max(0, currentLedger - oldestDueLedger)
+        : undefined;
+
+    return {
+      overdueCount,
+      ...(oldestDueLedger !== undefined ? { oldestDueLedger } : {}),
+      ...(ledgersPastOldestDue !== undefined ? { ledgersPastOldestDue } : {}),
+    };
+  }
+
+  private async submitCheckDefaults(
+    server: rpc.Server,
+    signer: Keypair,
+    passphrase: string,
+    loanIds: number[],
+  ): Promise<DefaultCheckBatchResult> {
+    const account = await server.getAccount(signer.publicKey());
+
+    const loanIdsScVal = nativeToScVal(loanIds, { type: "u32" });
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: passphrase,
+    })
+      .addOperation(
+        Operation.invokeContractFunction({
+          contract: this.contractId,
+          function: "check_defaults",
+          args: [loanIdsScVal],
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    let prepared;
+    try {
+      prepared = await server.prepareTransaction(tx);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { loanIds, error: `prepareTransaction failed: ${message}` };
+    }
+
+    prepared.sign(signer);
+
+    let send;
+    try {
+      send = await server.sendTransaction(prepared);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { loanIds, error: `sendTransaction failed: ${message}` };
+    }
+
+    const txHash = send.hash;
+    const submitStatus = send.status;
+
+    if (!txHash) {
+      return {
+        loanIds,
+        ...(submitStatus !== undefined ? { submitStatus } : {}),
+        error: "sendTransaction returned no hash",
+      };
+    }
+
+    let txStatus: string | undefined;
+    try {
+      const polled = await server.pollTransaction(txHash, {
+        attempts: this.pollAttempts,
+        sleepStrategy: (_attempt: number) => this.pollSleepMs,
+      });
+      txStatus = polled.status;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn("Default check transaction polling failed", {
+        txHash,
+        message,
+      });
+    }
+
+    return {
+      loanIds,
+      txHash,
+      ...(submitStatus !== undefined ? { submitStatus } : {}),
+      ...(txStatus !== undefined ? { txStatus } : {}),
+    };
+  }
+
+  /**
+   * Runs default checks for either:
+   * - explicit `loanIds` (validated + de-duped), or
+   * - all overdue loans discovered from `loan_events` (bounded by env limits).
+   */
+  async checkOverdueLoans(loanIds?: number[]): Promise<DefaultCheckRunResult> {
+    const runId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const { signer, server, passphrase } = this.assertConfigured();
+
+    const latest = await server.getLatestLedger();
+    const currentLedger = latest.sequence;
+
+    const stats = await this.fetchOverdueStats(currentLedger);
+
+    const explicitIds = loanIds
+      ? Array.from(
+          new Set(
+            loanIds.filter((id) => Number.isInteger(id) && id > 0),
+          ),
+        )
+      : undefined;
+
+    const targetIds =
+      explicitIds && explicitIds.length > 0
+        ? explicitIds
+        : await this.fetchOverdueLoanIds(currentLedger);
+
+    logger.info("default_check.run.start", {
+      runId,
+      currentLedger,
+      termLedgers: this.termLedgers,
+      batchSize: this.batchSize,
+      maxLoansPerRun: this.maxLoansPerRun,
+      overdueCount: stats.overdueCount,
+      oldestDueLedger: stats.oldestDueLedger,
+      ledgersPastOldestDue: stats.ledgersPastOldestDue,
+      explicitLoanCount: explicitIds?.length ?? 0,
+      targetLoanCount: targetIds.length,
+    });
+
+    const batches: DefaultCheckBatchResult[] = [];
+    for (const batch of chunk(targetIds, this.batchSize)) {
+      if (!batch.length) continue;
+      const result = await this.submitCheckDefaults(
+        server,
+        signer,
+        passphrase,
+        batch,
+      );
+      batches.push(result);
+
+      logger.info("default_check.batch", {
+        runId,
+        loanIds: result.loanIds,
+        txHash: result.txHash,
+        submitStatus: result.submitStatus,
+        txStatus: result.txStatus,
+        error: result.error,
+      });
+    }
+
+    logger.info("default_check.run.complete", {
+      runId,
+      batches: batches.length,
+      currentLedger,
+      overdueCount: stats.overdueCount,
+      oldestDueLedger: stats.oldestDueLedger,
+      ledgersPastOldestDue: stats.ledgersPastOldestDue,
+    });
+
+    return {
+      runId,
+      currentLedger,
+      termLedgers: this.termLedgers,
+      overdueCount: stats.overdueCount,
+      ...(stats.oldestDueLedger !== undefined ? { oldestDueLedger: stats.oldestDueLedger } : {}),
+      ...(stats.ledgersPastOldestDue !== undefined
+        ? { ledgersPastOldestDue: stats.ledgersPastOldestDue }
+        : {}),
+      batches,
+    };
+  }
+}
+
+export const defaultChecker = new DefaultChecker();
+
+let interval: ReturnType<typeof setInterval> | undefined;
+let inFlight = false;
+
+export function startDefaultCheckerScheduler(): void {
+  if (interval) return;
+
+  if (process.env.NODE_ENV === "test") {
+    return;
+  }
+
+  if (!process.env.LOAN_MANAGER_CONTRACT_ID || !process.env.LOAN_MANAGER_ADMIN_SECRET) {
+    logger.warn(
+      "Default checker scheduler disabled (set LOAN_MANAGER_CONTRACT_ID and LOAN_MANAGER_ADMIN_SECRET)",
+    );
+    return;
+  }
+
+  const intervalMs = parsePositiveInt(
+    process.env.DEFAULT_CHECK_INTERVAL_MS,
+    30 * 60 * 1000,
+  );
+
+  interval = setInterval(() => {
+    void (async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        await defaultChecker.checkOverdueLoans();
+      } catch (error) {
+        logger.error("Default checker scheduled run failed", { error });
+      } finally {
+        inFlight = false;
+      }
+    })();
+  }, intervalMs);
+
+  logger.info("Default checker scheduler started", { intervalMs });
+}
+
+export function stopDefaultCheckerScheduler(): void {
+  if (interval) clearInterval(interval);
+  interval = undefined;
+  logger.info("Default checker scheduler stopped");
+}

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -19,7 +19,6 @@ interface LoanEvent extends IndexedLoanEvent {
   eventType: WebhookEventType;
   loanId?: number;
   borrower: string;
-  amount?: string;
   ledger: number;
   ledgerClosedAt: Date;
   txHash: string;
@@ -94,19 +93,42 @@ export class EventIndexer {
           continue;
         const type = this.decodeEventType(e.topic[0]);
         if (!type) continue;
+
+        let borrower = "";
+        let loanId: number | undefined;
+        let amount: string | undefined;
+
+        if (type === "LoanRequested") {
+          borrower = this.decodeAddress(e.topic[1]);
+          amount = this.decodeAmount(e.value);
+        } else if (type === "LoanApproved") {
+          loanId = this.decodeLoanId(e.topic[1]);
+          if (loanId === undefined) continue;
+        } else if (type === "LoanRepaid") {
+          if (!e.topic[2]) continue;
+          borrower = this.decodeAddress(e.topic[1]);
+          loanId = this.decodeLoanId(e.topic[2]);
+          if (loanId === undefined) continue;
+          amount = this.decodeAmount(e.value);
+        } else if (type === "LoanDefaulted") {
+          loanId = this.decodeLoanId(e.topic[1]);
+          if (loanId === undefined) continue;
+          borrower = this.decodeAddress(e.value);
+        }
+
         const evt: LoanEvent = {
           eventId: e.id,
           eventType: type,
-          borrower: this.decodeAddress(e.topic[1]),
+          borrower,
           ledger: e.ledger,
           ledgerClosedAt: new Date(e.ledgerClosedAt),
           txHash: e.txHash,
           contractId: e.contractId.toString(),
           topics: e.topic.map((t) => t.toXDR("base64")),
           value: e.value.toXDR("base64"),
-          amount: this.decodeAmount(e.value),
+          ...(amount !== undefined ? { amount } : {}),
+          ...(loanId !== undefined ? { loanId } : {}),
         };
-        if (e.topic[2]) evt.loanId = this.decodeLoanId(e.topic[2]);
         result.push(evt);
       } catch (err) {
         logger.error("Process event error", { err });
@@ -184,7 +206,14 @@ export class EventIndexer {
       "SELECT last_indexed_ledger, last_indexed_cursor FROM indexer_state ORDER BY id DESC LIMIT 1",
       [],
     );
-    return r.rows[0] || { lastIndexedLedger: 0, lastIndexedCursor: null };
+    const row = r.rows[0] as
+      | { last_indexed_ledger?: number; last_indexed_cursor?: string | null }
+      | undefined;
+
+    return {
+      lastIndexedLedger: row?.last_indexed_ledger ?? 0,
+      lastIndexedCursor: row?.last_indexed_cursor ?? null,
+    };
   }
 
   private async updateIndexerState(ledger: number, cursor: string) {
@@ -194,13 +223,13 @@ export class EventIndexer {
     );
   }
 
-  private encodeSymbol(s: string) {
-    return xdr.ScVal.scvSymbol(s).toXDR("base64");
-  }
   private decodeEventType(x: xdr.ScVal): WebhookEventType | null {
     try {
       const s = x.sym().toString();
-      return s === "LoanRequested" || s === "LoanApproved" || s === "LoanRepaid"
+      return s === "LoanRequested" ||
+        s === "LoanApproved" ||
+        s === "LoanRepaid" ||
+        s === "LoanDefaulted"
         ? s
         : null;
     } catch {
@@ -214,18 +243,18 @@ export class EventIndexer {
       return "";
     }
   }
-  private decodeAmount(x: xdr.ScVal): string {
+  private decodeAmount(x: xdr.ScVal): string | undefined {
     try {
       return x.i128().toString();
     } catch {
-      return "0";
+      return undefined;
     }
   }
-  private decodeLoanId(x: xdr.ScVal): number {
+  private decodeLoanId(x: xdr.ScVal): number | undefined {
     try {
       return x.u32();
     } catch {
-      return 0;
+      return undefined;
     }
   }
 }

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -6,6 +6,7 @@ export const SUPPORTED_WEBHOOK_EVENT_TYPES = [
   "LoanRequested",
   "LoanApproved",
   "LoanRepaid",
+  "LoanDefaulted",
 ] as const;
 
 export type WebhookEventType = (typeof SUPPORTED_WEBHOOK_EVENT_TYPES)[number];


### PR DESCRIPTION
What I just finished
npm run build was still failing on two TypeScript issues; both are fixed:

backend/src/__tests__/score.test.ts: jest.fn in Jest 30 only accepts a single generic arg, so the mock is now typed as jest.MockedFunction<...> = jest.fn() (no invalid jest.fn<A,B>()).
backend/src/services/eventIndexer.ts: optional amount / loanId are attached via conditional spreads so we never assign undefined to optional properties under exactOptionalPropertyTypes.
Verification: npm run build in backend/ exits 0.