### PR TITLE
feat(backend): add reindex admin API, request correlation IDs, webhoo…

### DIFF
--- a/backend/src/__tests__/adminReindex.test.ts
+++ b/backend/src/__tests__/adminReindex.test.ts
@@ -1,0 +1,27 @@
+import request from "supertest";
+import app from "../app.js";
+
+describe("Admin reindex endpoint", () => {
+  const apiKey = "test-internal-api-key";
+
+  beforeAll(() => {
+    process.env.INTERNAL_API_KEY = apiKey;
+  });
+
+  it("rejects requests without API key", async () => {
+    const response = await request(app).post(
+      "/api/admin/reindex?fromLedger=1&toLedger=2",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("validates ledger range query parameters", async () => {
+    const response = await request(app)
+      .post("/api/admin/reindex?fromLedger=abc&toLedger=2")
+      .set("x-api-key", apiKey);
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+});

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -140,6 +140,9 @@ describe("Auth API", () => {
       expect(verifyResponse.body.success).toBe(true);
       expect(verifyResponse.body.data.valid).toBe(true);
       expect(verifyResponse.body.data.publicKey).toBe(keypair.publicKey());
+      expect(verifyResponse.body.data.role).toBe("borrower");
+      expect(Array.isArray(verifyResponse.body.data.scopes)).toBe(true);
+      expect(verifyResponse.body.data.scopes).toContain("read:loans");
     });
 
     it("should reject missing token", async () => {

--- a/backend/src/__tests__/requestId.test.ts
+++ b/backend/src/__tests__/requestId.test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import app from "../app.js";
+
+describe("Request ID middleware", () => {
+  it("adds x-request-id when missing", async () => {
+    const response = await request(app).get("/");
+    const requestId = response.headers["x-request-id"] as string | undefined;
+
+    expect(response.status).toBe(200);
+    expect(requestId).toBeDefined();
+    expect(typeof requestId).toBe("string");
+    expect((requestId ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("preserves client x-request-id", async () => {
+    const requestId = "test-request-id-123";
+
+    const response = await request(app).get("/").set("x-request-id", requestId);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["x-request-id"]).toBe(requestId);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,6 +25,7 @@ import { swaggerSpec } from "./config/swagger.js";
 import { globalRateLimiter } from "./middleware/rateLimiter.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
+import { requestIdMiddleware } from "./middleware/requestId.js";
 import { asyncHandler } from "./middleware/asyncHandler.js";
 import { AppError } from "./errors/AppError.js";
 const app = express();
@@ -69,7 +70,12 @@ const corsOptions: cors.CorsOptions = {
     return callback(new Error("Not allowed by CORS"));
   },
   methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization", "x-api-key"],
+  allowedHeaders: [
+    "Content-Type",
+    "Authorization",
+    "x-api-key",
+    "x-request-id",
+  ],
   credentials: true,
 };
 
@@ -77,6 +83,7 @@ app.use(cors(corsOptions));
 app.use(compression());
 app.use(express.json());
 app.use(globalRateLimiter);
+app.use(requestIdMiddleware);
 app.use(requestLogger);
 
 app.get("/", (req: Request, res: Response) => {

--- a/backend/src/auth/rbac.ts
+++ b/backend/src/auth/rbac.ts
@@ -1,0 +1,49 @@
+export const USER_ROLES = ["admin", "borrower", "lender"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
+export const ROLE_SCOPES: Record<UserRole, string[]> = {
+  admin: ["admin:all"],
+  borrower: [
+    "read:loans",
+    "write:repayment",
+    "read:score",
+    "read:notifications",
+    "write:notifications",
+  ],
+  lender: ["read:loans", "read:pool"],
+};
+
+const parseWalletSet = (wallets: string | undefined): Set<string> => {
+  if (!wallets) return new Set();
+
+  return new Set(
+    wallets
+      .split(",")
+      .map((wallet) => wallet.trim())
+      .filter((wallet) => wallet.length > 0),
+  );
+};
+
+export const resolveRoleForWallet = (publicKey: string): UserRole => {
+  const adminWallets = parseWalletSet(process.env.ADMIN_WALLETS);
+  if (adminWallets.has(publicKey)) {
+    return "admin";
+  }
+
+  const lenderWallets = parseWalletSet(process.env.LENDER_WALLETS);
+  if (lenderWallets.has(publicKey)) {
+    return "lender";
+  }
+
+  return "borrower";
+};
+
+export const resolveScopesForRole = (role: UserRole): string[] => {
+  const ownScopes = ROLE_SCOPES[role] ?? [];
+  if (role === "admin") {
+    return [...ownScopes];
+  }
+
+  // Include admin scope only for admin; keep role scopes explicit for others.
+  return [...ownScopes];
+};

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -79,6 +79,8 @@ export const verify = (req: Request, res: Response): void => {
     success: true,
     data: {
       publicKey: req.user?.publicKey,
+      role: req.user?.role,
+      scopes: req.user?.scopes,
       valid: true,
     },
   });

--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { query } from "../db/connection.js";
 import logger from "../utils/logger.js";
+import { EventIndexer } from "../services/eventIndexer.js";
 import {
   SUPPORTED_WEBHOOK_EVENT_TYPES,
   webhookService,
@@ -335,7 +336,7 @@ export const deleteWebhookSubscription = async (
   res: Response,
 ) => {
   try {
-    const subscriptionId = Number(req.params.subscriptionId);
+    const subscriptionId = Number(req.params.id ?? req.params.subscriptionId);
 
     if (!Number.isInteger(subscriptionId) || subscriptionId <= 0) {
       return res.status(400).json({
@@ -361,6 +362,104 @@ export const deleteWebhookSubscription = async (
     res.status(500).json({
       success: false,
       message: "Failed to delete webhook subscription",
+    });
+  }
+};
+
+export const getWebhookDeliveries = async (req: Request, res: Response) => {
+  try {
+    const subscriptionId = Number(req.params.id ?? req.params.subscriptionId);
+    const limit = Number(req.query.limit ?? 50);
+
+    if (!Number.isInteger(subscriptionId) || subscriptionId <= 0) {
+      return res.status(400).json({
+        success: false,
+        message: "subscription id must be a positive integer",
+      });
+    }
+
+    const boundedLimit =
+      Number.isFinite(limit) && limit > 0 ? Math.min(limit, 200) : 50;
+
+    const deliveries = await webhookService.getSubscriptionDeliveries(
+      subscriptionId,
+      boundedLimit,
+    );
+
+    res.json({
+      success: true,
+      data: {
+        subscriptionId,
+        deliveries,
+      },
+    });
+  } catch (error) {
+    logger.error("Failed to fetch webhook deliveries", { error });
+    res.status(500).json({
+      success: false,
+      message: "Failed to fetch webhook deliveries",
+    });
+  }
+};
+
+export const reindexLedgerRange = async (req: Request, res: Response) => {
+  try {
+    const fromLedger = Number(req.query.fromLedger);
+    const toLedger = Number(req.query.toLedger);
+
+    if (!Number.isInteger(fromLedger) || !Number.isInteger(toLedger)) {
+      return res.status(400).json({
+        success: false,
+        message: "fromLedger and toLedger must be integers",
+      });
+    }
+
+    if (fromLedger <= 0 || toLedger <= 0 || fromLedger > toLedger) {
+      return res.status(400).json({
+        success: false,
+        message: "Ledger range is invalid",
+      });
+    }
+
+    const maxRange = Number(process.env.REINDEX_MAX_RANGE ?? 25000);
+    const requestedRange = toLedger - fromLedger + 1;
+    if (requestedRange > maxRange) {
+      return res.status(400).json({
+        success: false,
+        message: `Requested range exceeds maximum of ${maxRange} ledgers`,
+      });
+    }
+
+    const rpcUrl =
+      process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+    const contractId = process.env.LOAN_MANAGER_CONTRACT_ID;
+
+    if (!contractId) {
+      return res.status(500).json({
+        success: false,
+        message: "LOAN_MANAGER_CONTRACT_ID is not configured",
+      });
+    }
+
+    const batchSize = Number(process.env.INDEXER_BATCH_SIZE ?? 100);
+    const indexer = new EventIndexer({
+      rpcUrl,
+      contractId,
+      pollIntervalMs: 30_000,
+      batchSize,
+    });
+
+    const result = await indexer.reindexRange(fromLedger, toLedger);
+
+    res.json({
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    logger.error("Failed to reindex ledger range", { error });
+    res.status(500).json({
+      success: false,
+      message: "Failed to reindex ledger range",
     });
   }
 };

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -12,7 +12,7 @@ import logger from "../utils/logger.js";
  */
 export const errorHandler = (
   err: Error,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void => {
@@ -35,8 +35,9 @@ export const errorHandler = (
   if (err instanceof AppError) {
     if (!err.isOperational) {
       logger.error(`Internal AppError: ${err.message}`, {
-        path: _req.path,
-        method: _req.method,
+        requestId: req.requestId,
+        path: req.path,
+        method: req.method,
         stack: err.stack,
       });
     }
@@ -50,6 +51,7 @@ export const errorHandler = (
 
   // ── Unexpected / Programming Errors ──────────────────────────
   logger.error("Unhandled error", {
+    requestId: req.requestId,
     message: err.message,
     name: err.name,
     ...(err.stack && { stack: err.stack }),

--- a/backend/src/middleware/jwtAuth.ts
+++ b/backend/src/middleware/jwtAuth.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { AppError } from "../errors/AppError.js";
+import { type UserRole } from "../auth/rbac.js";
 import {
   verifyJwtToken,
   extractBearerToken,
@@ -116,8 +117,9 @@ export const requireBorrower = (
   _res: Response,
   next: NextFunction,
 ): void => {
-  if (!req.user?.publicKey) {
-    throw AppError.unauthorized("Authentication required");
+  if (!req.user?.publicKey) throw AppError.unauthorized("Authentication required");
+  if (req.user.role !== "borrower" && req.user.role !== "admin") {
+    throw AppError.forbidden("Borrower role required");
   }
 
   next();
@@ -128,11 +130,49 @@ export const requireLender = (
   _res: Response,
   next: NextFunction,
 ): void => {
-  if (!req.user?.publicKey) {
-    throw AppError.unauthorized("Authentication required");
+  if (!req.user?.publicKey) throw AppError.unauthorized("Authentication required");
+  if (req.user.role !== "lender" && req.user.role !== "admin") {
+    throw AppError.forbidden("Lender role required");
   }
 
   next();
+};
+
+export const requireRoles = (...roles: UserRole[]) => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    if (!req.user?.publicKey) {
+      throw AppError.unauthorized("Authentication required");
+    }
+
+    if (!roles.includes(req.user.role)) {
+      throw AppError.forbidden("Insufficient role permissions");
+    }
+
+    next();
+  };
+};
+
+export const requireScopes = (...requiredScopes: string[]) => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    if (!req.user?.publicKey) {
+      throw AppError.unauthorized("Authentication required");
+    }
+
+    const grantedScopes = new Set(req.user.scopes ?? []);
+    if (grantedScopes.has("admin:all")) {
+      return next();
+    }
+
+    const missingScope = requiredScopes.find(
+      (scope) => !grantedScopes.has(scope),
+    );
+
+    if (missingScope) {
+      throw AppError.forbidden(`Missing required scope: ${missingScope}`);
+    }
+
+    next();
+  };
 };
 
 export { JwtPayload };

--- a/backend/src/middleware/requestId.ts
+++ b/backend/src/middleware/requestId.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, NextFunction } from "express";
+import {
+  createRequestId,
+  runWithRequestContext,
+} from "../utils/requestContext.js";
+
+declare module "express" {
+  interface Request {
+    requestId?: string;
+  }
+}
+
+export const requestIdMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const incomingHeader = req.header("x-request-id");
+  const requestId =
+    typeof incomingHeader === "string" && incomingHeader.trim().length > 0
+      ? incomingHeader.trim()
+      : createRequestId();
+
+  req.requestId = requestId;
+  res.setHeader("x-request-id", requestId);
+
+  runWithRequestContext(requestId, () => {
+    next();
+  });
+};

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -19,6 +19,7 @@ export const requestLogger = (
     const { statusCode } = res;
 
     const payload = {
+      requestId: req.requestId,
       method,
       url: originalUrl,
       statusCode,

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -5,6 +5,13 @@ import { strictRateLimiter } from "../middleware/rateLimiter.js";
 import { validateBody } from "../middleware/validation.js";
 import { asyncHandler } from "../middleware/asyncHandler.js";
 import { defaultChecker } from "../services/defaultChecker.js";
+import {
+  createWebhookSubscription,
+  deleteWebhookSubscription,
+  getWebhookDeliveries,
+  listWebhookSubscriptions,
+  reindexLedgerRange,
+} from "../controllers/indexerController.js";
 
 const router = Router();
 
@@ -54,5 +61,115 @@ router.post(
     });
   }),
 );
+
+/**
+ * @swagger
+ * /admin/reindex:
+ *   post:
+ *     summary: Backfill/reindex contract events for a ledger range
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: fromLedger
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: toLedger
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Reindex completed
+ */
+router.post("/reindex", requireApiKey, strictRateLimiter, reindexLedgerRange);
+
+/**
+ * @swagger
+ * /admin/webhooks:
+ *   post:
+ *     summary: Register a webhook subscription
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [callbackUrl, eventTypes]
+ *             properties:
+ *               callbackUrl:
+ *                 type: string
+ *               eventTypes:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               secret:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Subscription created
+ *   get:
+ *     summary: List webhook subscriptions
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: List of subscriptions
+ */
+router.post("/webhooks", requireApiKey, strictRateLimiter, createWebhookSubscription);
+router.get("/webhooks", requireApiKey, listWebhookSubscriptions);
+
+/**
+ * @swagger
+ * /admin/webhooks/{id}:
+ *   delete:
+ *     summary: Remove a webhook subscription
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Subscription deleted
+ */
+router.delete("/webhooks/:id", requireApiKey, strictRateLimiter, deleteWebhookSubscription);
+
+/**
+ * @swagger
+ * /admin/webhooks/{id}/deliveries:
+ *   get:
+ *     summary: View webhook delivery history
+ *     tags: [Admin]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *     responses:
+ *       200:
+ *         description: Delivery history returned
+ */
+router.get("/webhooks/:id/deliveries", requireApiKey, getWebhookDeliveries);
 
 export default router;

--- a/backend/src/routes/indexerRoutes.ts
+++ b/backend/src/routes/indexerRoutes.ts
@@ -11,6 +11,7 @@ import {
 import { requireApiKey } from "../middleware/auth.js";
 import {
   requireJwtAuth,
+  requireScopes,
   requireWalletOwnership,
 } from "../middleware/jwtAuth.js";
 import { requireLoanBorrowerAccess } from "../middleware/loanAccess.js";
@@ -90,6 +91,7 @@ router.get("/status", getIndexerStatus);
 router.get(
   "/events/borrower/:borrower",
   requireJwtAuth,
+  requireScopes("read:loans"),
   requireWalletOwnership,
   getBorrowerEvents,
 );
@@ -122,6 +124,7 @@ router.get(
 router.get(
   "/events/loan/:loanId",
   requireJwtAuth,
+  requireScopes("read:loans"),
   requireLoanBorrowerAccess,
   getLoanEvents,
 );

--- a/backend/src/routes/loanRoutes.ts
+++ b/backend/src/routes/loanRoutes.ts
@@ -8,6 +8,7 @@ import {
 } from "../controllers/loanController.js";
 import {
   requireJwtAuth,
+  requireScopes,
   requireWalletOwnership,
 } from "../middleware/jwtAuth.js";
 import { requireLoanBorrowerAccess } from "../middleware/loanAccess.js";
@@ -51,6 +52,7 @@ const router = Router();
 router.get(
   "/borrower/:borrower",
   requireJwtAuth,
+  requireScopes("read:loans"),
   requireWalletOwnership,
   validate(borrowerParamSchema),
   getBorrowerLoans,
@@ -85,6 +87,7 @@ router.get(
 router.get(
   "/:loanId",
   requireJwtAuth,
+  requireScopes("read:loans"),
   requireLoanBorrowerAccess,
   getLoanDetails,
 );

--- a/backend/src/routes/notificationsRoutes.ts
+++ b/backend/src/routes/notificationsRoutes.ts
@@ -5,7 +5,7 @@ import {
   markAllRead,
   streamNotifications,
 } from "../controllers/notificationController.js";
-import { requireJwtAuth } from "../middleware/jwtAuth.js";
+import { requireJwtAuth, requireScopes } from "../middleware/jwtAuth.js";
 
 const router = Router();
 
@@ -42,7 +42,7 @@ const router = Router();
  *                     unreadCount:
  *                       type: integer
  */
-router.get("/", requireJwtAuth, getNotifications);
+router.get("/", requireJwtAuth, requireScopes("read:notifications"), getNotifications);
 
 /**
  * @swagger
@@ -56,7 +56,12 @@ router.get("/", requireJwtAuth, getNotifications);
  *       200:
  *         description: Server-Sent Events stream (text/event-stream)
  */
-router.get("/stream", requireJwtAuth, streamNotifications);
+router.get(
+  "/stream",
+  requireJwtAuth,
+  requireScopes("read:notifications"),
+  streamNotifications,
+);
 
 /**
  * @swagger
@@ -81,7 +86,12 @@ router.get("/stream", requireJwtAuth, streamNotifications);
  *       200:
  *         description: Notifications marked as read
  */
-router.post("/mark-read", requireJwtAuth, markRead);
+router.post(
+  "/mark-read",
+  requireJwtAuth,
+  requireScopes("write:notifications"),
+  markRead,
+);
 
 /**
  * @swagger
@@ -95,6 +105,11 @@ router.post("/mark-read", requireJwtAuth, markRead);
  *       200:
  *         description: All notifications marked as read
  */
-router.post("/mark-all-read", requireJwtAuth, markAllRead);
+router.post(
+  "/mark-all-read",
+  requireJwtAuth,
+  requireScopes("write:notifications"),
+  markAllRead,
+);
 
 export default router;

--- a/backend/src/routes/poolRoutes.ts
+++ b/backend/src/routes/poolRoutes.ts
@@ -4,7 +4,9 @@ import {
   getDepositorPortfolio,
 } from "../controllers/poolController.js";
 import {
+  requireLender,
   requireJwtAuth,
+  requireScopes,
   requireWalletParamMatchesJwt,
 } from "../middleware/jwtAuth.js";
 import { validate } from "../middleware/validation.js";
@@ -49,7 +51,7 @@ const router = Router();
  *       401:
  *         description: Missing or invalid Bearer token
  */
-router.get("/stats", requireJwtAuth, getPoolStats);
+router.get("/stats", requireJwtAuth, requireLender, requireScopes("read:pool"), getPoolStats);
 
 /**
  * @swagger
@@ -80,6 +82,8 @@ router.get("/stats", requireJwtAuth, getPoolStats);
 router.get(
   "/depositor/:address",
   requireJwtAuth,
+  requireLender,
+  requireScopes("read:pool"),
   requireWalletParamMatchesJwt("address"),
   validate(addressParamSchema),
   getDepositorPortfolio,

--- a/backend/src/routes/scoreRoutes.ts
+++ b/backend/src/routes/scoreRoutes.ts
@@ -10,6 +10,7 @@ import { requireApiKey } from "../middleware/auth.js";
 import { strictRateLimiter } from "../middleware/rateLimiter.js";
 import {
   requireJwtAuth,
+  requireScopes,
   requireWalletParamMatchesJwt,
 } from "../middleware/jwtAuth.js";
 
@@ -54,6 +55,7 @@ const router = Router();
 router.get(
   "/:userId",
   requireJwtAuth,
+  requireScopes("read:score"),
   requireWalletParamMatchesJwt("userId"),
   validate(getScoreSchema),
   getScore,

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,9 +1,16 @@
 import jwt from "jsonwebtoken";
 import { Keypair, StrKey } from "@stellar/stellar-sdk";
 import crypto from "crypto";
+import {
+  resolveRoleForWallet,
+  resolveScopesForRole,
+  type UserRole,
+} from "../auth/rbac.js";
 
 export interface JwtPayload {
   publicKey: string;
+  role: UserRole;
+  scopes: string[];
   iat: number;
   exp: number;
 }
@@ -80,8 +87,13 @@ export function verifyChallengeTimestamp(
 
 export function generateJwtToken(publicKey: string): string {
   const secret = getJwtSecret();
+  const role = resolveRoleForWallet(publicKey);
+  const scopes = resolveScopesForRole(role);
+
   const payload: Omit<JwtPayload, "iat" | "exp"> = {
     publicKey,
+    role,
+    scopes,
   };
 
   return jwt.sign(payload, secret, {

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -1,14 +1,14 @@
-import { SorobanRpc, xdr, scValToNative } from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc, scValToNative, xdr } from "@stellar/stellar-sdk";
 import { query } from "../db/connection.js";
 import logger from "../utils/logger.js";
+import { createRequestId, runWithRequestContext } from "../utils/requestContext.js";
 import {
-  WebhookEventType,
-  IndexedLoanEvent,
+  type IndexedLoanEvent,
+  type WebhookEventType,
   webhookService,
 } from "./webhookService.js";
 import { eventStreamService } from "./eventStreamService.js";
 
-// Typing for raw Soroban events
 interface SorobanRawEvent {
   id: string;
   pagingToken: string;
@@ -34,168 +34,456 @@ interface LoanEvent extends IndexedLoanEvent {
   termLedgers?: number;
 }
 
-export class EventIndexer {
-  private rpc: SorobanRpc.Server;
-  private contractId: string;
+interface EventIndexerConfig {
+  rpcUrl: string;
+  contractId: string;
+  pollIntervalMs?: number;
+  batchSize?: number;
+}
 
-  constructor(rpcUrl: string, contractId: string) {
-    this.rpc = new SorobanRpc.Server(rpcUrl);
-    this.contractId = contractId;
+interface StoreEventsResult {
+  insertedCount: number;
+}
+
+interface ProcessChunkResult {
+  lastProcessedLedger: number;
+  fetchedEvents: number;
+  insertedEvents: number;
+}
+
+export class EventIndexer {
+  private readonly rpc: SorobanRpc.Server;
+  private readonly contractId: string;
+  private readonly pollIntervalMs: number;
+  private readonly batchSize: number;
+  private running = false;
+  private pollTimeout: NodeJS.Timeout | null = null;
+
+  constructor(config: EventIndexerConfig);
+  constructor(rpcUrl: string, contractId: string);
+  constructor(configOrRpcUrl: EventIndexerConfig | string, contractId?: string) {
+    if (typeof configOrRpcUrl === "string") {
+      if (!contractId) {
+        throw new Error("contractId is required when using rpcUrl constructor");
+      }
+      this.rpc = new SorobanRpc.Server(configOrRpcUrl);
+      this.contractId = contractId;
+      this.pollIntervalMs = 30_000;
+      this.batchSize = 100;
+      return;
+    }
+
+    this.rpc = new SorobanRpc.Server(configOrRpcUrl.rpcUrl);
+    this.contractId = configOrRpcUrl.contractId;
+    this.pollIntervalMs = configOrRpcUrl.pollIntervalMs ?? 30_000;
+    this.batchSize = configOrRpcUrl.batchSize ?? 100;
   }
 
-  /**
-   * Main entry point to process contract events from a sequence range
-   */
+  async start(): Promise<void> {
+    if (this.running) {
+      logger.warn("Indexer start requested while already running");
+      return;
+    }
+
+    this.running = true;
+    await this.pollOnce();
+    this.scheduleNextPoll();
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.pollTimeout) {
+      clearTimeout(this.pollTimeout);
+      this.pollTimeout = null;
+    }
+  }
+
   async processEvents(startLedger: number, endLedger: number): Promise<number> {
+    const chunkResult = await this.processChunk(startLedger, endLedger);
+    return chunkResult.lastProcessedLedger;
+  }
+
+  async reindexRange(fromLedger: number, toLedger: number): Promise<{
+    fromLedger: number;
+    toLedger: number;
+    fetchedEvents: number;
+    insertedEvents: number;
+    lastProcessedLedger: number;
+  }> {
+    let current = fromLedger;
+    let totalFetched = 0;
+    let totalInserted = 0;
+    let lastProcessedLedger = fromLedger - 1;
+
+    while (current <= toLedger) {
+      const chunkEnd = Math.min(current + this.batchSize - 1, toLedger);
+      const result = await this.processChunk(current, chunkEnd);
+
+      totalFetched += result.fetchedEvents;
+      totalInserted += result.insertedEvents;
+      lastProcessedLedger = result.lastProcessedLedger;
+      current = chunkEnd + 1;
+    }
+
+    return {
+      fromLedger,
+      toLedger,
+      fetchedEvents: totalFetched,
+      insertedEvents: totalInserted,
+      lastProcessedLedger,
+    };
+  }
+
+  private scheduleNextPoll(): void {
+    if (!this.running) return;
+
+    this.pollTimeout = setTimeout(async () => {
+      try {
+        await this.pollOnce();
+      } catch (error) {
+        logger.error("Indexer poll iteration failed", { error });
+      } finally {
+        this.scheduleNextPoll();
+      }
+    }, this.pollIntervalMs);
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (!this.running) return;
+
+    const lastIndexedLedger = await this.getLastIndexedLedger();
+    const latestLedger = await this.getLatestLedgerSequence();
+
+    if (latestLedger <= lastIndexedLedger) {
+      return;
+    }
+
+    const fromLedger = lastIndexedLedger + 1;
+    const toLedger = Math.min(fromLedger + this.batchSize - 1, latestLedger);
+
+    const result = await this.processChunk(fromLedger, toLedger);
+    await this.updateLastIndexedLedger(result.lastProcessedLedger);
+  }
+
+  private async getLatestLedgerSequence(): Promise<number> {
     try {
-      const response = await this.rpc.getEvents({
+      const latest = (await (this.rpc as unknown as {
+        getLatestLedger: () => Promise<Record<string, unknown>>;
+      }).getLatestLedger()) as Record<string, unknown>;
+
+      const candidate =
+        latest.sequence ?? latest.sequenceNumber ?? latest.seq ?? latest.id;
+      const sequence = Number(candidate);
+
+      return Number.isFinite(sequence) && sequence > 0 ? sequence : 0;
+    } catch (error) {
+      logger.warn("Failed to fetch latest ledger sequence", { error });
+      return 0;
+    }
+  }
+
+  private async getLastIndexedLedger(): Promise<number> {
+    const result = await query(
+      `SELECT last_indexed_ledger
+       FROM indexer_state
+       ORDER BY id DESC
+       LIMIT 1`,
+      [],
+    );
+
+    if (!result.rows.length) {
+      await query(
+        `INSERT INTO indexer_state (last_indexed_ledger)
+         VALUES (0)`,
+        [],
+      );
+      return 0;
+    }
+
+    return Number(result.rows[0]?.last_indexed_ledger ?? 0);
+  }
+
+  private async updateLastIndexedLedger(ledger: number): Promise<void> {
+    const updateResult = await query(
+      `UPDATE indexer_state
+       SET last_indexed_ledger = GREATEST(last_indexed_ledger, $1),
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = (
+         SELECT id
+         FROM indexer_state
+         ORDER BY id DESC
+         LIMIT 1
+       )`,
+      [ledger],
+    );
+
+    if ((updateResult.rowCount ?? 0) === 0) {
+      await query(
+        `INSERT INTO indexer_state (last_indexed_ledger)
+         VALUES ($1)`,
+        [ledger],
+      );
+    }
+  }
+
+  private async processChunk(
+    startLedger: number,
+    endLedger: number,
+  ): Promise<ProcessChunkResult> {
+    const correlationId = `indexer-${createRequestId()}`;
+
+    return runWithRequestContext(correlationId, async () => {
+      if (endLedger < startLedger) {
+        return {
+          lastProcessedLedger: endLedger,
+          fetchedEvents: 0,
+          insertedEvents: 0,
+        };
+      }
+
+      try {
+        const events = await this.fetchEventsInRange(startLedger, endLedger);
+        if (events.length === 0) {
+          return {
+            lastProcessedLedger: endLedger,
+            fetchedEvents: 0,
+            insertedEvents: 0,
+          };
+        }
+
+        const storeResult = await this.storeEvents(events);
+        const maxLedger = events.reduce(
+          (max, event) => Math.max(max, Number(event.ledger)),
+          startLedger,
+        );
+
+        logger.info("Indexer processed chunk", {
+          startLedger,
+          endLedger,
+          fetchedEvents: events.length,
+          insertedEvents: storeResult.insertedCount,
+        });
+
+        return {
+          lastProcessedLedger: Math.max(maxLedger, endLedger),
+          fetchedEvents: events.length,
+          insertedEvents: storeResult.insertedCount,
+        };
+      } catch (error) {
+        logger.error("Error processing event chunk", {
+          startLedger,
+          endLedger,
+          error,
+        });
+        throw error;
+      }
+    });
+  }
+
+  private async fetchEventsInRange(
+    startLedger: number,
+    endLedger: number,
+  ): Promise<SorobanRawEvent[]> {
+    const result: SorobanRawEvent[] = [];
+    let cursor: string | undefined;
+    let hasMorePages = true;
+
+    while (hasMorePages) {
+      const response = (await this.rpc.getEvents({
         startLedger,
+        endLedger,
+        cursor,
+        limit: this.batchSize,
         filters: [
           {
             type: "contract",
             contractIds: [this.contractId],
           },
         ],
-      });
+      } as never)) as unknown as {
+        events?: SorobanRawEvent[];
+        cursor?: string;
+        nextCursor?: string;
+      };
 
-      const events = response.events as unknown as SorobanRawEvent[];
-      if (events.length === 0) return endLedger;
+      const events = (response.events ?? []).filter(
+        (event) => event.ledger >= startLedger && event.ledger <= endLedger,
+      );
 
-      logger.info(`Found ${events.length} events from contract ${this.contractId}`);
+      result.push(...events);
 
-      const processed = await this.storeEvents(events);
-      return processed;
-    } catch (error) {
-      logger.error("Error processing events:", error);
-      throw error;
+      const nextCursor = response.nextCursor ?? response.cursor;
+      if (!nextCursor || nextCursor === cursor || events.length === 0) {
+        hasMorePages = false;
+        continue;
+      }
+
+      cursor = nextCursor;
     }
+
+    return result;
   }
 
-  private async storeEvents(events: SorobanRawEvent[]): Promise<number> {
-    const result: LoanEvent[] = [];
+  private async storeEvents(events: SorobanRawEvent[]): Promise<StoreEventsResult> {
+    const parsedEvents: LoanEvent[] = [];
 
-    for (const e of events) {
+    for (const event of events) {
       try {
-        const type = this.decodeEventType(e.topic[0]);
-        if (!type) continue;
-
-        let borrower = "";
-        let loanId: number | undefined;
-        let amount: string | undefined;
-        let interestRateBps: number | undefined;
-        let termLedgers: number | undefined;
-
-        if (type === "LoanRequested") {
-          borrower = this.decodeAddress(e.topic[1]);
-          amount = this.decodeAmount(e.value);
-        } else if (type === "LoanApproved") {
-          loanId = this.decodeLoanId(e.topic[1]);
-          if (loanId === undefined) continue;
-          // Capture current contract defaults at time of approval
-          interestRateBps = 1200; // Matches contract DEFAULT_INTEREST_RATE_BPS
-          termLedgers = 17280; // Matches contract DEFAULT_TERM_LEDGERS
-        } else if (type === "LoanRepaid") {
-          if (!e.topic[2]) continue;
-          borrower = this.decodeAddress(e.topic[1]);
-          loanId = this.decodeLoanId(e.topic[2]);
-          amount = this.decodeAmount(e.value);
-        } else if (type === "LoanDefaulted") {
-          loanId = this.decodeLoanId(e.topic[1]);
-          if (loanId === undefined) continue;
-          borrower = this.decodeAddress(e.value);
-        } else if (type === "Seized") {
-          borrower = this.decodeAddress(e.topic[1]);
+        const parsed = this.parseEvent(event);
+        if (parsed) {
+          parsedEvents.push(parsed);
         }
-
-        const evt: LoanEvent = {
-          eventId: e.id,
-          eventType: type,
-          ledger: e.ledger,
-          ledgerClosedAt: new Date(e.ledgerClosedAt),
-          txHash: e.txHash,
-          contractId: e.contractId.toString(),
-          topics: e.topic.map((t) => t.toXDR("base64")),
-          value: e.value.toXDR("base64"),
-          ...(amount !== undefined ? { amount } : {}),
-          ...(loanId !== undefined ? { loanId } : {}),
-          ...(interestRateBps !== undefined ? { interestRateBps } : {}),
-          ...(termLedgers !== undefined ? { termLedgers } : {}),
-          borrower,
-        };
-        result.push(evt);
-      } catch (err) {
-        logger.warn(`Failed to parse event ${e.id}:`, err);
+      } catch (error) {
+        logger.warn("Failed to parse event", {
+          eventId: event.id,
+          error,
+        });
       }
     }
 
-    if (result.length === 0) return events[events.length - 1].ledger;
+    if (parsedEvents.length === 0) {
+      return { insertedCount: 0 };
+    }
 
-    // Use transaction for database insertion
+    const insertedEvents: LoanEvent[] = [];
+
     await query("BEGIN", []);
     try {
-      for (const e of result) {
-        // Check for duplicates
-        const ex = await query(
-          "SELECT 1 FROM loan_events WHERE event_id = $1",
-          [e.eventId],
-        );
-        if (ex.rows.length) continue;
-        await query(
-          `INSERT INTO loan_events (event_id, event_type, loan_id, borrower, amount, ledger, ledger_closed_at, tx_hash, contract_id, topics, value, interest_rate_bps, term_ledgers)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+      for (const event of parsedEvents) {
+        const insertResult = await query(
+          `INSERT INTO loan_events (
+            event_id,
+            event_type,
+            loan_id,
+            borrower,
+            amount,
+            ledger,
+            ledger_closed_at,
+            tx_hash,
+            contract_id,
+            topics,
+            value,
+            interest_rate_bps,
+            term_ledgers
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+          ON CONFLICT (event_id) DO NOTHING
+          RETURNING event_id`,
           [
-            e.eventId,
-            e.eventType,
-            e.loanId || null,
-            e.borrower || null,
-            e.amount || null,
-            e.ledger,
-            e.ledgerClosedAt,
-            e.txHash,
-            e.contractId,
-            JSON.stringify(e.topics),
-            e.value,
-            e.interestRateBps || null,
-            e.termLedgers || null,
+            event.eventId,
+            event.eventType,
+            event.loanId ?? null,
+            event.borrower || null,
+            event.amount ?? null,
+            event.ledger,
+            event.ledgerClosedAt,
+            event.txHash,
+            event.contractId,
+            JSON.stringify(event.topics),
+            event.value,
+            event.interestRateBps ?? null,
+            event.termLedgers ?? null,
           ],
         );
 
-        // Update score in bi-directional way (increase on repay, decrease on default)
-        if (e.eventType === "LoanRepaid") {
-          await this.updateUserScore(e.borrower, 15); // +15 for repayment
-        } else if (e.eventType === "LoanDefaulted") {
-          await this.updateUserScore(e.borrower, -50); // penalty for default
+        if ((insertResult.rowCount ?? 0) > 0) {
+          insertedEvents.push(event);
+          if (event.eventType === "LoanRepaid") {
+            await this.updateUserScore(event.borrower, 15);
+          } else if (event.eventType === "LoanDefaulted") {
+            await this.updateUserScore(event.borrower, -50);
+          }
         }
-
-        // Dispatch webhooks
-        webhookService.dispatch(e).catch((err) => {
-          logger.error(`Webhook dispatch failed for ${e.eventId}:`, err);
-        });
-
-        // Broadcast to SSE clients for real-time updates
-        eventStreamService.broadcast({
-          eventId: e.eventId,
-          eventType: e.eventType,
-          ...(e.loanId !== undefined ? { loanId: e.loanId } : {}),
-          borrower: e.borrower,
-          ...(e.amount !== undefined ? { amount: e.amount } : {}),
-          ledger: e.ledger,
-          ledgerClosedAt: e.ledgerClosedAt.toISOString(),
-          txHash: e.txHash,
-        });
-
-        // Trigger notifications
-        this.triggerNotification(e).catch((err) => {
-          logger.error(`Notification trigger failed for ${e.eventId}:`, err);
-        });
       }
+
       await query("COMMIT", []);
-    } catch (err) {
+    } catch (error) {
       await query("ROLLBACK", []);
-      throw err;
+      throw error;
     }
 
-    return events[events.length - 1].ledger;
+    for (const event of insertedEvents) {
+      webhookService.dispatch(event).catch((error) => {
+        logger.error("Webhook dispatch failed", {
+          eventId: event.eventId,
+          error,
+        });
+      });
+
+      eventStreamService.broadcast({
+        eventId: event.eventId,
+        eventType: event.eventType,
+        ...(event.loanId !== undefined ? { loanId: event.loanId } : {}),
+        borrower: event.borrower,
+        ...(event.amount !== undefined ? { amount: event.amount } : {}),
+        ledger: event.ledger,
+        ledgerClosedAt: event.ledgerClosedAt.toISOString(),
+        txHash: event.txHash,
+      });
+
+      this.triggerNotification(event).catch((error) => {
+        logger.error("Notification trigger failed", {
+          eventId: event.eventId,
+          error,
+        });
+      });
+    }
+
+    return {
+      insertedCount: insertedEvents.length,
+    };
+  }
+
+  private parseEvent(event: SorobanRawEvent): LoanEvent | null {
+    const type = this.decodeEventType(event.topic[0]);
+    if (!type) return null;
+
+    let borrower = "";
+    let loanId: number | undefined;
+    let amount: string | undefined;
+    let interestRateBps: number | undefined;
+    let termLedgers: number | undefined;
+
+    if (type === "LoanRequested") {
+      if (!event.topic[1]) return null;
+      borrower = this.decodeAddress(event.topic[1]);
+      amount = this.decodeAmount(event.value);
+    } else if (type === "LoanApproved") {
+      if (!event.topic[1]) return null;
+      loanId = this.decodeLoanId(event.topic[1]);
+      if (loanId === undefined) return null;
+      interestRateBps = 1200;
+      termLedgers = 17280;
+    } else if (type === "LoanRepaid") {
+      if (!event.topic[1] || !event.topic[2]) return null;
+      borrower = this.decodeAddress(event.topic[1]);
+      loanId = this.decodeLoanId(event.topic[2]);
+      amount = this.decodeAmount(event.value);
+    } else if (type === "LoanDefaulted") {
+      if (!event.topic[1]) return null;
+      loanId = this.decodeLoanId(event.topic[1]);
+      if (loanId === undefined) return null;
+      borrower = this.decodeAddress(event.value);
+    } else if (type === "Seized") {
+      if (!event.topic[1]) return null;
+      borrower = this.decodeAddress(event.topic[1]);
+    }
+
+    return {
+      eventId: event.id,
+      eventType: type,
+      ledger: event.ledger,
+      ledgerClosedAt: new Date(event.ledgerClosedAt),
+      txHash: event.txHash,
+      contractId: event.contractId.toString(),
+      topics: event.topic.map((topic) => topic.toXDR("base64")),
+      value: event.value.toXDR("base64"),
+      ...(amount !== undefined ? { amount } : {}),
+      ...(loanId !== undefined ? { loanId } : {}),
+      ...(interestRateBps !== undefined ? { interestRateBps } : {}),
+      ...(termLedgers !== undefined ? { termLedgers } : {}),
+      borrower,
+    };
   }
 
   private async updateUserScore(userId: string, delta: number): Promise<void> {
@@ -204,74 +492,82 @@ export class EventIndexer {
       await query(
         `INSERT INTO scores (user_id, current_score)
          VALUES ($1, $2)
-         ON CONFLICT (user_id) 
-         DO UPDATE SET 
+         ON CONFLICT (user_id)
+         DO UPDATE SET
            current_score = LEAST(850, GREATEST(300, scores.current_score + $3)),
            updated_at = CURRENT_TIMESTAMP`,
         [userId, 500 + delta, delta],
       );
-      logger.info(`Updated score for user ${userId} by ${delta} points`);
+      logger.info("Updated user score from indexed event", {
+        userId,
+        delta,
+      });
     } catch (error) {
-      logger.error(`Failed to update score for user ${userId}:`, error);
+      logger.error("Failed to update user score", { userId, error });
     }
   }
 
   private async triggerNotification(event: LoanEvent): Promise<void> {
     if (!event.borrower) return;
 
+    let type = "";
     let title = "";
     let message = "";
 
     switch (event.eventType) {
       case "LoanApproved":
+        type = "loan_approved";
         title = "Loan Approved";
         message = event.loanId
           ? `Your loan #${event.loanId} has been approved.`
           : "Your loan has been approved.";
         break;
       case "LoanRepaid":
+        type = "repayment_confirmed";
         title = "Repayment Confirmed";
         message = event.loanId
           ? `Repayment for loan #${event.loanId} has been confirmed.`
           : "Your loan repayment has been confirmed.";
         break;
       case "LoanDefaulted":
+        type = "loan_defaulted";
         title = "Loan Defaulted";
         message = event.loanId
           ? `Loan #${event.loanId} has been marked as defaulted.`
           : "A loan has been marked as defaulted.";
         break;
+      default:
+        return;
     }
 
-    if (title && message) {
-      await query(
-        `INSERT INTO notifications (user_id, title, message, loan_id)
-         VALUES ($1, $2, $3, $4)`,
-        [event.borrower, title, message, event.loanId || null],
-      );
-    }
+    await query(
+      `INSERT INTO notifications (user_id, type, title, message, loan_id)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [event.borrower, type, title, message, event.loanId ?? null],
+    );
   }
 
-  // Decoding helpers
-  private decodeAddress(x: xdr.ScVal): string {
-    return scValToNative(x).toString();
+  private decodeAddress(value: xdr.ScVal): string {
+    return scValToNative(value).toString();
   }
 
-  private decodeAmount(x: xdr.ScVal): string {
-    return scValToNative(x).toString(); // BigInt amount
+  private decodeAmount(value: xdr.ScVal): string {
+    return scValToNative(value).toString();
   }
 
-  private decodeLoanId(x: xdr.ScVal): number | undefined {
+  private decodeLoanId(value: xdr.ScVal): number | undefined {
     try {
-      return Number(scValToNative(x));
+      return Number(scValToNative(value));
     } catch {
       return undefined;
     }
   }
 
-  private decodeEventType(x: xdr.ScVal): WebhookEventType | null {
+  private decodeEventType(value: xdr.ScVal | undefined): WebhookEventType | null {
+    if (!value) return null;
+
     try {
-      const s = x.sym().toString();
+      const eventType = value.sym().toString();
       const supported: string[] = [
         "LoanRequested",
         "LoanApproved",
@@ -282,7 +578,10 @@ export class EventIndexer {
         "Unpaused",
         "MinScoreUpdated",
       ];
-      return supported.includes(s) ? (s as WebhookEventType) : null;
+
+      return supported.includes(eventType)
+        ? (eventType as WebhookEventType)
+        : null;
     } catch {
       return null;
     }

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { query } from "../db/connection.js";
 import logger from "../utils/logger.js";
 
@@ -30,54 +31,258 @@ export interface IndexedLoanEvent {
   value: string;
 }
 
+export interface WebhookSubscription {
+  id: number;
+  callbackUrl: string;
+  eventTypes: WebhookEventType[];
+  secret?: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WebhookDelivery {
+  id: number;
+  subscriptionId: number;
+  eventId: string;
+  eventType: WebhookEventType;
+  attemptCount: number;
+  lastStatusCode?: number;
+  lastError?: string;
+  deliveredAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface RegisterWebhookInput {
+  callbackUrl: string;
+  eventTypes: WebhookEventType[];
+  secret?: string;
+}
+
 export class WebhookService {
-  /**
-   * Identifies if an event is relevant for webhooks
-   */
   static isSupported(type: string): type is WebhookEventType {
     return SUPPORTED_WEBHOOK_EVENT_TYPES.includes(type as WebhookEventType);
   }
 
-  /**
-   * Dispatches events to registered webhooks.
-   * Currently, we just log them or store them in a way that
-   * an external consumer can poll/receive them.
-   */
+  async registerSubscription(
+    input: RegisterWebhookInput,
+  ): Promise<WebhookSubscription> {
+    const result = await query(
+      `INSERT INTO webhook_subscriptions (callback_url, event_types, secret, is_active)
+       VALUES ($1, $2::jsonb, $3, true)
+       RETURNING id, callback_url, event_types, secret, is_active, created_at, updated_at`,
+      [input.callbackUrl, JSON.stringify(input.eventTypes), input.secret ?? null],
+    );
+
+    return this.mapSubscriptionRow(result.rows[0] as Record<string, unknown>);
+  }
+
+  async listSubscriptions(): Promise<WebhookSubscription[]> {
+    const result = await query(
+      `SELECT id, callback_url, event_types, secret, is_active, created_at, updated_at
+       FROM webhook_subscriptions
+       ORDER BY created_at DESC`,
+      [],
+    );
+
+    return result.rows.map((row) =>
+      this.mapSubscriptionRow(row as Record<string, unknown>),
+    );
+  }
+
+  async deleteSubscription(id: number): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM webhook_subscriptions
+       WHERE id = $1`,
+      [id],
+    );
+
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async getSubscriptionDeliveries(
+    subscriptionId: number,
+    limit: number = 50,
+  ): Promise<WebhookDelivery[]> {
+    const result = await query(
+      `SELECT id, subscription_id, event_id, event_type, attempt_count, last_status_code,
+              last_error, delivered_at, created_at, updated_at
+       FROM webhook_deliveries
+       WHERE subscription_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [subscriptionId, limit],
+    );
+
+    return result.rows.map((row) =>
+      this.mapDeliveryRow(row as Record<string, unknown>),
+    );
+  }
+
   async dispatch(event: IndexedLoanEvent): Promise<void> {
-    logger.info(`Dispatching webhook event: ${event.eventType}`, {
+    logger.info("Dispatching webhook event", {
+      eventId: event.eventId,
+      eventType: event.eventType,
       loanId: event.loanId,
       borrower: event.borrower,
     });
 
     try {
-      // 1. Fetch active webhooks for this borrower / event type
-      // (Simplified: broadcast to all registered global webhooks)
-      const webhooks = await query(
-        "SELECT id, url, secret FROM webhooks WHERE is_active = true",
-        [],
+      const webhooksResult = await query(
+        `SELECT id, callback_url, secret
+         FROM webhook_subscriptions
+         WHERE is_active = true
+           AND event_types @> $1::jsonb`,
+        [JSON.stringify([event.eventType])],
       );
 
-      for (const hook of webhooks.rows) {
-        // In a real implementation, this would be an async worker task
-        // with retries, exponential backoff, etc.
-        this.sendToWebhook(hook.url, hook.secret, event).catch((err) => {
-          logger.error(`Failed to send to webhook ${hook.url}:`, err);
-        });
-      }
+      await Promise.all(
+        webhooksResult.rows.map((hook) =>
+          this.sendToWebhook(
+            Number((hook as { id: number }).id),
+            String((hook as { callback_url: string }).callback_url),
+            ((hook as { secret?: string | null }).secret ?? undefined) ||
+              undefined,
+            event,
+          ),
+        ),
+      );
     } catch (error) {
-      logger.error("Error during webhook dispatch:", error);
+      logger.error("Error during webhook dispatch", {
+        eventId: event.eventId,
+        eventType: event.eventType,
+        error,
+      });
     }
   }
 
   private async sendToWebhook(
-    url: string,
-    secret: string,
+    subscriptionId: number,
+    callbackUrl: string,
+    secret: string | undefined,
     payload: IndexedLoanEvent,
   ): Promise<void> {
-    // Implementation for signing and sending the POST request
-    // const signature = crypto.createHmac('sha256', secret).update(JSON.stringify(payload)).digest('hex');
-    // await axios.post(url, payload, { headers: { 'X-RemitLend-Signature': signature } });
-    logger.debug(`[Mock] Sending ${payload.eventType} to ${url}`);
+    const body = JSON.stringify(payload);
+
+    const signature = secret
+      ? crypto.createHmac("sha256", secret).update(body).digest("hex")
+      : undefined;
+
+    try {
+      const response = await fetch(callbackUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(signature && { "x-remitlend-signature": signature }),
+        },
+        body,
+      });
+
+      const successful = response.ok;
+
+      await query(
+        `INSERT INTO webhook_deliveries (
+          subscription_id,
+          event_id,
+          event_type,
+          attempt_count,
+          last_status_code,
+          last_error,
+          delivered_at
+        )
+        VALUES ($1, $2, $3, 1, $4, $5, $6)`,
+        [
+          subscriptionId,
+          payload.eventId,
+          payload.eventType,
+          response.status,
+          successful ? null : `Webhook returned status ${response.status}`,
+          successful ? new Date() : null,
+        ],
+      );
+
+      if (!successful) {
+        logger.warn("Webhook delivery failed", {
+          subscriptionId,
+          callbackUrl,
+          eventId: payload.eventId,
+          statusCode: response.status,
+        });
+      }
+    } catch (error) {
+      await query(
+        `INSERT INTO webhook_deliveries (
+          subscription_id,
+          event_id,
+          event_type,
+          attempt_count,
+          last_error
+        )
+        VALUES ($1, $2, $3, 1, $4)`,
+        [
+          subscriptionId,
+          payload.eventId,
+          payload.eventType,
+          error instanceof Error ? error.message : "Unknown webhook error",
+        ],
+      );
+
+      logger.error("Failed to send webhook", {
+        subscriptionId,
+        callbackUrl,
+        eventId: payload.eventId,
+        error,
+      });
+    }
+  }
+
+  private mapSubscriptionRow(row: Record<string, unknown>): WebhookSubscription {
+    const secret =
+      typeof row.secret === "string" && row.secret.length > 0
+        ? row.secret
+        : undefined;
+
+    return {
+      id: Number(row.id),
+      callbackUrl: String(row.callback_url),
+      eventTypes: (row.event_types as WebhookEventType[]) ?? [],
+      ...(secret ? { secret } : {}),
+      isActive: Boolean(row.is_active),
+      createdAt: new Date(String(row.created_at)),
+      updatedAt: new Date(String(row.updated_at)),
+    };
+  }
+
+  private mapDeliveryRow(row: Record<string, unknown>): WebhookDelivery {
+    const lastStatusCode =
+      typeof row.last_status_code === "number"
+        ? row.last_status_code
+        : row.last_status_code !== null && row.last_status_code !== undefined
+          ? Number(row.last_status_code)
+          : undefined;
+
+    const lastError =
+      typeof row.last_error === "string" && row.last_error.length > 0
+        ? row.last_error
+        : undefined;
+
+    const deliveredAt = row.delivered_at
+      ? new Date(String(row.delivered_at))
+      : undefined;
+
+    return {
+      id: Number(row.id),
+      subscriptionId: Number(row.subscription_id),
+      eventId: String(row.event_id),
+      eventType: String(row.event_type) as WebhookEventType,
+      attemptCount: Number(row.attempt_count ?? 1),
+      ...(lastStatusCode !== undefined ? { lastStatusCode } : {}),
+      ...(lastError ? { lastError } : {}),
+      ...(deliveredAt ? { deliveredAt } : {}),
+      createdAt: new Date(String(row.created_at)),
+      updatedAt: new Date(String(row.updated_at)),
+    };
   }
 }
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import winston from "winston";
+import { getRequestId } from "./requestContext.js";
 
 const levels = {
   error: 0,
@@ -44,11 +45,21 @@ const productionFormat = winston.format.combine(
   winston.format.json(),
 );
 
+const withRequestId = winston.format((info) => {
+  const requestIdFromContext = getRequestId();
+  if (requestIdFromContext && !info.requestId) {
+    info.requestId = requestIdFromContext;
+  }
+  return info;
+});
+
 const isProduction = process.env.NODE_ENV === "production";
 
 const transports: winston.transport[] = [
   new winston.transports.Console({
-    format: isProduction ? productionFormat : devFormat,
+    format: isProduction
+      ? winston.format.combine(withRequestId(), productionFormat)
+      : winston.format.combine(withRequestId(), devFormat),
   }),
 ];
 

--- a/backend/src/utils/requestContext.ts
+++ b/backend/src/utils/requestContext.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+
+interface RequestContext {
+  requestId: string;
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+export const createRequestId = (): string => randomUUID();
+
+export const runWithRequestContext = <T>(
+  requestId: string,
+  callback: () => T,
+): T => {
+  return requestContextStorage.run({ requestId }, callback);
+};
+
+export const getRequestId = (): string | undefined => {
+  return requestContextStorage.getStore()?.requestId;
+};


### PR DESCRIPTION
…k admin APIs, and RBAC scopes

add admin reindex endpoint for ledger-range backfills with dedupe-safe processing
- add request correlation IDs via x-request-id and structured logger context propagation
- expose admin webhook subscription CRUD and delivery history endpoints
- implement role/scope-based access control and apply scope guards to protected routes
- add regression tests for request-id behavior, auth role/scope payload, and reindex validation

## Issues closed:
Closes #233 
Closes #235 
Closes #236 
Closes #147 