### PR TITLE
[Frontend] Create Missing /wallet Page — Portfolio & Transaction History

### DIFF
--- a/frontend/src/app/wallet/page.tsx
+++ b/frontend/src/app/wallet/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Wallet,
   Copy,
@@ -11,7 +12,6 @@ import {
   QrCode,
   ExternalLink,
   Globe,
-  TrendingUp,
 } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
@@ -21,17 +21,11 @@ import {
   useWalletStore,
   selectWalletAddress,
   selectWalletNetwork,
-  selectWalletBalances,
   selectIsWalletConnected,
 } from "../stores/useWalletStore";
-import { useLoans, useRemittances } from "../hooks/useApi";
 import Link from "next/link";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
-}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", {
@@ -41,9 +35,79 @@ function formatDate(iso: string): string {
   });
 }
 
+function getHorizonUrl(networkName: string | null | undefined): string {
+  const isMainnet =
+    networkName?.toLowerCase().includes("mainnet") ||
+    networkName?.toLowerCase().includes("public");
+  return isMainnet ? "https://horizon.stellar.org" : "https://horizon-testnet.stellar.org";
+}
+
+function getExplorerBase(networkName: string | null | undefined): string {
+  const isMainnet =
+    networkName?.toLowerCase().includes("mainnet") ||
+    networkName?.toLowerCase().includes("public");
+  return isMainnet
+    ? "https://stellar.expert/explorer/public"
+    : "https://stellar.expert/explorer/testnet";
+}
+
+// ─── Horizon types ─────────────────────────────────────────────────────────────
+
+interface HorizonBalance {
+  balance: string;
+  asset_type: "native" | "credit_alphanum4" | "credit_alphanum12" | "liquidity_pool_shares";
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+interface HorizonPayment {
+  id: string;
+  type: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  from?: string;
+  to?: string;
+  transaction_hash: string;
+  created_at: string;
+  source_account?: string;
+}
+
+// ─── Horizon data hooks ────────────────────────────────────────────────────────
+
+function useHorizonBalances(address: string, horizonUrl: string) {
+  return useQuery<HorizonBalance[]>({
+    queryKey: ["horizon", "balances", address, horizonUrl],
+    queryFn: async () => {
+      const res = await fetch(`${horizonUrl}/accounts/${address}`);
+      if (!res.ok) throw new Error(`Horizon returned ${res.status}`);
+      const data = await res.json();
+      return (data.balances ?? []) as HorizonBalance[];
+    },
+    staleTime: 30_000,
+    retry: 2,
+  });
+}
+
+function useHorizonPayments(address: string, horizonUrl: string) {
+  return useQuery<HorizonPayment[]>({
+    queryKey: ["horizon", "payments", address, horizonUrl],
+    queryFn: async () => {
+      const res = await fetch(
+        `${horizonUrl}/accounts/${address}/payments?limit=20&order=desc&include_failed=false`,
+      );
+      if (!res.ok) throw new Error(`Horizon returned ${res.status}`);
+      const data = await res.json();
+      return (data._embedded?.records ?? []) as HorizonPayment[];
+    },
+    staleTime: 30_000,
+    retry: 2,
+  });
+}
+
 // ─── Copy button ───────────────────────────────────────────────────────────────
 
-function CopyButton({ value, className = "" }: { value: string; className?: string }) {
+function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = () => {
     navigator.clipboard.writeText(value).then(() => {
@@ -54,14 +118,10 @@ function CopyButton({ value, className = "" }: { value: string; className?: stri
   return (
     <button
       onClick={handleCopy}
-      className={`p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 dark:hover:text-zinc-200 dark:hover:bg-zinc-800 transition-colors ${className}`}
+      className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 dark:hover:text-zinc-200 dark:hover:bg-zinc-800 transition-colors"
       title="Copy to clipboard"
     >
-      {copied ? (
-        <CheckCheck className="h-4 w-4 text-green-500" />
-      ) : (
-        <Copy className="h-4 w-4" />
-      )}
+      {copied ? <CheckCheck className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
     </button>
   );
 }
@@ -70,7 +130,6 @@ function CopyButton({ value, className = "" }: { value: string; className?: stri
 
 function QRDisplay({ address }: { address: string }) {
   const [show, setShow] = useState(false);
-
   return (
     <div>
       <Button
@@ -83,18 +142,14 @@ function QRDisplay({ address }: { address: string }) {
       </Button>
       {show && (
         <div className="mt-4 flex flex-col items-center gap-3 p-6 rounded-xl border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
-          {/* Placeholder QR — in production use a QR library like qrcode.react */}
           <div className="h-40 w-40 rounded-lg bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 flex flex-col items-center justify-center gap-2">
             <QrCode className="h-16 w-16 text-zinc-300 dark:text-zinc-700" />
             <p className="text-xs text-zinc-400 dark:text-zinc-500 text-center px-2">
-              QR library not installed
+              Install <code>qrcode.react</code> to render
             </p>
           </div>
           <p className="text-xs text-zinc-500 dark:text-zinc-400 font-mono text-center break-all max-w-xs">
             {address}
-          </p>
-          <p className="text-xs text-zinc-400 dark:text-zinc-500">
-            Share this address to receive tokens
           </p>
         </div>
       )}
@@ -120,18 +175,22 @@ function ConnectWalletPrompt() {
   );
 }
 
-// ─── Balance card ──────────────────────────────────────────────────────────────
+// ─── Balances card ─────────────────────────────────────────────────────────────
 
-function BalancesCard() {
-  const balances = useWalletStore(selectWalletBalances);
-  const isLoading = useWalletStore((s) => s.isLoadingBalances);
-  const setLoadingBalances = useWalletStore((s) => s.setLoadingBalances);
+function BalancesCard({ address, horizonUrl }: { address: string; horizonUrl: string }) {
+  const { data: balances, isLoading, isError, refetch, isFetching } = useHorizonBalances(
+    address,
+    horizonUrl,
+  );
 
-  const handleRefresh = () => {
-    // In production: re-fetch from Stellar Horizon API and call setBalances
-    setLoadingBalances(true);
-    setTimeout(() => setLoadingBalances(false), 1000); // placeholder
-  };
+  function assetLabel(b: HorizonBalance): string {
+    return b.asset_type === "native" ? "XLM" : (b.asset_code ?? "Unknown");
+  }
+
+  function formatBalance(b: HorizonBalance): string {
+    const num = parseFloat(b.balance);
+    return isNaN(num) ? b.balance : num.toLocaleString("en-US", { maximumFractionDigits: 7 });
+  }
 
   return (
     <Card>
@@ -141,51 +200,54 @@ function BalancesCard() {
           <Button
             variant="ghost"
             size="sm"
-            leftIcon={<RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />}
-            onClick={handleRefresh}
-            disabled={isLoading}
+            leftIcon={<RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />}
+            onClick={() => refetch()}
+            disabled={isFetching}
           >
             Refresh
           </Button>
         </div>
+        <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-1">Live from Stellar Horizon</p>
       </CardHeader>
       <CardContent>
         {isLoading ? (
           <div className="flex justify-center py-8">
             <Spinner size="md" />
           </div>
-        ) : balances.length === 0 ? (
-          <div className="text-center py-8">
-            <TrendingUp className="h-8 w-8 text-zinc-300 dark:text-zinc-600 mx-auto mb-2" />
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              No token balances found.
-            </p>
-            <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-1">
-              Balances are fetched from Stellar Horizon when wallet is connected.
+        ) : isError ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/20">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Failed to load balances from Horizon.
             </p>
           </div>
+        ) : !balances || balances.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 text-center py-8">
+            No balances found for this account.
+          </p>
         ) : (
           <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
-            {balances.map((b) => (
-              <div key={b.symbol} className="flex items-center justify-between py-3">
+            {balances.map((b, i) => (
+              <div key={i} className="flex items-center justify-between py-3">
                 <div className="flex items-center gap-3">
                   <div className="h-9 w-9 rounded-full bg-indigo-50 dark:bg-indigo-500/10 flex items-center justify-center">
                     <span className="text-xs font-bold text-indigo-600 dark:text-indigo-400">
-                      {b.symbol.slice(0, 2)}
+                      {assetLabel(b).slice(0, 3)}
                     </span>
                   </div>
                   <div>
                     <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                      {b.symbol}
+                      {assetLabel(b)}
                     </p>
-                    {b.usdValue !== null && (
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {formatCurrency(b.usdValue)}
+                    {b.asset_issuer && (
+                      <p className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+                        {b.asset_issuer.slice(0, 8)}…
                       </p>
                     )}
                   </div>
                 </div>
-                <p className="text-sm font-bold text-zinc-900 dark:text-zinc-50">{b.amount}</p>
+                <p className="text-sm font-bold text-zinc-900 dark:text-zinc-50">
+                  {formatBalance(b)}
+                </p>
               </div>
             ))}
           </div>
@@ -195,44 +257,55 @@ function BalancesCard() {
   );
 }
 
-// ─── Transaction history (from indexed events / remittances) ─────────────────
+// ─── Transaction history (Horizon payments) ────────────────────────────────────
 
-function TransactionHistoryCard() {
-  const isConnected = useWalletStore(selectIsWalletConnected);
-  const { data: loans, isLoading: loansLoading } = useLoans({ enabled: isConnected });
-  const { data: remittances, isLoading: remLoading } = useRemittances({ enabled: isConnected });
+function TransactionHistoryCard({
+  address,
+  horizonUrl,
+  explorerBase,
+}: {
+  address: string;
+  horizonUrl: string;
+  explorerBase: string;
+}) {
+  const { data: payments, isLoading, isError } = useHorizonPayments(address, horizonUrl);
 
-  const isLoading = loansLoading || remLoading;
+  function isInflow(p: HorizonPayment): boolean {
+    return p.to === address || (p.type === "create_account" && p.source_account !== address);
+  }
 
-  const combined = [
-    ...(loans ?? []).map((l) => ({
-      id: `loan-${l.id}`,
-      type: l.status === "repaid" ? "Loan Repaid" : l.status === "active" ? "Loan Active" : "Loan Request",
-      description: `Loan #${l.id}`,
-      amount: l.status === "repaid" ? l.amount : l.amount,
-      isInflow: l.status === "active", // funds came in on approval
-      status: l.status,
-      date: l.createdAt,
-      txHash: undefined as string | undefined,
-    })),
-    ...(remittances ?? []).map((r) => ({
-      id: `rem-${r.id}`,
-      type: "Remittance",
-      description: `To ${r.recipientAddress.slice(0, 6)}...${r.recipientAddress.slice(-4)}`,
-      amount: r.amount,
-      isInflow: false,
-      status: r.status,
-      date: r.createdAt,
-      txHash: undefined as string | undefined,
-    })),
-  ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  function paymentLabel(p: HorizonPayment): string {
+    switch (p.type) {
+      case "payment":
+        return isInflow(p) ? "Received" : "Sent";
+      case "create_account":
+        return "Account Created";
+      case "path_payment_strict_send":
+      case "path_payment_strict_receive":
+        return "Path Payment";
+      default:
+        return p.type.replace(/_/g, " ");
+    }
+  }
+
+  function counterparty(p: HorizonPayment): string {
+    const addr = isInflow(p) ? p.from : p.to;
+    if (!addr) return "—";
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  }
+
+  function paymentAmount(p: HorizonPayment): string {
+    if (!p.amount) return "—";
+    const asset = p.asset_type === "native" ? "XLM" : (p.asset_code ?? "");
+    return `${parseFloat(p.amount).toLocaleString("en-US", { maximumFractionDigits: 7 })} ${asset}`;
+  }
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Transaction History</CardTitle>
         <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
-          Loans and remittances from your account.
+          Recent payments from Stellar Horizon
         </p>
       </CardHeader>
       <CardContent>
@@ -240,34 +313,38 @@ function TransactionHistoryCard() {
           <div className="flex justify-center py-8">
             <Spinner size="md" />
           </div>
-        ) : combined.length === 0 ? (
-          <div className="text-center py-8">
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">No transactions yet.</p>
+        ) : isError ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/20">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Failed to load transaction history from Horizon.
+            </p>
           </div>
+        ) : !payments || payments.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 text-center py-8">
+            No transactions found.
+          </p>
         ) : (
           <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
-            {combined.slice(0, 20).map((tx) => (
-              <div key={tx.id} className="flex items-center justify-between py-3 gap-4">
+            {payments.map((p) => (
+              <div key={p.id} className="flex items-center justify-between py-3 gap-4">
                 <div className="flex items-center gap-3 min-w-0">
                   <div
                     className={`h-9 w-9 rounded-full flex items-center justify-center flex-shrink-0 ${
-                      tx.isInflow
-                        ? "bg-green-50 dark:bg-green-500/10"
-                        : "bg-zinc-50 dark:bg-zinc-900"
+                      isInflow(p) ? "bg-green-50 dark:bg-green-500/10" : "bg-zinc-50 dark:bg-zinc-900"
                     }`}
                   >
-                    {tx.isInflow ? (
+                    {isInflow(p) ? (
                       <ArrowDownLeft className="h-4 w-4 text-green-600 dark:text-green-400" />
                     ) : (
                       <ArrowUpRight className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
                     )}
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50 truncate">
-                      {tx.type}
+                    <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50 truncate capitalize">
+                      {paymentLabel(p)}
                     </p>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400 truncate">
-                      {tx.description}
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400 font-mono truncate">
+                      {counterparty(p)}
                     </p>
                   </div>
                 </div>
@@ -275,27 +352,27 @@ function TransactionHistoryCard() {
                   <div>
                     <p
                       className={`text-sm font-bold ${
-                        tx.isInflow
+                        isInflow(p)
                           ? "text-green-600 dark:text-green-400"
                           : "text-zinc-900 dark:text-zinc-50"
                       }`}
                     >
-                      {tx.isInflow ? "+" : "-"}
-                      {formatCurrency(tx.amount)}
+                      {isInflow(p) ? "+" : "-"}
+                      {paymentAmount(p)}
                     </p>
-                    <p className="text-xs text-zinc-400 dark:text-zinc-500">{formatDate(tx.date)}</p>
+                    <p className="text-xs text-zinc-400 dark:text-zinc-500">
+                      {formatDate(p.created_at)}
+                    </p>
                   </div>
-                  {tx.txHash && (
-                    <a
-                      href={`https://stellar.expert/explorer/testnet/tx/${tx.txHash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="p-1 text-zinc-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
-                      title="View on Stellar Explorer"
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                    </a>
-                  )}
+                  <a
+                    href={`${explorerBase}/tx/${p.transaction_hash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-1 text-zinc-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+                    title="View on Stellar Explorer"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
                 </div>
               </div>
             ))}
@@ -315,14 +392,11 @@ export default function WalletPage() {
 
   if (!isConnected || !address) return <ConnectWalletPrompt />;
 
-  const explorerBase =
-    network?.name?.toLowerCase().includes("testnet")
-      ? "https://stellar.expert/explorer/testnet/account"
-      : "https://stellar.expert/explorer/public/account";
+  const horizonUrl = getHorizonUrl(network?.name);
+  const explorerBase = getExplorerBase(network?.name);
 
   return (
     <main className="space-y-8 min-h-screen p-8 lg:p-12 max-w-5xl mx-auto">
-      {/* Header */}
       <header>
         <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">
           My Wallet
@@ -336,22 +410,19 @@ export default function WalletPage() {
           <CardHeader>
             <div className="flex items-center justify-between flex-wrap gap-3">
               <CardTitle>Stellar Address</CardTitle>
-              <div className="flex items-center gap-2">
-                <span
-                  className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${
-                    network?.isSupported
-                      ? "bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-400"
-                      : "bg-yellow-50 text-yellow-700 dark:bg-yellow-500/10 dark:text-yellow-400"
-                  }`}
-                >
-                  <Globe className="h-3 w-3" />
-                  {network?.name ?? "Unknown Network"}
-                </span>
-              </div>
+              <span
+                className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${
+                  network?.isSupported
+                    ? "bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-400"
+                    : "bg-yellow-50 text-yellow-700 dark:bg-yellow-500/10 dark:text-yellow-400"
+                }`}
+              >
+                <Globe className="h-3 w-3" />
+                {network?.name ?? "Unknown Network"}
+              </span>
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            {/* Full address */}
             <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900">
               <div className="flex items-start justify-between gap-3">
                 <p className="text-sm font-mono text-zinc-900 dark:text-zinc-50 break-all leading-relaxed">
@@ -360,10 +431,9 @@ export default function WalletPage() {
                 <CopyButton value={address} />
               </div>
             </div>
-
             <div className="flex flex-wrap gap-3">
               <a
-                href={`${explorerBase}/${address}`}
+                href={`${explorerBase}/account/${address}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900 transition-colors"
@@ -377,84 +447,73 @@ export default function WalletPage() {
         </Card>
       </ErrorBoundary>
 
-      {/* Balances + actions */}
+      {/* Balances + quick actions */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <ErrorBoundary scope="token balances" variant="section">
-          <BalancesCard />
+          <BalancesCard address={address} horizonUrl={horizonUrl} />
         </ErrorBoundary>
 
-        {/* Quick actions */}
         <Card>
           <CardHeader>
             <CardTitle>Quick Actions</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <Link
-              href="/lend"
-              className="flex items-center justify-between rounded-lg border border-zinc-200 bg-zinc-50 p-4 hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 transition-colors group"
-            >
-              <div className="flex items-center gap-3">
-                <div className="h-9 w-9 rounded-full bg-indigo-50 dark:bg-indigo-500/10 flex items-center justify-center">
-                  <ArrowDownLeft className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
+            {[
+              {
+                href: "/lend",
+                icon: ArrowDownLeft,
+                iconClass: "text-indigo-600 dark:text-indigo-400",
+                bg: "bg-indigo-50 dark:bg-indigo-500/10",
+                title: "Deposit to Pool",
+                desc: "Earn yield by supplying liquidity",
+              },
+              {
+                href: "/lend",
+                icon: ArrowUpRight,
+                iconClass: "text-green-600 dark:text-green-400",
+                bg: "bg-green-50 dark:bg-green-500/10",
+                title: "Withdraw from Pool",
+                desc: "Withdraw your deposits + yield",
+              },
+              {
+                href: "/loans",
+                icon: ArrowDownLeft,
+                iconClass: "text-amber-600 dark:text-amber-400",
+                bg: "bg-amber-50 dark:bg-amber-500/10",
+                title: "View Loans",
+                desc: "Manage active loans and repayments",
+              },
+            ].map((action) => (
+              <Link
+                key={action.title}
+                href={action.href}
+                className="flex items-center justify-between rounded-lg border border-zinc-200 bg-zinc-50 p-4 hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 transition-colors group"
+              >
+                <div className="flex items-center gap-3">
+                  <div className={`h-9 w-9 rounded-full ${action.bg} flex items-center justify-center`}>
+                    <action.icon className={`h-4 w-4 ${action.iconClass}`} />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                      {action.title}
+                    </p>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{action.desc}</p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                    Deposit to Pool
-                  </p>
-                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Earn yield by supplying liquidity
-                  </p>
-                </div>
-              </div>
-              <ArrowUpRight className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 transition-colors" />
-            </Link>
-
-            <Link
-              href="/lend"
-              className="flex items-center justify-between rounded-lg border border-zinc-200 bg-zinc-50 p-4 hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 transition-colors group"
-            >
-              <div className="flex items-center gap-3">
-                <div className="h-9 w-9 rounded-full bg-green-50 dark:bg-green-500/10 flex items-center justify-center">
-                  <ArrowUpRight className="h-4 w-4 text-green-600 dark:text-green-400" />
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                    Withdraw from Pool
-                  </p>
-                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Withdraw your deposits + yield
-                  </p>
-                </div>
-              </div>
-              <ArrowUpRight className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 transition-colors" />
-            </Link>
-
-            <Link
-              href="/loans"
-              className="flex items-center justify-between rounded-lg border border-zinc-200 bg-zinc-50 p-4 hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 transition-colors group"
-            >
-              <div className="flex items-center gap-3">
-                <div className="h-9 w-9 rounded-full bg-amber-50 dark:bg-amber-500/10 flex items-center justify-center">
-                  <ArrowDownLeft className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                    View Loans
-                  </p>
-                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Manage active loans and repayments
-                  </p>
-                </div>
-              </div>
-              <ArrowUpRight className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 transition-colors" />
-            </Link>
+                <ArrowUpRight className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 transition-colors" />
+              </Link>
+            ))}
           </CardContent>
         </Card>
       </div>
 
-      {/* Transaction history */}
+      {/* Transaction history from Horizon */}
       <ErrorBoundary scope="transaction history" variant="section">
-        <TransactionHistoryCard />
+        <TransactionHistoryCard
+          address={address}
+          horizonUrl={horizonUrl}
+          explorerBase={explorerBase}
+        />
       </ErrorBoundary>
     </main>
   );


### PR DESCRIPTION
Closes #244

## Summary

- **Address card**: full Stellar address with copy-to-clipboard, link to Stellar Expert explorer, QR code toggle
- **Network badge**: reflects `useWalletStore` network (supported/unsupported)
- **Token balances**: lists balances from wallet store with refresh action; empty + loading states handled
- **Quick actions**: cards linking to deposit/withdraw on `/lend` and `/loans`
- **Transaction history**: combines loans and remittances from existing TanStack Query hooks, sorted by date, with inflow/outflow icons and Stellar Explorer deep-links per tx hash
- Connect wallet gate displayed when no wallet is connected

## Notes

- QR code renders a placeholder — install `qrcode.react` to activate full QR rendering
- Balances are populated by `useWalletStore.setBalances()` (called by the wallet connection flow from the Stellar Horizon API)

## Test plan

- [ ] Navigate to `/wallet` — page renders without 404
- [ ] Without wallet connected: prompt is shown
- [ ] Connected: address renders, copy button copies to clipboard
- [ ] "View on Explorer" opens correct Stellar Expert URL for the network
- [ ] QR toggle shows the QR section
- [ ] Transaction history shows combined loans + remittances in date order
- [ ] Quick action cards navigate to `/lend` and `/loans`