### PR TITLE
feat(lending-pool): add admin-configurable MaxPoolSize deposit cap (#…

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -8,6 +8,8 @@ pub enum DataKey {
     Deposit(Address),
     Admin,
     Paused,
+    MaxPoolSize,
+    TotalDeposits,
 }
 
 #[contract]
@@ -58,6 +60,13 @@ impl LendingPool {
         }
     }
 
+    fn read_total_deposits(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalDeposits)
+            .unwrap_or(0)
+    }
+
     pub fn initialize(env: Env, token: Address, admin: Address) {
         let token_key = Self::token_key();
         if env.storage().instance().has(&token_key) {
@@ -66,7 +75,43 @@ impl LendingPool {
         env.storage().instance().set(&token_key, &token);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDeposits, &0_i128);
         Self::bump_instance_ttl(&env);
+    }
+
+    /// Admin-only: set the maximum total deposits the pool will accept.
+    /// Pass `0` to remove the cap entirely.
+    pub fn set_max_pool_size(env: Env, max: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        if max < 0 {
+            panic!("max pool size must be non-negative");
+        }
+        env.storage().instance().set(&DataKey::MaxPoolSize, &max);
+        Self::bump_instance_ttl(&env);
+        env.events().publish((symbol_short!("MaxPool"),), max);
+    }
+
+    /// Returns the current max pool size cap (0 = no cap).
+    pub fn get_max_pool_size(env: Env) -> i128 {
+        Self::bump_instance_ttl(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxPoolSize)
+            .unwrap_or(0)
+    }
+
+    /// Returns the current sum of all provider deposits.
+    pub fn get_total_deposits(env: Env) -> i128 {
+        Self::bump_instance_ttl(&env);
+        Self::read_total_deposits(&env)
     }
 
     pub fn deposit(env: Env, provider: Address, amount: i128) {
@@ -76,9 +121,26 @@ impl LendingPool {
         if amount <= 0 {
             panic!("deposit amount must be positive");
         }
+
+        // Enforce max pool size cap when set (non-zero).
+        let max: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxPoolSize)
+            .unwrap_or(0);
+        if max > 0 {
+            let total = Self::read_total_deposits(&env);
+            let new_total = total.checked_add(amount).expect("deposit overflow");
+            if new_total > max {
+                panic!("deposit exceeds max pool size");
+            }
+        }
+
         let token = Self::read_token(&env);
         let token_client = TokenClient::new(&env, &token);
         token_client.transfer(&provider, &env.current_contract_address(), &amount);
+
+        // Update per-provider balance.
         let key = DataKey::Deposit(provider.clone());
         let mut current_balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
         current_balance = current_balance
@@ -86,6 +148,16 @@ impl LendingPool {
             .expect("deposit overflow");
         env.storage().persistent().set(&key, &current_balance);
         Self::bump_persistent_ttl(&env, &key);
+
+        // Update global total.
+        let new_total = Self::read_total_deposits(&env)
+            .checked_add(amount)
+            .expect("total deposits overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDeposits, &new_total);
+        Self::bump_instance_ttl(&env);
+
         env.events()
             .publish((symbol_short!("Deposit"), provider), amount);
     }
@@ -119,6 +191,8 @@ impl LendingPool {
             panic!("insufficient pool liquidity");
         }
         token_client.transfer(&pool_address, &provider, &amount);
+
+        // Update per-provider balance.
         let new_balance = current_balance
             .checked_sub(amount)
             .expect("withdraw underflow");
@@ -128,6 +202,16 @@ impl LendingPool {
             env.storage().persistent().set(&key, &new_balance);
             Self::bump_persistent_ttl(&env, &key);
         }
+
+        // Update global total.
+        let new_total = Self::read_total_deposits(&env)
+            .checked_sub(amount)
+            .expect("total deposits underflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalDeposits, &new_total);
+        Self::bump_instance_ttl(&env);
+
         env.events()
             .publish((symbol_short!("Withdraw"), provider), amount);
     }

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -233,3 +233,151 @@ fn test_deposit_withdraw_invariants() {
         );
     }
 }
+
+// ── MaxPoolSize tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_max_pool_size() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, _stellar_asset_client, _token_client) =
+        create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+
+    // Default: no cap
+    assert_eq!(pool_client.get_max_pool_size(), 0);
+
+    pool_client.set_max_pool_size(&10_000);
+    assert_eq!(pool_client.get_max_pool_size(), 10_000);
+}
+
+#[test]
+fn test_deposit_within_cap_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+    pool_client.set_max_pool_size(&5_000);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &5_000);
+
+    pool_client.deposit(&provider, &5_000);
+    assert_eq!(pool_client.get_deposit(&provider), 5_000);
+    assert_eq!(pool_client.get_total_deposits(), 5_000);
+}
+
+#[test]
+#[should_panic(expected = "deposit exceeds max pool size")]
+fn test_deposit_exceeds_cap_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+    pool_client.set_max_pool_size(&1_000);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &2_000);
+
+    // Should panic — 1001 > cap of 1000
+    pool_client.deposit(&provider, &1_001);
+}
+
+#[test]
+fn test_withdraw_reduces_total_deposits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+    pool_client.set_max_pool_size(&5_000);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &3_000);
+    pool_client.deposit(&provider, &3_000);
+    assert_eq!(pool_client.get_total_deposits(), 3_000);
+
+    pool_client.withdraw(&provider, &1_000);
+    assert_eq!(pool_client.get_total_deposits(), 2_000);
+}
+
+#[test]
+fn test_deposit_after_withdraw_frees_cap_space() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+    pool_client.set_max_pool_size(&3_000);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &3_000);
+    pool_client.deposit(&provider, &3_000);
+
+    // Pool is full; withdraw 1000 to free space
+    pool_client.withdraw(&provider, &1_000);
+
+    // Re-deposit 1000 — should succeed now
+    stellar_asset_client.mint(&provider, &1_000);
+    pool_client.deposit(&provider, &1_000);
+    assert_eq!(pool_client.get_total_deposits(), 3_000);
+}
+
+#[test]
+fn test_no_cap_allows_unlimited_deposits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+    // No set_max_pool_size call — cap stays 0 (unlimited)
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &1_000_000);
+    pool_client.deposit(&provider, &1_000_000);
+    assert_eq!(pool_client.get_total_deposits(), 1_000_000);
+}
+
+#[test]
+#[should_panic(expected = "max pool size must be non-negative")]
+fn test_set_negative_max_pool_size_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, _stellar_asset_client, _token_client) =
+        create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+
+    pool_client.set_max_pool_size(&-1);
+}


