### PR TITLE
[Frontend] Create Missing /settings Page

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -30,6 +30,7 @@ interface NotificationPrefs {
   loanDefaulted: boolean;
   scoreChanged: boolean;
   email: boolean;
+  sms: boolean;
   inApp: boolean;
 }
 
@@ -248,6 +249,7 @@ function NotificationsSection() {
     loanDefaulted: true,
     scoreChanged: false,
     email: false,
+    sms: false,
     inApp: true,
   });
 
@@ -269,6 +271,7 @@ function NotificationsSection() {
         <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
           <Toggle checked={prefs.inApp} onChange={() => toggle("inApp")} label="In-App Notifications" description="Show notifications inside RemitLend" />
           <Toggle checked={prefs.email} onChange={() => toggle("email")} label="Email Notifications" description="Requires a verified email address" />
+          <Toggle checked={prefs.sms} onChange={() => toggle("sms")} label="SMS Notifications" description="Requires a verified phone number" />
         </div>
 
         <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500 pb-2 pt-4">


### PR DESCRIPTION
Closes #243

## Summary

Six sections accessible via a side nav (horizontal on mobile, vertical on desktop):

| Section | What it does |
|---|---|
| **Profile** | Display name + optional email fields |
| **Wallet** | Connected address with copy button, network badge, disconnect |
| **Notifications** | Delivery toggles (in-app / **SMS** / email) + per-event toggles for all loan lifecycle events |
| **Security** | Active session timestamps, KYC status, JWT token reveal + copy for devs |
| **Display** | Theme toggle cycling light → dark → system, language selector |
| **Gamification** | Embeds the existing `GamificationSettings` component |

## Test plan

- [ ] Navigate to `/settings` — page renders without 404
- [ ] All six section tabs switch the displayed card
- [ ] Notification section shows in-app, SMS, and email delivery toggles
- [ ] Per-event toggles are interactive
- [ ] Wallet section shows address + copy works; disconnect clears wallet store
- [ ] Display theme toggle cycles and applies the theme
- [ ] Gamification section — sound/animation toggles work as in `/kingdom`
- [ ] Layout is responsive (horizontal nav pills on small screens)