### PR TITLE
chore: skeleton barrel export & theme toggle a11y improvement

### DIFF
--- a/frontend/src/app/components/skeletons/index.ts
+++ b/frontend/src/app/components/skeletons/index.ts
@@ -1,0 +1,5 @@
+export { DashboardSkeleton } from "./DashboardSkeleton";
+export { LoansListSkeleton } from "./LoansListSkeleton";
+export { LoanDetailSkeleton } from "./LoanDetailSkeleton";
+export { AnalyticsSkeleton } from "./AnalyticsSkeleton";
+export { CreditScoreSkeleton } from "./CreditScoreSkeleton";

--- a/frontend/src/app/components/ui/ThemeToggle.tsx
+++ b/frontend/src/app/components/ui/ThemeToggle.tsx
@@ -68,6 +68,7 @@ export function ThemeToggle() {
       onClick={cycle}
       className="p-2 text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900 rounded-lg transition-colors"
       aria-label={`${label} — click to change`}
+      aria-live="polite"
       title={label}
     >
       <Icon className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Add `index.ts` barrel export for all skeleton components for cleaner imports
- Add `aria-live="polite"` to ThemeToggle button for screen reader announcements on theme change

These components were implemented in #264. This PR adds minor improvements and properly closes the remaining open issues.

## Test plan
- [ ] Verify skeleton imports work via barrel export (`import { DashboardSkeleton } from "./components/skeletons"`)
- [ ] Verify theme toggle announces changes to screen readers

Closes #254
Closes #256
Closes #257