### PR TITLE
feat: add API versioning with v1 prefix

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -86,12 +86,21 @@ app.get("/health", (req: Request, res: Response) => {
   });
 });
 
+// Legacy routes (deprecated, maintained for backward compatibility)
 app.use("/api", simulationRoutes);
 app.use("/api/score", scoreRoutes);
 app.use("/api/loans", loanRoutes);
 app.use("/api/indexer", indexerRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/auth", authRoutes);
+
+// Versioned API routes (v1 - current)
+app.use("/api/v1", simulationRoutes);
+app.use("/api/v1/score", scoreRoutes);
+app.use("/api/v1/loans", loanRoutes);
+app.use("/api/v1/indexer", indexerRoutes);
+app.use("/api/v1/admin", adminRoutes);
+app.use("/api/v1/auth", authRoutes);
 
 // ── Diagnostic / Test Routes ─────────────────────────────────────
 // Only exposed in test environment to verify centralized error handling.


### PR DESCRIPTION
## Summary
Implements API versioning with `/api/v1/` prefix as requested in issue #226.

## Changes
- Added versioned API routes under `/api/v1/` prefix
- Maintained legacy routes for backward compatibility

## New Routes
| Endpoint | Description |
|----------|-------------|
| `/api/v1` | Simulation routes |
| `/api/v1/score` | Credit score API |
| `/api/v1/loans` | Loan management API |
| `/api/v1/indexer` | Blockchain indexer API |
| `/api/v1/admin` | Admin API |
| `/api/v1/auth` | Authentication API |

## Backward Compatibility
All existing `/api/*` routes continue to work during the deprecation period, ensuring no breaking changes for current integrations.

## Benefits
- Enables future API versioning (v2, v3, etc.)
- Allows breaking changes without disrupting existing clients
- Follows REST API best practices

Closes #226