### PR TITLE
feat(scripts): add deployment script with contract initialization order

### DIFF
--- a/scripts/deploy-config.json
+++ b/scripts/deploy-config.json
@@ -13,6 +13,9 @@
       },
       "loan_manager": {
         "wasm": "../contracts/target/wasm32-unknown-unknown/release/loan_manager.wasm"
+      },
+      "multisig_governance": {
+        "wasm": "../contracts/target/wasm32-unknown-unknown/release/multisig_governance.wasm"
       }
     }
   }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,13 +1,14 @@
-import { 
-  Keypair, 
-  Operation, 
-  TransactionBuilder, 
-  Rpc,
-  Address,
-  nativeToScVal,
-  xdr,
-  StrKey
+import {
+    Keypair,
+    Operation,
+    TransactionBuilder,
+    Rpc,
+    Address,
+    nativeToScVal,
+    xdr,
+    StrKey,
 } from '@stellar/stellar-sdk';
+import { createHash } from 'crypto';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
@@ -15,104 +16,145 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 const CONFIG_PATH = path.join(__dirname, 'deploy-config.json');
+const POLL_INTERVAL_MS = 2000;
 
-async function sendTransaction(server: Rpc.Server, tx: xdr.TransactionEnvelope, account: Keypair, networkPassphrase: string) {
-    let response = await server.simulateTransaction(tx);
-    if (Rpc.Api.isSimulationError(response)) {
-        throw new Error(`Simulation failed: ${JSON.stringify(response.error, null, 2)}`);
+// Compute the SHA-256 hash of WASM bytes — this is the on-chain upload key.
+function computeWasmHash(wasm: Buffer): Buffer {
+    return createHash('sha256').update(wasm).digest();
+}
+
+// Deterministic per-contract salt so re-runs don't stomp each other's addresses.
+function contractSalt(name: string): Buffer {
+    return createHash('sha256').update(`remitlend:${name}`).digest();
+}
+
+// Extract the newly created contract ID from transaction result metadata.
+function extractContractId(resultMeta: xdr.TransactionMeta): string {
+    const v3 = resultMeta.v3();
+    for (const opMeta of v3.operations()) {
+        for (const change of opMeta.changes()) {
+            if (change.switch().name !== 'ledgerEntryCreated') continue;
+            const data = change.created().data();
+            if (data.switch().name !== 'contractData') continue;
+            const cd = data.contractData();
+            if (cd.key().switch().name !== 'scvLedgerKeyContractInstance') continue;
+            const contract = cd.contract();
+            if (contract.switch().name === 'scAddressTypeContract') {
+                return StrKey.encodeContract(contract.contractId());
+            }
+        }
+    }
+    throw new Error('Could not extract contract ID from transaction metadata');
+}
+
+async function sendTx(
+    server: Rpc.Server,
+    tx: ReturnType<TransactionBuilder['build']>,
+    account: Keypair,
+): Promise<Rpc.Api.GetSuccessfulTransactionResponse> {
+    const sim = await server.simulateTransaction(tx);
+    if (Rpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${JSON.stringify(sim.error, null, 2)}`);
     }
 
-    // Prepare transaction with simulation results
     const preparedTx = await server.prepareTransaction(tx);
     preparedTx.sign(account);
-    
-    let sendResponse = await server.sendTransaction(preparedTx);
+
+    const sendResponse = await server.sendTransaction(preparedTx);
     if (sendResponse.status !== 'PENDING') {
-        throw new Error(`Send transaction failed: ${JSON.stringify(sendResponse, null, 2)}`);
+        throw new Error(`Send failed: ${JSON.stringify(sendResponse, null, 2)}`);
     }
 
-    console.log(`Transaction sent. Hash: ${sendResponse.hash}. Waiting for confirmation...`);
-    
+    console.log(`    tx ${sendResponse.hash} … polling`);
+
     let txResponse = await server.getTransaction(sendResponse.hash);
     while (txResponse.status === 'NOT_FOUND') {
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
         txResponse = await server.getTransaction(sendResponse.hash);
     }
-    
-    if (txResponse.status === 'FAILED') {
-        throw new Error(`Transaction failed: ${JSON.stringify(txResponse.resultXdr, null, 2)}`);
+
+    if (txResponse.status !== 'SUCCESS') {
+        throw new Error(`Transaction failed: ${JSON.stringify(txResponse, null, 2)}`);
     }
 
-    return txResponse;
+    return txResponse as Rpc.Api.GetSuccessfulTransactionResponse;
 }
 
-async function uploadWasm(server: Rpc.Server, wasmPath: string, account: Keypair, networkPassphrase: string) {
+// Upload WASM bytecode to the network and return its SHA-256 hash.
+// If the same WASM was uploaded before the hash is already indexed, but the
+// operation is idempotent and safe to repeat.
+async function uploadWasm(
+    server: Rpc.Server,
+    wasmPath: string,
+    account: Keypair,
+    networkPassphrase: string,
+): Promise<Buffer> {
     const wasm = await fs.readFile(wasmPath);
-    const source = await server.getAccount(account.publicKey());
-    
-    const tx = new TransactionBuilder(source, {
-        fee: '10000',
-        networkPassphrase
-    })
-    .addOperation(Operation.uploadContractWasm({ wasm }))
-    .setTimeout(30)
-    .build();
+    const wasmHash = computeWasmHash(wasm);
 
-    const result = await sendTransaction(server, tx, account, networkPassphrase);
-    if (!result.resultMetaXdr) throw new Error('Missing resultMetaXdr');
-    
-    // Extract WASM ID from the transaction result
-    // In a real scenario, you'd parse the XDR to find the wasmId
-    // For this script, we'll use the simulation result which includes it
-    const sim = await server.simulateTransaction(tx);
-    if (Rpc.Api.isSimulationSuccess(sim) && sim.result) {
-        return (sim as any).result.wasmId;
-    }
-    throw new Error('Could not determine WASM ID');
+    console.log(`  uploading ${path.basename(wasmPath)} (hash ${wasmHash.toString('hex').slice(0, 12)}…)`);
+
+    const source = await server.getAccount(account.publicKey());
+    const tx = new TransactionBuilder(source, { fee: '100000', networkPassphrase })
+        .addOperation(Operation.uploadContractWasm({ wasm }))
+        .setTimeout(30)
+        .build();
+
+    await sendTx(server, tx, account);
+    return wasmHash;
 }
 
-async function createInstance(server: Rpc.Server, wasmId: string, account: Keypair, networkPassphrase: string) {
+// Instantiate a contract from an uploaded WASM hash. Returns the new contract ID.
+async function createInstance(
+    server: Rpc.Server,
+    wasmHash: Buffer,
+    salt: Buffer,
+    account: Keypair,
+    networkPassphrase: string,
+): Promise<string> {
     const source = await server.getAccount(account.publicKey());
-    const tx = new TransactionBuilder(source, {
-        fee: '10000',
-        networkPassphrase
-    })
-    .addOperation(Operation.createSmartContract({
-        wasmId,
-        address: Address.fromString(account.publicKey())
-    }))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(source, { fee: '100000', networkPassphrase })
+        .addOperation(
+            Operation.createCustomContract({
+                address: Address.fromString(account.publicKey()),
+                wasmHash,
+                salt,
+            }),
+        )
+        .setTimeout(30)
+        .build();
 
-    const result = await sendTransaction(server, tx, account, networkPassphrase);
-    // Extract contract ID from meta XDR
-    const sim = await server.simulateTransaction(tx);
-    if (Rpc.Api.isSimulationSuccess(sim) && sim.result) {
-        return (sim as any).result.address;
-    }
-    throw new Error('Could not determine Contract ID');
+    const result = await sendTx(server, tx, account);
+    return extractContractId(result.resultMetaXdr);
 }
 
-async function invoke(server: Rpc.Server, contractId: string, method: string, args: any[], account: Keypair, networkPassphrase: string) {
+// Call a contract function with positional arguments.
+async function invoke(
+    server: Rpc.Server,
+    contractId: string,
+    method: string,
+    args: unknown[],
+    account: Keypair,
+    networkPassphrase: string,
+): Promise<void> {
     const source = await server.getAccount(account.publicKey());
-    const tx = new TransactionBuilder(source, {
-        fee: '10000',
-        networkPassphrase
-    })
-    .addOperation(Operation.invokeHostFunction({
-        func: xdr.HostFunction.hostFunctionTypeInvokeContract(
-            new xdr.InvokeContractArgs({
-                contractAddress: Address.fromString(contractId).toScAddress(),
-                functionName: method,
-                args: args.map(arg => nativeToScVal(arg))
-            })
-        ),
-        auth: []
-    }))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(source, { fee: '100000', networkPassphrase })
+        .addOperation(
+            Operation.invokeHostFunction({
+                func: xdr.HostFunction.hostFunctionTypeInvokeContract(
+                    new xdr.InvokeContractArgs({
+                        contractAddress: Address.fromString(contractId).toScAddress(),
+                        functionName: method,
+                        args: args.map(arg => nativeToScVal(arg)),
+                    }),
+                ),
+                auth: [],
+            }),
+        )
+        .setTimeout(30)
+        .build();
 
-    return sendTransaction(server, tx, account, networkPassphrase);
+    await sendTx(server, tx, account);
 }
 
 async function main() {
@@ -121,56 +163,130 @@ async function main() {
     if (!config) throw new Error(`No config for network: ${network}`);
 
     const secretKey = process.env.SECRET_KEY;
-    if (!secretKey) throw new Error('SECRET_KEY env required');
+    if (!secretKey) throw new Error('SECRET_KEY environment variable is required');
+
     const account = Keypair.fromSecret(secretKey);
-    const adminAddr = config.admin === 'YOUR_ADMIN_PUBLIC_KEY' ? account.publicKey() : config.admin;
+    // Fall back to the deployer's own key when admin is not set in config.
+    const adminAddr =
+        config.admin === 'YOUR_ADMIN_PUBLIC_KEY' ? account.publicKey() : config.admin;
 
     const server = new Rpc.Server(config.rpcUrl);
     const passphrase = config.networkPassphrase;
 
-    console.log(`Starting deployment on ${network}...`);
+    console.log(`\nRemitLend deployment → ${network}`);
+    console.log(`admin : ${adminAddr}`);
+    console.log(`token : ${config.token}\n`);
 
-    // 1. Deploy Remittance NFT
-    const nftWasmId = await uploadWasm(server, path.resolve(__dirname, config.contracts.remittance_nft.wasm), account, passphrase);
-    const nftContractId = await createInstance(server, nftWasmId, account, passphrase);
-    console.log(`NFT Contract Deployed: ${nftContractId}`);
+    // ── 1. Upload all WASM binaries ─────────────────────────────────────────────
+    console.log('[1/4] Uploading WASM binaries…');
+    const nftWasmHash = await uploadWasm(
+        server,
+        path.resolve(__dirname, config.contracts.remittance_nft.wasm),
+        account,
+        passphrase,
+    );
+    const poolWasmHash = await uploadWasm(
+        server,
+        path.resolve(__dirname, config.contracts.lending_pool.wasm),
+        account,
+        passphrase,
+    );
+    const managerWasmHash = await uploadWasm(
+        server,
+        path.resolve(__dirname, config.contracts.loan_manager.wasm),
+        account,
+        passphrase,
+    );
+    const govWasmHash = await uploadWasm(
+        server,
+        path.resolve(__dirname, config.contracts.multisig_governance.wasm),
+        account,
+        passphrase,
+    );
 
-    // 2. Deploy Lending Pool
-    const poolWasmId = await uploadWasm(server, path.resolve(__dirname, config.contracts.lending_pool.wasm), account, passphrase);
-    const poolContractId = await createInstance(server, poolWasmId, account, passphrase);
-    console.log(`Pool Contract Deployed: ${poolContractId}`);
+    // ── 2. Instantiate contracts ────────────────────────────────────────────────
+    console.log('\n[2/4] Creating contract instances…');
 
-    // 3. Deploy Loan Manager
-    const managerWasmId = await uploadWasm(server, path.resolve(__dirname, config.contracts.loan_manager.wasm), account, passphrase);
-    const managerContractId = await createInstance(server, managerWasmId, account, passphrase);
-    console.log(`Manager Contract Deployed: ${managerContractId}`);
+    console.log('  RemittanceNFT');
+    const nftContractId = await createInstance(server, nftWasmHash, contractSalt('nft'), account, passphrase);
+    console.log(`    → ${nftContractId}`);
 
-    // 4. Initialize Contracts
-    console.log('Initializing contracts...');
+    console.log('  LendingPool');
+    const poolContractId = await createInstance(server, poolWasmHash, contractSalt('pool'), account, passphrase);
+    console.log(`    → ${poolContractId}`);
+
+    console.log('  LoanManager');
+    const managerContractId = await createInstance(server, managerWasmHash, contractSalt('manager'), account, passphrase);
+    console.log(`    → ${managerContractId}`);
+
+    console.log('  Governance');
+    const govContractId = await createInstance(server, govWasmHash, contractSalt('governance'), account, passphrase);
+    console.log(`    → ${govContractId}`);
+
+    // ── 3. Initialize in dependency order ──────────────────────────────────────
+    //
+    // Ordering constraints:
+    //   a. NFT must be initialized before authorize_minter can be called.
+    //   b. authorize_minter(LoanManager) must run BEFORE LoanManager.initialize,
+    //      because LoanManager.initialize asserts it is already an authorized minter.
+    //   c. LendingPool has no dependency on NFT or LoanManager at init time.
+    //   d. LoanManager.initialize takes (nft, pool, token, admin) so both NFT and
+    //      Pool addresses must be known first.
+    //   e. Governance.initialize takes (admin, target_contract). We point it at
+    //      LoanManager as the primary governed contract.
+    //
+    console.log('\n[3/4] Initializing contracts…');
+
+    // NFT
+    console.log('  NFT.initialize');
     await invoke(server, nftContractId, 'initialize', [adminAddr], account, passphrase);
-    await invoke(server, poolContractId, 'initialize', [config.token, adminAddr], account, passphrase);
-    await invoke(server, managerContractId, 'initialize', [nftContractId, poolContractId, config.token, adminAddr], account, passphrase);
 
-    // 5. Link Contracts
-    console.log('Linking contracts...');
+    // Authorize LoanManager as minter BEFORE LoanManager.initialize checks for it.
+    console.log('  NFT.authorize_minter(LoanManager)');
     await invoke(server, nftContractId, 'authorize_minter', [managerContractId], account, passphrase);
 
-    // 6. Save to .env files
-    const envData = `
-# RemitLend Contract IDs (${network})
-NEXT_PUBLIC_NFT_CONTRACT_ID=${nftContractId}
-NEXT_PUBLIC_POOL_CONTRACT_ID=${poolContractId}
-NEXT_PUBLIC_MANAGER_CONTRACT_ID=${managerContractId}
-`;
+    // LendingPool
+    console.log('  LendingPool.initialize');
+    await invoke(server, poolContractId, 'initialize', [config.token, adminAddr], account, passphrase);
 
-    await fs.appendFile(path.join(__dirname, '../frontend/.env.local'), envData);
-    await fs.appendFile(path.join(__dirname, '../backend/.env'), envData);
+    // LoanManager — validates minter authorization on-chain during this call.
+    console.log('  LoanManager.initialize');
+    await invoke(
+        server,
+        managerContractId,
+        'initialize',
+        [nftContractId, poolContractId, config.token, adminAddr],
+        account,
+        passphrase,
+    );
 
-    console.log('Deployment complete! Contract IDs saved to .env files.');
+    // Governance — target is LoanManager (the core protocol contract).
+    console.log('  Governance.initialize(target=LoanManager)');
+    await invoke(server, govContractId, 'initialize', [adminAddr, managerContractId], account, passphrase);
+
+    // ── 4. Persist contract IDs ─────────────────────────────────────────────────
+    console.log('\n[4/4] Writing contract addresses to .env files…');
+
+    const envBlock = [
+        ``,
+        `# RemitLend contracts — ${network} — ${new Date().toISOString()}`,
+        `NEXT_PUBLIC_NFT_CONTRACT_ID=${nftContractId}`,
+        `NEXT_PUBLIC_POOL_CONTRACT_ID=${poolContractId}`,
+        `NEXT_PUBLIC_MANAGER_CONTRACT_ID=${managerContractId}`,
+        `NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=${govContractId}`,
+    ].join('\n');
+
+    await fs.appendFile(path.join(__dirname, '../frontend/.env.local'), envBlock);
+    await fs.appendFile(path.join(__dirname, '../backend/.env'), envBlock);
+
+    console.log('\nDeployment complete.');
+    console.log(`  RemittanceNFT  : ${nftContractId}`);
+    console.log(`  LendingPool    : ${poolContractId}`);
+    console.log(`  LoanManager    : ${managerContractId}`);
+    console.log(`  Governance     : ${govContractId}`);
 }
 
 main().catch(error => {
-    console.error('Deployment failed:');
-    console.error(error);
+    console.error('\nDeployment failed:', error instanceof Error ? error.message : error);
     process.exit(1);
 });


### PR DESCRIPTION
## Summary

Resolves #306

- **Fix broken WASM hash extraction** — replaced the invalid re-simulation pattern with `SHA-256(wasmBytes)`, which is the deterministic on-chain upload key
- **Fix broken contract ID extraction** — parse `resultMetaXdr` ledger entry changes for the `scvLedgerKeyContractInstance` `contractData` entry instead of re-simulating a sent transaction
- **Fix `Operation.createSmartContract`** → `Operation.createCustomContract` (correct stellar-sdk API)
- **Add Governance contract** — uploads, instantiates, and initializes `multisig_governance`; adds its WASM path to `deploy-config.json`

## Initialization order

The script enforces the exact dependency chain required by the contracts:

```
NFT.initialize(admin)
NFT.authorize_minter(LoanManager)      ← must precede LoanManager.initialize
LendingPool.initialize(token, admin)
LoanManager.initialize(nft, pool, token, admin)   ← on-chain assert: is_authorized_minter
Governance.initialize(admin, LoanManager)
```

`LoanManager.initialize` calls `nft_client.is_authorized_minter(&env.current_contract_address())` and panics if the minter is not already authorized, so `authorize_minter` must run first.

## Test plan

- [ ] Build all contract WASM binaries (`./scripts/build.sh`)
- [ ] Set `SECRET_KEY` in environment and update `deploy-config.json` with a valid token address
- [ ] Run `cd scripts && npm run deploy testnet`
- [ ] Confirm all four contract IDs are printed and written to `frontend/.env.local` and `backend/.env`
- [ ] Verify on Stellar testnet explorer that each contract is live and initialized