### PR DESCRIPTION
---

**feat(lending-pool): add admin-configurable MaxPoolSize deposit cap**

Closes #220

**Problem**

The lending pool had no upper bound on total deposits, which is a standard risk vector in DeFi — an unbounded pool can exceed what the protocol can safely manage or insure.

**Solution**

Added a `DataKey::MaxPoolSize` storage key that an admin can configure at any time. The pool tracks a running `TotalDeposits` counter that is incremented on every deposit and decremented on every withdrawal. Before accepting a deposit, the contract checks whether the new total would exceed the cap.

**Changes**

- `DataKey::MaxPoolSize` — instance storage, admin-configurable, `0` means no cap (default)
- `DataKey::TotalDeposits` — instance storage, tracks live sum of all provider deposits
- `set_max_pool_size(max: i128)` — admin-only, emits `MaxPool` event on update
- `get_max_pool_size()` / `get_total_deposits()` — read-only accessors
- `deposit()` — enforces cap before transferring tokens; panics with `"deposit exceeds max pool size"`
- `withdraw()` — decrements `TotalDeposits` to free cap space for future deposits

**Tests added**

- `test_set_and_get_max_pool_size` — default is 0, admin can set it
- `test_deposit_within_cap_succeeds` — exact-cap deposit goes through
- `test_deposit_exceeds_cap_panics` — one unit over cap panics
- `test_withdraw_reduces_total_deposits` — total tracks correctly after withdrawal
- `test_deposit_after_withdraw_frees_cap_space` — freed space is reusable
- `test_no_cap_allows_unlimited_deposits` — 0 cap = no restriction
- `test_set_negative_max_pool_size_panics` — negative cap rejected