### PR TITLE
[Frontend] Wire Loan Repayment Form to Actual Smart Contract

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "prepare": "cd .. && husky install frontend/.husky"
   },
   "dependencies": {
+    "@stellar/freighter-api": "^2.1.0",
+    "@stellar/stellar-sdk": "^13.3.0",
     "@tanstack/react-query": "^5.11.2",
     "@tanstack/react-query-devtools": "^5.91.3",
     "clsx": "^2.1.1",

--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -9,7 +9,10 @@ import { TransactionPreviewModal } from "../transaction/TransactionPreviewModal"
 import { useTransactionPreview } from "../../hooks/useTransactionPreview";
 import { useContractToast } from "../../hooks/useContractToast";
 import { formatLoanRepayment } from "../../utils/transactionFormatter";
-import { executeRepayTransaction } from "../../utils/contractService";
+import {
+  prepareRepayTransaction,
+  signAndSubmitTransaction,
+} from "../../utils/contractService";
 import { queryKeys } from "../../hooks/useApi";
 import { useWalletStore, selectWalletAddress } from "../../stores/useWalletStore";
 import { useGamificationStore } from "../../stores/useGamificationStore";
@@ -24,6 +27,7 @@ interface LoanRepaymentFormProps {
 export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRepaymentFormProps) {
   const [amount, setAmount] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [isPreparing, setIsPreparing] = useState(false);
 
   const txPreview = useTransactionPreview();
   const toast = useContractToast();
@@ -62,7 +66,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
     return true;
   };
 
-  const handleRepayClick = () => {
+  const handleRepayClick = async () => {
     if (!validateAmount()) return;
     if (!borrowerAddress) {
       setError("No wallet connected");
@@ -70,15 +74,32 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
     }
 
     const numAmount = parseFloat(amount);
+
+    // Step 1: build + simulate on Soroban RPC to get the unsigned XDR.
+    // Doing this before opening the modal means the user sees a verified
+    // transaction (with correct resource fees) rather than an estimate.
+    setIsPreparing(true);
+    let xdr: string;
+    try {
+      xdr = await prepareRepayTransaction(borrowerAddress, loanId, numAmount);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to prepare transaction";
+      setError(message);
+      setIsPreparing(false);
+      return;
+    }
+    setIsPreparing(false);
+
+    // Step 2: show the preview modal with the verified XDR attached.
     const previewData = formatLoanRepayment({ loanId, amount: numAmount });
 
-    txPreview.show(previewData, async () => {
+    txPreview.show({ ...previewData, rawXDR: xdr }, async () => {
+      // Step 3 (on confirm): sign with Freighter and submit.
       const toastId = toast.showPending("Submitting repayment...");
 
       try {
-        const txHash = await executeRepayTransaction(borrowerAddress, loanId, numAmount);
+        const txHash = await signAndSubmitTransaction(xdr);
 
-        // Update toast to success with Stellar Explorer link
         toast.showSuccess(toastId, {
           successMessage: "Repayment confirmed on-chain!",
           txHash,
@@ -171,10 +192,11 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
           <Button
             variant="primary"
             onClick={handleRepayClick}
-            disabled={!amount || !!error || !borrowerAddress}
+            disabled={!amount || !!error || !borrowerAddress || isPreparing}
+            isLoading={isPreparing}
             className="w-full"
           >
-            Review Repayment
+            {isPreparing ? "Preparing..." : "Review Repayment"}
           </Button>
         </CardContent>
       </Card>

--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/Card";
 import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { TransactionPreviewModal } from "../transaction/TransactionPreviewModal";
 import { useTransactionPreview } from "../../hooks/useTransactionPreview";
+import { useContractToast } from "../../hooks/useContractToast";
 import { formatLoanRepayment } from "../../utils/transactionFormatter";
-import { DollarSign, AlertCircle } from "lucide-react";
+import { executeRepayTransaction } from "../../utils/contractService";
+import { queryKeys } from "../../hooks/useApi";
+import { useWalletStore, selectWalletAddress } from "../../stores/useWalletStore";
 import { useGamificationStore } from "../../stores/useGamificationStore";
+import { DollarSign, AlertCircle } from "lucide-react";
 
 interface LoanRepaymentFormProps {
   loanId: number;
@@ -19,8 +24,12 @@ interface LoanRepaymentFormProps {
 export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRepaymentFormProps) {
   const [amount, setAmount] = useState("");
   const [error, setError] = useState<string | null>(null);
+
   const txPreview = useTransactionPreview();
+  const toast = useContractToast();
+  const queryClient = useQueryClient();
   const gamificationStore = useGamificationStore();
+  const borrowerAddress = useWalletStore(selectWalletAddress);
 
   const handleAmountChange = (value: string) => {
     setAmount(value);
@@ -55,47 +64,48 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
 
   const handleRepayClick = () => {
     if (!validateAmount()) return;
-
-    const numAmount = parseFloat(amount);
-
-    // Show transaction preview modal
-    const previewData = formatLoanRepayment({
-      loanId,
-      amount: numAmount,
-    });
-
-    txPreview.show(previewData, async () => {
-      // This is where the actual transaction would be executed
-      // For now, we'll simulate it
-      await simulateRepayment(loanId, numAmount);
-    });
-  };
-
-  const simulateRepayment = async (loanId: number, amount: number): Promise<void> => {
-    // Simulate API call delay
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    // TODO: Replace with actual smart contract call
-    // Example: await loanContract.repay(loanId, amount);
-
-    // TODO: Success notification will be handled by useContractMutation wrapper
-    // when integrated with actual contract calls
-
-    // TEMPORARY: Trigger gamification directly since there's no actual API mutation yet
-    gamificationStore.addXP(50, "Loan repayment");
-    gamificationStore.unlockAchievement("first_repayment");
-
-    // Also trigger on-time streak if applicable (demo purpose here)
-    const isStreak = Math.random() > 0.5; // Simulate streak detection
-    if (isStreak) {
-      setTimeout(() => {
-        gamificationStore.addXP(100, "On-time repayment streak");
-        gamificationStore.unlockAchievement("streak_master");
-      }, 1000); // Trigger after first notification
+    if (!borrowerAddress) {
+      setError("No wallet connected");
+      return;
     }
 
-    // Reset form
-    setAmount("");
+    const numAmount = parseFloat(amount);
+    const previewData = formatLoanRepayment({ loanId, amount: numAmount });
+
+    txPreview.show(previewData, async () => {
+      const toastId = toast.showPending("Submitting repayment...");
+
+      try {
+        const txHash = await executeRepayTransaction(borrowerAddress, loanId, numAmount);
+
+        // Update toast to success with Stellar Explorer link
+        toast.showSuccess(toastId, {
+          successMessage: "Repayment confirmed on-chain!",
+          txHash,
+          network: "testnet",
+        });
+
+        // Invalidate all loan-related queries so the UI reflects the new state
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.loans.all() }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.loans.detail(String(loanId)) }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress),
+          }),
+        ]);
+
+        // Award gamification XP for a real repayment
+        gamificationStore.addXP(50, "Loan repayment");
+        gamificationStore.unlockAchievement("first_repayment");
+
+        setAmount("");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Repayment failed";
+        toast.showError(toastId, { errorMessage: message });
+        // Re-throw so useTransactionPreview keeps the modal open for retry
+        throw err;
+      }
+    });
   };
 
   const handlePayFullAmount = () => {
@@ -161,7 +171,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
           <Button
             variant="primary"
             onClick={handleRepayClick}
-            disabled={!amount || !!error}
+            disabled={!amount || !!error || !borrowerAddress}
             className="w-full"
           >
             Review Repayment

--- a/frontend/src/app/components/transaction/TransactionPreviewModal.tsx
+++ b/frontend/src/app/components/transaction/TransactionPreviewModal.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Modal } from "../ui/Modal";
 import { Button } from "../ui/Button";
-import { AlertTriangle, ArrowRight, Info, Fuel } from "lucide-react";
+import { AlertTriangle, ArrowRight, Info, Fuel, ChevronDown, ChevronUp } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -35,6 +35,8 @@ export interface TransactionPreviewData {
   estimatedGasFee?: string;
   network: string;
   contractAddress?: string;
+  /** Base64-encoded XDR of the assembled (unsigned) transaction envelope */
+  rawXDR?: string;
 }
 
 interface TransactionPreviewModalProps {
@@ -55,6 +57,7 @@ export function TransactionPreviewModal({
   isLoading = false,
 }: TransactionPreviewModalProps) {
   const [hasAcknowledged, setHasAcknowledged] = React.useState(false);
+  const [isXDRExpanded, setIsXDRExpanded] = React.useState(false);
 
   // Reset acknowledgment when modal opens
   React.useEffect(() => {
@@ -181,6 +184,46 @@ export function TransactionPreviewModal({
             <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
               Actual fee may vary based on network conditions
             </p>
+          </div>
+        )}
+
+        {/* Raw XDR — collapsible for advanced users */}
+        {data.rawXDR && (
+          <div className="rounded-lg border border-gray-200 dark:border-zinc-800">
+            <button
+              type="button"
+              onClick={() => setIsXDRExpanded((prev) => !prev)}
+              className="flex w-full items-center justify-between px-4 py-3 text-left"
+            >
+              <span className="text-xs font-semibold text-gray-600 dark:text-zinc-400 uppercase tracking-wide">
+                Raw Transaction XDR
+              </span>
+              {isXDRExpanded ? (
+                <ChevronUp className="h-4 w-4 text-gray-400 dark:text-zinc-500" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-gray-400 dark:text-zinc-500" />
+              )}
+            </button>
+            {isXDRExpanded && (
+              <div className="border-t border-gray-200 dark:border-zinc-800 p-4">
+                <p className="mb-2 text-xs text-gray-500 dark:text-zinc-500">
+                  Base64-encoded, assembled unsigned transaction envelope. You can verify this
+                  on{" "}
+                  <a
+                    href={`https://laboratory.stellar.org/#xdr-viewer?input=${encodeURIComponent(data.rawXDR)}&type=TransactionEnvelope`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline text-blue-600 dark:text-blue-400"
+                  >
+                    Stellar Laboratory
+                  </a>
+                  .
+                </p>
+                <pre className="overflow-x-auto rounded bg-gray-100 dark:bg-zinc-900 p-3 text-[10px] leading-relaxed font-mono text-gray-700 dark:text-zinc-300 break-all whitespace-pre-wrap">
+                  {data.rawXDR}
+                </pre>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/app/utils/contractService.ts
+++ b/frontend/src/app/utils/contractService.ts
@@ -1,0 +1,147 @@
+/**
+ * utils/contractService.ts
+ *
+ * Soroban contract interaction utilities for the frontend.
+ * Builds, simulates, signs (via Freighter), and submits transactions.
+ *
+ * Required peer dependencies (not bundled with the frontend by default):
+ *   npm install @stellar/stellar-sdk @stellar/freighter-api
+ *
+ * Environment variables:
+ *   NEXT_PUBLIC_MANAGER_CONTRACT_ID   — deployed LoanManager contract address
+ *   NEXT_PUBLIC_SOROBAN_RPC_URL       — Soroban RPC endpoint (defaults to testnet)
+ *   NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE — network passphrase (defaults to testnet)
+ */
+
+const LOAN_MANAGER_CONTRACT_ID = process.env.NEXT_PUBLIC_MANAGER_CONTRACT_ID ?? "";
+const SOROBAN_RPC_URL =
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
+const STELLAR_NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
+
+// Stellar token amounts use 7 decimal places.
+// 1 USDC (or any SEP-0041 token) = 10_000_000 stroops.
+const TOKEN_SCALE = 10_000_000n;
+
+function toStroops(humanAmount: number): bigint {
+  return BigInt(Math.round(humanAmount * Number(TOKEN_SCALE)));
+}
+
+// Poll interval and max attempts for transaction confirmation
+const POLL_INTERVAL_MS = 2_000;
+const MAX_POLL_ATTEMPTS = 30; // 60 seconds total
+
+/**
+ * Builds, signs via Freighter, submits, and polls a `repay` transaction.
+ *
+ * Corresponds to the loan_manager contract function:
+ *   repay(borrower: Address, loan_id: u32, amount: i128)
+ *
+ * @param borrowerAddress  Connected wallet's Stellar address
+ * @param loanId           On-chain loan ID (u32)
+ * @param amount           Human-readable amount (e.g. 100.0 for 100 USDC)
+ * @returns                Confirmed transaction hash
+ */
+export async function executeRepayTransaction(
+  borrowerAddress: string,
+  loanId: number,
+  amount: number,
+): Promise<string> {
+  if (!LOAN_MANAGER_CONTRACT_ID) {
+    throw new Error(
+      "NEXT_PUBLIC_MANAGER_CONTRACT_ID is not set. Run the deploy script first.",
+    );
+  }
+
+  // Dynamic imports keep these heavy packages out of the initial bundle
+  // and prevent crashes during SSR (these APIs only work in the browser).
+  const [sdk, freighterApi] = await Promise.all([
+    import("@stellar/stellar-sdk"),
+    import("@stellar/freighter-api"),
+  ]);
+
+  const { Contract, TransactionBuilder, BASE_FEE, nativeToScVal, rpc } = sdk;
+  const server = new rpc.Server(SOROBAN_RPC_URL);
+
+  // Load the account's current sequence number from the network.
+  const account = await server.getAccount(borrowerAddress).catch(() => {
+    throw new Error(
+      `Account ${borrowerAddress.slice(0, 8)}... not found on network. Ensure it is funded.`,
+    );
+  });
+
+  const contract = new Contract(LOAN_MANAGER_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "repay",
+        // The contract's `repay` expects auth from the borrower, so the borrower
+        // address is passed as the first argument and must be the signer.
+        nativeToScVal(borrowerAddress, { type: "address" }),
+        nativeToScVal(loanId, { type: "u32" }),
+        nativeToScVal(toStroops(amount), { type: "i128" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  // Simulate to obtain the correct resource fee and populate auth entries.
+  // This also validates that the transaction will succeed before asking the
+  // user to sign it.
+  const simResult = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Transaction simulation failed: ${simResult.error}`);
+  }
+
+  // Assemble: merges the simulation's footprint and fee into the transaction.
+  const assembled = rpc.assembleTransaction(tx, simResult).build();
+  const unsignedXDR = assembled.toXDR();
+
+  // Sign with Freighter browser extension.
+  // Freighter v3 returns a string; v4+ returns { signedXDR: string }.
+  const signResult = await freighterApi.signTransaction(unsignedXDR, {
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+  });
+  const signedXDR =
+    typeof signResult === "string"
+      ? signResult
+      : (signResult as { signedXDR: string }).signedXDR;
+
+  if (!signedXDR) {
+    throw new Error("Wallet returned an empty signed transaction. Did you cancel?");
+  }
+
+  // Submit the signed transaction to the network.
+  const signedTx = TransactionBuilder.fromXDR(signedXDR, STELLAR_NETWORK_PASSPHRASE);
+  const sendResponse = await server.sendTransaction(signedTx);
+
+  if (sendResponse.status === "ERROR") {
+    const resultCode =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sendResponse as any).errorResult?.result?.switch?.()?.name ?? "Unknown";
+    throw new Error(`Transaction submission failed (${resultCode})`);
+  }
+
+  // Poll until the transaction is finalized (SUCCESS or FAILED).
+  const txHash = sendResponse.hash;
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const result = await server.getTransaction(txHash);
+    if (result.status === "FAILED") {
+      throw new Error("Transaction was rejected on-chain. The loan may no longer be active.");
+    }
+    if (result.status === "SUCCESS") {
+      return txHash;
+    }
+    // status === "NOT_FOUND" means still pending — keep polling
+  }
+
+  throw new Error(
+    `Transaction confirmation timed out after ${(MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s. ` +
+      `Check the Stellar Explorer for hash: ${txHash}`,
+  );
+}

--- a/frontend/src/app/utils/contractService.ts
+++ b/frontend/src/app/utils/contractService.ts
@@ -2,14 +2,24 @@
  * utils/contractService.ts
  *
  * Soroban contract interaction utilities for the frontend.
- * Builds, simulates, signs (via Freighter), and submits transactions.
  *
- * Required peer dependencies (not bundled with the frontend by default):
- *   npm install @stellar/stellar-sdk @stellar/freighter-api
+ * The repayment flow is split into two explicit steps so the UI can show the
+ * user the raw XDR (verified transaction envelope) inside the preview modal
+ * before asking them to sign with Freighter:
+ *
+ *   1. prepareRepayTransaction  — builds the tx, simulates on Soroban RPC,
+ *                                  assembles the footprint, returns the unsigned
+ *                                  XDR string.
+ *   2. signAndSubmitTransaction — signs via Freighter, submits to the network,
+ *                                  polls until confirmed, returns the tx hash.
+ *
+ * Required peer dependencies (listed in package.json):
+ *   @stellar/stellar-sdk  ^13
+ *   @stellar/freighter-api ^2
  *
  * Environment variables:
- *   NEXT_PUBLIC_MANAGER_CONTRACT_ID   — deployed LoanManager contract address
- *   NEXT_PUBLIC_SOROBAN_RPC_URL       — Soroban RPC endpoint (defaults to testnet)
+ *   NEXT_PUBLIC_MANAGER_CONTRACT_ID        — deployed LoanManager contract address
+ *   NEXT_PUBLIC_SOROBAN_RPC_URL            — Soroban RPC endpoint (defaults to testnet)
  *   NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE — network passphrase (defaults to testnet)
  */
 
@@ -32,17 +42,21 @@ const POLL_INTERVAL_MS = 2_000;
 const MAX_POLL_ATTEMPTS = 30; // 60 seconds total
 
 /**
- * Builds, signs via Freighter, submits, and polls a `repay` transaction.
+ * Step 1 — Build and simulate.
  *
- * Corresponds to the loan_manager contract function:
- *   repay(borrower: Address, loan_id: u32, amount: i128)
+ * Constructs a `repay(borrower, loan_id, amount)` transaction, simulates it
+ * on the Soroban RPC to populate the footprint and resource fees, then returns
+ * the assembled (but still unsigned) transaction as a base64-encoded XDR string.
+ *
+ * Throwing here (e.g. sim error, account not found) prevents the preview modal
+ * from opening so the user never sees an invalid transaction.
  *
  * @param borrowerAddress  Connected wallet's Stellar address
  * @param loanId           On-chain loan ID (u32)
  * @param amount           Human-readable amount (e.g. 100.0 for 100 USDC)
- * @returns                Confirmed transaction hash
+ * @returns                Unsigned, assembled XDR string ready for signing
  */
-export async function executeRepayTransaction(
+export async function prepareRepayTransaction(
   borrowerAddress: string,
   loanId: number,
   amount: number,
@@ -55,11 +69,7 @@ export async function executeRepayTransaction(
 
   // Dynamic imports keep these heavy packages out of the initial bundle
   // and prevent crashes during SSR (these APIs only work in the browser).
-  const [sdk, freighterApi] = await Promise.all([
-    import("@stellar/stellar-sdk"),
-    import("@stellar/freighter-api"),
-  ]);
-
+  const sdk = await import("@stellar/stellar-sdk");
   const { Contract, TransactionBuilder, BASE_FEE, nativeToScVal, rpc } = sdk;
   const server = new rpc.Server(SOROBAN_RPC_URL);
 
@@ -99,11 +109,32 @@ export async function executeRepayTransaction(
 
   // Assemble: merges the simulation's footprint and fee into the transaction.
   const assembled = rpc.assembleTransaction(tx, simResult).build();
-  const unsignedXDR = assembled.toXDR();
+  return assembled.toXDR();
+}
+
+/**
+ * Step 2 — Sign and submit.
+ *
+ * Takes the assembled (unsigned) XDR returned by `prepareRepayTransaction`,
+ * requests a signature from Freighter, submits to the network, and polls until
+ * the transaction is finalized.
+ *
+ * @param xdr  Unsigned, assembled XDR string (from prepareRepayTransaction)
+ * @returns    Confirmed transaction hash
+ */
+export async function signAndSubmitTransaction(xdr: string): Promise<string> {
+  // Dynamic imports for SSR safety
+  const [sdk, freighterApi] = await Promise.all([
+    import("@stellar/stellar-sdk"),
+    import("@stellar/freighter-api"),
+  ]);
+
+  const { TransactionBuilder, rpc } = sdk;
+  const server = new rpc.Server(SOROBAN_RPC_URL);
 
   // Sign with Freighter browser extension.
   // Freighter v3 returns a string; v4+ returns { signedXDR: string }.
-  const signResult = await freighterApi.signTransaction(unsignedXDR, {
+  const signResult = await freighterApi.signTransaction(xdr, {
     networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
   });
   const signedXDR =


### PR DESCRIPTION
Closes #246

## Summary

Replaces the `simulateRepayment` placeholder in `LoanRepaymentForm.tsx` with a real Soroban transaction flow. Introduces `contractService.ts` for the on-chain interaction logic.

### `frontend/src/app/utils/contractService.ts` (new)

- Dynamically imports `@stellar/stellar-sdk` and `@stellar/freighter-api` (avoids SSR crashes; keeps them out of the initial bundle)
- Fetches the borrower's account sequence from Soroban RPC
- Builds a `repay(borrower: Address, loan_id: u32, amount: i128)` contract invocation against `NEXT_PUBLIC_MANAGER_CONTRACT_ID`
- Simulates the transaction to populate auth entries and get the real resource fee
- Assembles via `rpc.assembleTransaction`
- Signs with Freighter (handles both v3 string return and v4 `{ signedXDR }` shapes)
- Submits and polls until `SUCCESS` or `FAILED` (max 60 s)
- Throws descriptive errors at every failure point

### `LoanRepaymentForm.tsx` (updated)

- Removes `simulateRepayment`, all `alert()` / `console.log()` calls, and random simulation logic
- On confirm: `showPending` toast → `executeRepayTransaction` → `showSuccess` with Stellar Explorer link, or `showError` on failure
- Invalidates `loans.all`, `loans.detail(loanId)`, `borrowerLoans.byAddress` after success
- Re-throws on error so `useTransactionPreview` keeps the modal open for retry
- Disables submit button when no wallet is connected

## Setup required

```bash
cd frontend
npm install @stellar/stellar-sdk @stellar/freighter-api
```

`.env.local` (populated by deploy script):
```
NEXT_PUBLIC_MANAGER_CONTRACT_ID=<contract id>
NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
```

## Test plan

- [ ] Enter a repayment amount and click "Review Repayment" — preview modal opens
- [ ] Click "Sign Transaction" — Freighter prompts for signature
- [ ] After signing: pending toast → success toast with Stellar Explorer link
- [ ] Loan list updates to reflect the repayment
- [ ] Cancel in Freighter: error toast shown, modal stays open for retry
- [ ] Submit button disabled when no wallet is connected