### PR TITLE
feat: enhance yield handling and interest rate configuration

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -197,6 +197,11 @@ impl LendingPool {
             .instance()
             .set(&DataKey::UnclaimedYieldPool, &next_unclaimed);
         Self::bump_instance_ttl(env);
+
+        env.events().publish(
+            (Symbol::new(env, "YieldSynced"),),
+            (new_yield, total_deposits, next_index),
+        );
     }
 
     fn harvest_provider(env: &Env, provider: &Address) {
@@ -484,7 +489,11 @@ impl LendingPool {
 
         let claimable = Self::read_claimable_yield(&env, &provider);
         if claimable <= 0 {
-            panic!("no yield available");
+            env.events().publish(
+                (Symbol::new(&env, "YieldClaimFailed"), provider),
+                Symbol::new(&env, "NoYieldAvailable"),
+            );
+            return;
         }
 
         let pool_balance = Self::pool_balance(&env);

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -267,6 +267,59 @@ fn test_claim_yield_distributes_pro_rata_interest() {
 }
 
 #[test]
+fn test_claim_yield_with_no_realized_yield_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &1_000);
+    pool_client.deposit(&provider, &1_000);
+
+    let provider_balance_before = token_client.balance(&provider);
+    let pool_balance_before = token_client.balance(&pool_id);
+
+    // Should not panic when no yield is available.
+    pool_client.claim_yield(&provider);
+
+    assert_eq!(token_client.balance(&provider), provider_balance_before);
+    assert_eq!(token_client.balance(&pool_id), pool_balance_before);
+    assert_eq!(pool_client.get_deposit(&provider), 1_000);
+}
+
+#[test]
+fn test_second_claim_without_new_yield_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_id, &token_admin);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &1_000);
+    pool_client.deposit(&provider, &1_000);
+
+    // Realize yield and claim it once.
+    stellar_asset_client.mint(&pool_id, &100);
+    pool_client.claim_yield(&provider);
+    let balance_after_first_claim = token_client.balance(&provider);
+
+    // No new realized yield; second claim should be a no-op.
+    pool_client.claim_yield(&provider);
+    assert_eq!(token_client.balance(&provider), balance_after_first_claim);
+}
+
+#[test]
 fn test_admin_transfer_flow() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -115,10 +115,17 @@ impl LoanManager {
 
     fn read_interest_rate(env: &Env) -> u32 {
         Self::bump_instance_ttl(env);
-        env.storage()
+        let configured_rate = env
+            .storage()
             .instance()
             .get(&DataKey::InterestRateBps)
-            .unwrap_or(Self::DEFAULT_INTEREST_RATE_BPS)
+            .unwrap_or(Self::DEFAULT_INTEREST_RATE_BPS);
+
+        if configured_rate == 0 {
+            Self::DEFAULT_INTEREST_RATE_BPS
+        } else {
+            configured_rate
+        }
     }
 
     fn read_default_term(env: &Env) -> u32 {

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{LoanManager, LoanManagerClient, LoanStatus};
+use crate::{DataKey, LoanManager, LoanManagerClient, LoanStatus};
 use remittance_nft::{RemittanceNFT, RemittanceNFTClient};
 use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
@@ -184,6 +184,44 @@ fn test_configurable_interest_rate_and_default_term() {
 
     let approved_loan = manager.get_loan(&loan_id);
     assert_eq!(approved_loan.due_date, approval_ledger + 20_000);
+}
+
+#[test]
+#[should_panic(expected = "interest rate must be positive")]
+fn test_set_interest_rate_zero_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (manager, _nft_client, _pool, _token, _token_admin) = setup_test(&env);
+    manager.set_interest_rate(&0);
+}
+
+#[test]
+fn test_legacy_zero_interest_config_falls_back_to_default() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_address, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    // Simulate a legacy/misconfigured zero interest rate in instance storage.
+    env.as_contract(&manager.address, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::InterestRateBps, &0u32);
+    });
+
+    assert_eq!(manager.get_interest_rate(), 1_200);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(&borrower, &600, &history_hash, &None);
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_address, &10_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000);
+    let pending_loan = manager.get_loan(&loan_id);
+    assert_eq!(pending_loan.interest_rate_bps, 1_200);
 }
 
 #[test]


### PR DESCRIPTION
-## Summary
This PR addresses two contract issues:

- Closes #307: Missing tests and safety handling for zero interest rate configuration in `loan_manager`
- Closes #302: Missing yield distribution observability events in `lending_pool`

## What Changed

### 1) Loan Manager: zero interest rate hardening and coverage (#307)
- Added a defensive fallback in interest-rate reads:
  - If stored `InterestRateBps` is `0`, the contract now falls back to default `1200` bps.
- Kept admin configuration guard intact:
  - `set_interest_rate(0)` remains rejected with `interest rate must be positive`.
- Added tests for both paths:
  - Rejecting `set_interest_rate(0)`
  - Legacy/misconfigured on-chain `0` value falling back to `1200` and propagating to new loans

### 2) Lending Pool: yield lifecycle events and graceful zero-claim handling (#302)
- Added event emission in `sync_yield()`:
  - `YieldSynced(new_yield, total_deposits, acc_yield_per_deposit)`
- Preserved successful claim event:
  - `YieldClaimed(provider, amount)` on successful claim
- Updated zero-yield claim behavior:
  - Instead of panicking on no yield, `claim_yield()` now emits:
    - `YieldClaimFailed(provider, NoYieldAvailable)`
  - Then returns early (no-op)
- Added tests to cover new behavior:
  - Claim with no realized yield does not panic and does not change balances
  - A second claim without newly realized yield is a no-op

## Behavior Notes
- This PR improves observability for yield distribution/index updates.
- `claim_yield()` no longer fails hard when claimable yield is zero; it now fails gracefully via event emission.

## Validation
Executed and passing:
- `cargo fmt --check`
- `cargo test -p loan_manager`
- `cargo test -p lending_pool`

## Linked Issues
- Closes #307
- Closes #302