### PR TITLE
feat(frontend): ship borrower API pages, global search, and lender dashboard

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,21 +1,9 @@
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const compat = new FlatCompat({ baseDirectory: __dirname });
-
-export default [
-  ...compat.extends(
-    "next/core-web-vitals",
-    "eslint:recommended",
-    "plugin:jsx-a11y/recommended",
-    "plugin:prettier/recommended",
-  ),
-  {
-    rules: {
-      "prettier/prettier": "error",
-    },
-  },
-];
+export default defineConfig([
+  ...nextVitals,
+  ...nextTypescript,
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
+]);

--- a/frontend/src/app/components/global_ui/Breadcrumbs.tsx
+++ b/frontend/src/app/components/global_ui/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ const segmentLabels: Record<string, string> = {
   borrower: "Borrower Portal",
   lender: "Lender Portal",
   loans: "Loans",
+  lend: "Lender Portal",
   remittances: "Remittances",
   wallet: "Wallet",
   settings: "Settings",

--- a/frontend/src/app/components/global_ui/Header.tsx
+++ b/frontend/src/app/components/global_ui/Header.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { useRouter } from "next/navigation";
 import { Menu, Search, User, Wallet } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -7,6 +15,7 @@ import { ThemeToggle } from "../ui/ThemeToggle";
 import { NotificationDropdown } from "./NotificationDropdown";
 import { useWalletStore } from "../../stores/useWalletStore";
 import { useGamificationStore } from "../../stores/useGamificationStore";
+import { useLoans, useRemittances } from "../../hooks/useApi";
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -18,11 +27,178 @@ interface HeaderProps {
 }
 
 export function Header({ onMenuClick, className }: HeaderProps) {
+  const router = useRouter();
   const isConnected = useWalletStore((state) => state.status === "connected");
   const setConnected = useWalletStore((state) => state.setConnected);
   const disconnect = useWalletStore((state) => state.disconnect);
-  const address = useWalletStore((state) => state.address);
   const gamificationStore = useGamificationStore();
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { data: loans = [] } = useLoans({ enabled: isConnected });
+  const { data: remittances = [] } = useRemittances({ enabled: isConnected });
+
+  const pages = useMemo(
+    () => [
+      { name: "Dashboard", href: "/" },
+      { name: "Loans", href: "/loans" },
+      { name: "Remittances", href: "/remittances" },
+      { name: "Lend", href: "/lend" },
+      { name: "Analytics", href: "/analytics" },
+      { name: "Wallet", href: "/wallet" },
+      { name: "Settings", href: "/settings" },
+    ],
+    [],
+  );
+
+  const searchResults = useMemo(() => {
+    const term = debouncedQuery.trim().toLowerCase();
+    if (!term) {
+      return [] as {
+        id: string;
+        title: string;
+        subtitle: string;
+        category: "Loans" | "Pages" | "Transactions";
+        href: string;
+      }[];
+    }
+
+    const loanResults = loans
+      .filter(
+        (loan) =>
+          loan.id.toLowerCase().includes(term) || loan.borrowerId.toLowerCase().includes(term),
+      )
+      .slice(0, 5)
+      .map((loan) => ({
+        id: `loan-${loan.id}`,
+        title: `Loan #${loan.id}`,
+        subtitle: loan.borrowerId,
+        category: "Loans" as const,
+        href: `/loans/${loan.id}`,
+      }));
+
+    const pageResults = pages
+      .filter(
+        (page) => page.name.toLowerCase().includes(term) || page.href.toLowerCase().includes(term),
+      )
+      .slice(0, 5)
+      .map((page) => ({
+        id: `page-${page.href}`,
+        title: page.name,
+        subtitle: page.href,
+        category: "Pages" as const,
+        href: page.href,
+      }));
+
+    const transactionResults = remittances
+      .filter((remittance) => remittance.id.toLowerCase().includes(term))
+      .slice(0, 5)
+      .map((remittance) => ({
+        id: `tx-${remittance.id}`,
+        title: `Tx ${remittance.id.slice(0, 10)}...`,
+        subtitle: `${remittance.amount} ${remittance.fromCurrency} to ${remittance.toCurrency}`,
+        category: "Transactions" as const,
+        href: "/remittances",
+      }));
+
+    return [...loanResults, ...pageResults, ...transactionResults];
+  }, [debouncedQuery, loans, pages, remittances]);
+
+  const groupedResults = useMemo(() => {
+    const categories: Array<"Loans" | "Pages" | "Transactions"> = [
+      "Loans",
+      "Pages",
+      "Transactions",
+    ];
+    return categories
+      .map((category) => ({
+        category,
+        items: searchResults.filter((item) => item.category === category),
+      }))
+      .filter((group) => group.items.length > 0);
+  }, [searchResults]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [query]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setIsOpen(true);
+        inputRef.current?.focus();
+      }
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, []);
+
+  const handleSelect = (href: string) => {
+    setIsOpen(false);
+    setQuery("");
+    setDebouncedQuery("");
+    router.push(href);
+  };
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((prev) =>
+        searchResults.length === 0 ? 0 : (prev + 1) % searchResults.length,
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((prev) =>
+        searchResults.length === 0 ? 0 : (prev - 1 + searchResults.length) % searchResults.length,
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const selected = searchResults[activeIndex];
+      if (selected) {
+        handleSelect(selected.href);
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsOpen(false);
+    }
+  };
 
   const handleWalletToggle = () => {
     if (isConnected) {
@@ -48,15 +224,81 @@ export function Header({ onMenuClick, className }: HeaderProps) {
           <Menu className="h-6 w-6" />
         </button>
 
-        <div className="hidden lg:flex relative max-w-md">
+        <div ref={wrapperRef} className="relative hidden lg:flex w-full max-w-xl">
           <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             <Search className="h-4 w-4 text-zinc-400" />
           </div>
           <input
+            ref={inputRef}
             type="search"
-            placeholder="Search loans, users..."
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setIsOpen(true);
+              setActiveIndex(0);
+            }}
+            onFocus={() => setIsOpen(true)}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Search loans, pages, transactions..."
+            role="combobox"
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
+            aria-controls="header-search-results"
             className="block w-full rounded-full border border-zinc-200 bg-zinc-50 py-2 pl-10 pr-3 text-sm placeholder-zinc-500 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 dark:placeholder-zinc-500"
           />
+          <span className="pointer-events-none absolute inset-y-0 right-3 hidden items-center text-xs text-zinc-400 xl:flex">
+            Ctrl/Cmd + K
+          </span>
+
+          {isOpen && (
+            <div
+              id="header-search-results"
+              role="listbox"
+              className="absolute top-12 z-40 max-h-[26rem] w-full overflow-y-auto rounded-2xl border border-zinc-200 bg-white p-2 shadow-xl shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none"
+            >
+              {debouncedQuery.trim().length === 0 ? (
+                <p className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">
+                  Type to search loans, pages, and transaction hashes.
+                </p>
+              ) : searchResults.length === 0 ? (
+                <p className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">
+                  No results found
+                </p>
+              ) : (
+                groupedResults.map((group) => (
+                  <div key={group.category} className="mb-2 last:mb-0">
+                    <p className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                      {group.category}
+                    </p>
+                    {group.items.map((item) => {
+                      const globalIndex = searchResults.findIndex(
+                        (result) => result.id === item.id,
+                      );
+                      const isActive = globalIndex === activeIndex;
+                      return (
+                        <button
+                          key={item.id}
+                          onClick={() => handleSelect(item.href)}
+                          className={cn(
+                            "flex w-full items-start justify-between rounded-xl px-3 py-2 text-left transition",
+                            isActive
+                              ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300"
+                              : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-900",
+                          )}
+                        >
+                          <span className="text-sm font-medium">{item.title}</span>
+                          <span className="ml-3 text-xs text-zinc-500 dark:text-zinc-400">
+                            {item.subtitle}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/app/components/global_ui/Sidebar.tsx
+++ b/frontend/src/app/components/global_ui/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   HandCoins,
+  PiggyBank,
   SendHorizontal,
   Settings,
   X,
@@ -27,6 +28,7 @@ interface SidebarProps {
 const navItems = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Loans", href: "/loans", icon: HandCoins },
+  { name: "Lend", href: "/lend", icon: PiggyBank },
   { name: "Remittances", href: "/remittances", icon: SendHorizontal },
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Kingdom", href: "/kingdom", icon: Crown },

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -48,6 +48,10 @@ export const queryKeys = {
   borrowerLoans: {
     byAddress: (address: string) => ["borrowerLoans", address] as const,
   },
+  pool: {
+    stats: () => ["pool", "stats"] as const,
+    depositor: (address: string) => ["pool", "depositor", address] as const,
+  },
 } as const;
 
 // ─── Base fetch helper ────────────────────────────────────────────────────────
@@ -143,6 +147,43 @@ export interface BorrowerLoan {
   approvedAt?: string;
 }
 
+export interface LoanEvent {
+  type: string;
+  amount: string | number;
+  timestamp: string;
+  txHash?: string;
+}
+
+export interface LoanDetails {
+  loanId: number;
+  principal: number;
+  accruedInterest: number;
+  totalRepaid: number;
+  totalOwed: number;
+  interestRate: number;
+  status: "active" | "repaid" | "defaulted" | "pending";
+  requestedAt?: string;
+  approvedAt?: string;
+  events: LoanEvent[];
+}
+
+export interface PoolStats {
+  totalDeposits: number;
+  totalOutstanding: number;
+  utilizationRate: number;
+  apy: number;
+  activeLoansCount: number;
+}
+
+export interface DepositorPortfolio {
+  address: string;
+  depositAmount: number;
+  sharePercent: number;
+  estimatedYield: number;
+  apy: number;
+  firstDepositAt: string | null;
+}
+
 export interface LoanStats {
   totalActive: number;
   totalOwed: number;
@@ -170,11 +211,24 @@ export function useLoans(options?: Omit<UseQueryOptions<Loan[]>, "queryKey" | "q
  */
 export function useLoan(
   id: string | undefined,
-  options?: Omit<UseQueryOptions<Loan>, "queryKey" | "queryFn">,
+  options?: Omit<UseQueryOptions<LoanDetails>, "queryKey" | "queryFn">,
 ) {
-  return useQuery<Loan>({
+  return useQuery<LoanDetails>({
     queryKey: queryKeys.loans.detail(id ?? ""),
-    queryFn: () => apiFetch<Loan>(`/loans/${id}`),
+    queryFn: async () => {
+      const response = await apiFetch<LoanDetails | { success: boolean; data: LoanDetails }>(
+        `/loans/${id}`,
+      );
+      if (
+        typeof response === "object" &&
+        response !== null &&
+        "success" in response &&
+        "data" in response
+      ) {
+        return response.data;
+      }
+      return response;
+    },
     enabled: !!id,
     ...options,
   });
@@ -338,6 +392,11 @@ interface BorrowerLoansApiResponse {
   data: { borrower: string; loans: BorrowerLoan[]; totalLoans: number };
 }
 
+interface PoolApiResponse<T> {
+  success: boolean;
+  data: T;
+}
+
 /**
  * Fetches all loans for a borrower address.
  * Results are cached by address so multiple components sharing the same
@@ -372,6 +431,34 @@ export function useBorrowerLoans(borrowerAddress: string | undefined) {
   };
 
   return { ...query, loans, stats };
+}
+
+export function usePoolStats(options?: Omit<UseQueryOptions<PoolStats>, "queryKey" | "queryFn">) {
+  return useQuery<PoolStats>({
+    queryKey: queryKeys.pool.stats(),
+    queryFn: async () => {
+      const response = await apiFetch<PoolApiResponse<PoolStats>>("/pool/stats");
+      return response.data;
+    },
+    ...options,
+  });
+}
+
+export function useDepositorPortfolio(
+  address: string | undefined,
+  options?: Omit<UseQueryOptions<DepositorPortfolio>, "queryKey" | "queryFn">,
+) {
+  return useQuery<DepositorPortfolio>({
+    queryKey: queryKeys.pool.depositor(address ?? ""),
+    queryFn: async () => {
+      const response = await apiFetch<PoolApiResponse<DepositorPortfolio>>(
+        `/pool/depositor/${address}`,
+      );
+      return response.data;
+    },
+    enabled: !!address,
+    ...options,
+  });
 }
 
 // ─── Notification types & hooks ───────────────────────────────────────────────

--- a/frontend/src/app/lend/page.tsx
+++ b/frontend/src/app/lend/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  ArrowDownLeft,
+  ArrowUpRight,
+  CircleDollarSign,
+  HandCoins,
+  Percent,
+  PiggyBank,
+} from "lucide-react";
+import { ErrorBoundary } from "../components/global_ui/ErrorBoundary";
+import { YieldEarningsChart } from "../components/charts/YieldEarningsChart";
+import { useDepositorPortfolio, useLoans, usePoolStats, useYieldHistory } from "../hooks/useApi";
+import { selectWalletAddress, useWalletStore } from "../stores/useWalletStore";
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+export default function LendPage() {
+  const [depositAmount, setDepositAmount] = useState("100");
+  const [withdrawAmount, setWithdrawAmount] = useState("50");
+  const address = useWalletStore(selectWalletAddress);
+
+  const {
+    data: poolStats,
+    isLoading: poolLoading,
+    isError: poolError,
+  } = usePoolStats({ enabled: !!address });
+  const {
+    data: depositor,
+    isLoading: depositorLoading,
+    isError: depositorError,
+  } = useDepositorPortfolio(address ?? undefined, { enabled: !!address });
+  const {
+    data: loans,
+    isLoading: loansLoading,
+    isError: loansError,
+  } = useLoans({ enabled: !!address });
+  const {
+    data: yieldHistory,
+    isLoading: historyLoading,
+    isError: historyError,
+  } = useYieldHistory(address ?? undefined, { enabled: !!address });
+
+  const chartData = useMemo(
+    () =>
+      (yieldHistory ?? []).map((entry) => ({
+        date: new Date(entry.date).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        }),
+        earnings: entry.earnings,
+        apy: entry.apy,
+        principal: entry.principal,
+      })),
+    [yieldHistory],
+  );
+
+  if (!address) {
+    return (
+      <section className="rounded-3xl border border-zinc-200 bg-white p-8 dark:border-zinc-800 dark:bg-zinc-950">
+        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lender Dashboard</h1>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+          Connect your wallet to view your lending pool portfolio.
+        </p>
+      </section>
+    );
+  }
+
+  if (poolError || depositorError || loansError || historyError) {
+    return (
+      <section className="rounded-3xl border border-red-200 bg-red-50 p-6 text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+        Failed to load lender dashboard data. Please try again.
+      </section>
+    );
+  }
+
+  const isLoading = poolLoading || depositorLoading || loansLoading || historyLoading;
+
+  return (
+    <main className="space-y-6">
+      <header>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600">
+          Lender Portal
+        </p>
+        <h1 className="mt-2 text-3xl font-bold text-zinc-900 dark:text-zinc-50">Lend</h1>
+        <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
+          Track pool performance, manage deposits, and monitor yield growth.
+        </p>
+      </header>
+
+      <ErrorBoundary scope="lender overview" variant="section">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {[
+            {
+              label: "Total Pool Size",
+              value: isLoading ? "--" : formatCurrency(poolStats?.totalDeposits ?? 0),
+              icon: CircleDollarSign,
+            },
+            {
+              label: "Utilization Rate",
+              value: isLoading ? "--" : formatPercent(poolStats?.utilizationRate ?? 0),
+              icon: Percent,
+            },
+            {
+              label: "Current APY",
+              value: isLoading ? "--" : formatPercent(poolStats?.apy ?? 0),
+              icon: Activity,
+            },
+            {
+              label: "Active Loans",
+              value: isLoading ? "--" : String(poolStats?.activeLoansCount ?? 0),
+              icon: HandCoins,
+            },
+          ].map((item) => (
+            <article
+              key={item.label}
+              className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none"
+            >
+              <div className="flex items-center gap-3">
+                <div className="rounded-2xl bg-indigo-50 p-3 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+                  <item.icon className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-sm text-zinc-500 dark:text-zinc-400">{item.label}</p>
+                  <p className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                    {item.value}
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+      </ErrorBoundary>
+
+      <ErrorBoundary scope="depositor summary" variant="section">
+        <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <article className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">My Deposits</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              <div className="rounded-2xl bg-zinc-50 p-4 dark:bg-zinc-900">
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">Deposited Amount</p>
+                <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                  {isLoading ? "--" : formatCurrency(depositor?.depositAmount ?? 0)}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-zinc-50 p-4 dark:bg-zinc-900">
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">Share of Pool</p>
+                <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                  {isLoading ? "--" : formatPercent(depositor?.sharePercent ?? 0)}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-zinc-50 p-4 dark:bg-zinc-900">
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">Estimated Earnings</p>
+                <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                  {isLoading ? "--" : formatCurrency(depositor?.estimatedYield ?? 0)}
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <article className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+              Deposit / Withdraw
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <form className="space-y-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+                <label
+                  htmlFor="deposit-amount"
+                  className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                >
+                  Deposit Amount
+                </label>
+                <input
+                  id="deposit-amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={depositAmount}
+                  onChange={(event) => setDepositAmount(event.target.value)}
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900"
+                />
+                <button
+                  type="button"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
+                >
+                  <ArrowUpRight className="h-4 w-4" />
+                  Deposit
+                </button>
+              </form>
+
+              <form className="space-y-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+                <label
+                  htmlFor="withdraw-amount"
+                  className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                >
+                  Withdraw Amount
+                </label>
+                <input
+                  id="withdraw-amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={withdrawAmount}
+                  onChange={(event) => setWithdrawAmount(event.target.value)}
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900"
+                />
+                <button
+                  type="button"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  <ArrowDownLeft className="h-4 w-4" />
+                  Withdraw
+                </button>
+              </form>
+            </div>
+            <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+              Contract integration can be wired into these form actions.
+            </p>
+          </article>
+        </section>
+      </ErrorBoundary>
+
+      <ErrorBoundary scope="loan portfolio" variant="section">
+        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Loan Portfolio</h2>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Read-only view of loans currently funded through the pool.
+          </p>
+
+          <div className="mt-4 space-y-3">
+            {(loans ?? [])
+              .filter((loan) => loan.status === "active")
+              .slice(0, 8)
+              .map((loan) => (
+                <article
+                  key={loan.id}
+                  className="flex flex-col gap-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <p className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+                      Loan #{loan.id}
+                    </p>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                      Borrower: {loan.borrowerId}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-zinc-600 dark:text-zinc-400">
+                    <span>{formatCurrency(loan.amount)}</span>
+                    <span>{loan.interestRate.toFixed(2)}% APR</span>
+                    <span>{loan.termDays} days</span>
+                    <span className="rounded-full bg-zinc-100 px-3 py-1 font-medium capitalize text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                      {loan.status}
+                    </span>
+                  </div>
+                  <Link
+                    href={`/loans/${loan.id}`}
+                    className="inline-flex items-center gap-2 rounded-full border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+                  >
+                    View
+                  </Link>
+                </article>
+              ))}
+
+            {!isLoading &&
+              (loans ?? []).filter((loan) => loan.status === "active").length === 0 && (
+                <div className="rounded-2xl border border-dashed border-zinc-300 px-6 py-8 text-center dark:border-zinc-700">
+                  <PiggyBank className="mx-auto h-6 w-6 text-zinc-400" />
+                  <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    No active pool-funded loans available yet.
+                  </p>
+                </div>
+              )}
+          </div>
+        </section>
+      </ErrorBoundary>
+
+      <ErrorBoundary scope="yield history" variant="section">
+        <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+          <YieldEarningsChart data={chartData} />
+        </section>
+      </ErrorBoundary>
+    </main>
+  );
+}

--- a/frontend/src/app/loans/[loanId]/page.tsx
+++ b/frontend/src/app/loans/[loanId]/page.tsx
@@ -1,8 +1,60 @@
-import Link from "next/link";
-import { ChevronRight, Wallet } from "lucide-react";
+"use client";
 
-export default async function LoanDetailsPage({ params }: { params: Promise<{ loanId: string }> }) {
-  const { loanId } = await params;
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { ChevronRight, ExternalLink, Wallet } from "lucide-react";
+import { LoanDetailSkeleton } from "../../components/skeletons/LoanDetailSkeleton";
+import { useLoan } from "../../hooks/useApi";
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+export default function LoanDetailsPage() {
+  const params = useParams<{ loanId: string }>();
+  const loanId = params.loanId;
+  const { data: loan, isLoading, isError } = useLoan(loanId);
+
+  if (isLoading) {
+    return <LoanDetailSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <section className="rounded-3xl border border-red-200 bg-red-50 p-6 text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+        Failed to fetch loan details. Please try again.
+      </section>
+    );
+  }
+
+  if (!loan) {
+    return (
+      <section className="rounded-3xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-950">
+        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Loan not found</h1>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+          The requested loan could not be located.
+        </p>
+        <Link
+          href="/loans"
+          className="mt-4 inline-flex items-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:bg-zinc-100 dark:text-zinc-900"
+        >
+          Back to loans
+        </Link>
+      </section>
+    );
+  }
+
+  const progress =
+    loan.totalOwed > 0
+      ? Math.min((loan.totalRepaid / (loan.totalRepaid + loan.totalOwed)) * 100, 100)
+      : 100;
+  const latestTxHash = loan.events.find((event) => Boolean(event.txHash))?.txHash;
+  const statusTone =
+    loan.status === "repaid"
+      ? "text-green-600 dark:text-green-400"
+      : loan.status === "defaulted"
+        ? "text-red-600 dark:text-red-400"
+        : "text-indigo-600 dark:text-indigo-400";
 
   return (
     <section className="space-y-6">
@@ -21,10 +73,10 @@ export default async function LoanDetailsPage({ params }: { params: Promise<{ lo
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Repayment plan</h2>
           <div className="mt-5 grid gap-4 sm:grid-cols-2">
             {[
-              ["Principal remaining", "$1,240"],
-              ["Interest accrued", "$74"],
-              ["Due date", "April 18, 2026"],
-              ["Status", "Current"],
+              ["Principal", formatCurrency(loan.principal)],
+              ["Interest accrued", formatCurrency(loan.accruedInterest)],
+              ["Total repaid", formatCurrency(loan.totalRepaid)],
+              ["Total owed", formatCurrency(loan.totalOwed)],
             ].map(([label, value]) => (
               <div key={label} className="rounded-2xl bg-zinc-50 p-4 dark:bg-zinc-900">
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">{label}</p>
@@ -33,6 +85,51 @@ export default async function LoanDetailsPage({ params }: { params: Promise<{ lo
                 </p>
               </div>
             ))}
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Repayment progress</p>
+              <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                {progress.toFixed(1)}%
+              </p>
+            </div>
+            <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-800">
+              <div className="h-2 rounded-full bg-indigo-600" style={{ width: `${progress}%` }} />
+            </div>
+            <p className={`mt-3 text-sm font-semibold capitalize ${statusTone}`}>
+              Status: {loan.status}
+            </p>
+          </div>
+
+          <div className="mt-6">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+              Repayment timeline
+            </h3>
+            <div className="mt-3 space-y-3">
+              {loan.events.length === 0 ? (
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">No events yet.</p>
+              ) : (
+                loan.events.map((event, index) => (
+                  <div
+                    key={`${event.type}-${event.timestamp}-${index}`}
+                    className="rounded-xl border border-zinc-200 p-3 dark:border-zinc-800"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                        {event.type}
+                      </p>
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {new Date(event.timestamp).toLocaleString()}
+                      </p>
+                    </div>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                      Amount: {formatCurrency(Number(event.amount) || 0)}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </article>
 
@@ -49,9 +146,21 @@ export default async function LoanDetailsPage({ params }: { params: Promise<{ lo
               href={`/repay/${loanId}`}
               className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
             >
-              Repay this loan
+              Make Payment
               <ChevronRight className="h-4 w-4" />
             </Link>
+
+            {latestTxHash && (
+              <a
+                href={`https://stellar.expert/explorer/testnet/tx/${latestTxHash}`}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-3 inline-flex items-center gap-2 rounded-full border border-indigo-300 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+              >
+                View on Explorer
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            )}
           </div>
         </aside>
       </div>

--- a/frontend/src/app/loans/page.tsx
+++ b/frontend/src/app/loans/page.tsx
@@ -1,25 +1,73 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, CalendarRange, CircleDollarSign, ShieldCheck } from "lucide-react";
 import { ErrorBoundary } from "../components/global_ui/ErrorBoundary";
+import { LoansListSkeleton } from "../components/skeletons/LoansListSkeleton";
+import { useBorrowerLoans } from "../hooks/useApi";
+import { useWalletStore, selectWalletAddress } from "../stores/useWalletStore";
 
-const loans = [
-  {
-    id: 421,
-    borrower: "Farmer Collective",
-    status: "Active",
-    balance: "$1,240",
-    dueDate: "Apr 18",
-  },
-  {
-    id: 422,
-    borrower: "Solar Retail Hub",
-    status: "Pending",
-    balance: "$980",
-    dueDate: "Apr 30",
-  },
-];
+const PAGE_SIZE = 6;
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function getLoanDisplayStatus(status: string, nextPaymentDeadline: string, now: number) {
+  if (status !== "active") {
+    return status;
+  }
+  return new Date(nextPaymentDeadline).getTime() < now ? "defaulted" : "active";
+}
 
 export default function LoansPage() {
+  const [activeTab, setActiveTab] = useState<"all" | "active" | "repaid" | "defaulted">("all");
+  const [page, setPage] = useState(1);
+  const [now] = useState(() => Date.now());
+  const address = useWalletStore(selectWalletAddress);
+  const { loans, stats, isLoading, isError } = useBorrowerLoans(address ?? undefined);
+
+  const filteredLoans = useMemo(() => {
+    const enriched = loans.map((loan) => ({
+      ...loan,
+      displayStatus: getLoanDisplayStatus(loan.status, loan.nextPaymentDeadline, now),
+    }));
+
+    if (activeTab === "all") {
+      return enriched;
+    }
+
+    return enriched.filter((loan) => loan.displayStatus === activeTab);
+  }, [activeTab, loans, now]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredLoans.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const paginatedLoans = filteredLoans.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
+  );
+  const dueThisWeek = loans.filter((loan) => {
+    const dueAt = new Date(loan.nextPaymentDeadline).getTime();
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    return dueAt >= now && dueAt <= now + sevenDays;
+  }).length;
+
+  const portfolioHealth =
+    stats.overdueCount === 0 ? "Strong" : stats.overdueCount <= 2 ? "Watch" : "At Risk";
+
+  if (isLoading) {
+    return <LoansListSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <section className="rounded-3xl border border-red-200 bg-red-50 p-6 text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+        Failed to load loans. Please reconnect your wallet and try again.
+      </section>
+    );
+  }
+
   return (
     <section className="space-y-6">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
@@ -37,9 +85,17 @@ export default function LoansPage() {
       <ErrorBoundary scope="loan summary cards" variant="section">
         <div className="grid gap-4 md:grid-cols-3">
           {[
-            { label: "Outstanding", value: "$2,220", icon: CircleDollarSign },
-            { label: "Due This Week", value: "1 loan", icon: CalendarRange },
-            { label: "Portfolio Health", value: "Strong", icon: ShieldCheck },
+            {
+              label: "Outstanding",
+              value: formatCurrency(stats.totalOwed),
+              icon: CircleDollarSign,
+            },
+            {
+              label: "Due This Week",
+              value: `${dueThisWeek} loan${dueThisWeek === 1 ? "" : "s"}`,
+              icon: CalendarRange,
+            },
+            { label: "Portfolio Health", value: portfolioHealth, icon: ShieldCheck },
           ].map((item) => (
             <article
               key={item.label}
@@ -62,36 +118,104 @@ export default function LoansPage() {
       </ErrorBoundary>
 
       <ErrorBoundary scope="loan list" variant="section">
-        <div className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
-          <div className="space-y-3">
-            {loans.map((loan) => (
-              <article
-                key={loan.id}
-                className="flex flex-col gap-4 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800 md:flex-row md:items-center md:justify-between"
+        <div className="space-y-4 rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+          <div className="flex flex-wrap gap-2">
+            {[
+              { key: "all", label: "All" },
+              { key: "active", label: "Active" },
+              { key: "repaid", label: "Repaid" },
+              { key: "defaulted", label: "Defaulted" },
+            ].map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => {
+                  setActiveTab(tab.key as typeof activeTab);
+                  setPage(1);
+                }}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                  activeTab === tab.key
+                    ? "bg-indigo-600 text-white"
+                    : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                }`}
               >
-                <div>
-                  <p className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                    Loan #{loan.id}
-                  </p>
-                  <p className="text-sm text-zinc-500 dark:text-zinc-400">{loan.borrower}</p>
-                </div>
-                <div className="flex flex-wrap items-center gap-3 text-sm">
-                  <span className="rounded-full bg-zinc-100 px-3 py-1 font-medium text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                    {loan.status}
-                  </span>
-                  <span className="text-zinc-600 dark:text-zinc-400">{loan.balance}</span>
-                  <span className="text-zinc-600 dark:text-zinc-400">Due {loan.dueDate}</span>
-                </div>
-                <Link
-                  href={`/loans/${loan.id}`}
-                  className="inline-flex items-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-                >
-                  View details
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              </article>
+                {tab.label}
+              </button>
             ))}
           </div>
+
+          {paginatedLoans.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+              <p className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+                No loans found
+              </p>
+              <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+                You do not have loans in this category yet.
+              </p>
+              <Link
+                href="/"
+                className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
+              >
+                Request a loan
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {paginatedLoans.map((loan) => (
+                <article
+                  key={loan.id}
+                  className="flex flex-col gap-4 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <p className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                      Loan #{loan.id}
+                    </p>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">{loan.borrower}</p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm">
+                    <span className="rounded-full bg-zinc-100 px-3 py-1 font-medium capitalize text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                      {loan.displayStatus}
+                    </span>
+                    <span className="text-zinc-600 dark:text-zinc-400">
+                      {formatCurrency(loan.totalOwed)}
+                    </span>
+                    <span className="text-zinc-600 dark:text-zinc-400">
+                      Due {new Date(loan.nextPaymentDeadline).toLocaleDateString()}
+                    </span>
+                  </div>
+                  <Link
+                    href={`/loans/${loan.id}`}
+                    className="inline-flex items-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  >
+                    View details
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </article>
+              ))}
+            </div>
+          )}
+
+          {paginatedLoans.length > 0 && totalPages > 1 && (
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <button
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                disabled={currentPage === 1}
+                className="rounded-full border border-zinc-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700"
+              >
+                Prev
+              </button>
+              <span className="text-sm text-zinc-600 dark:text-zinc-400">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+                disabled={currentPage === totalPages}
+                className="rounded-full border border-zinc-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700"
+              >
+                Next
+              </button>
+            </div>
+          )}
         </div>
       </ErrorBoundary>
     </section>


### PR DESCRIPTION
## Summary
- replace hardcoded borrower loans and loan detail screens with API-driven data, including status filters, pagination, loading/empty/error states, repayment progress, and timeline rendering
- add a functional header search with debounced query, categorized results (Loans/Pages/Transactions), keyboard navigation, and Cmd/Ctrl+K quick open behavior
- introduce a new `/lend` dashboard with pool overview metrics, depositor stats, deposit/withdraw UI sections, funded-loan list, and yield history chart; add Lend navigation and breadcrumb label
- update frontend ESLint flat config to a Next.js 16 compatible setup so pre-commit lint-staged checks run successfully

Closes #247
Closes #249
Closes #250
Closes #253