### PR TITLE
feat(ui): add reusable LoanStatusBadge component

### DIFF
--- a/frontend/src/app/components/borrower/LoanCard.tsx
+++ b/frontend/src/app/components/borrower/LoanCard.tsx
@@ -5,6 +5,7 @@ import { Card } from "../ui/Card";
 import { Button } from "../ui/Button";
 import type { BorrowerLoan } from "../../hooks/useApi";
 import { formatCurrency, formatDate, getDaysUntilDeadline } from "./loanFormatters";
+import { LoanStatusBadge } from "../ui/LoanStatusBadge";
 
 export interface LoanCardProps {
   loan: BorrowerLoan;
@@ -34,15 +35,7 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
               ? "bg-yellow-100 text-yellow-800"
               : "bg-green-100 text-green-800",
         }
-      : {
-          label: loan.status.charAt(0).toUpperCase() + loan.status.slice(1),
-          className:
-            loan.status === "active"
-              ? "bg-green-100 text-green-800"
-              : loan.status === "pending"
-                ? "bg-yellow-100 text-yellow-800"
-                : "bg-gray-100 text-gray-800",
-        };
+      : null;
 
   // ── Deadline colours ───────────────────────────────────────────────────────
   const deadlineBg = isOverdue ? "bg-red-50" : isUrgent ? "bg-yellow-50" : "bg-gray-50";
@@ -70,9 +63,13 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
       <div className="flex justify-between items-start mb-4">
         <div>
           <h3 className="text-lg font-semibold">Loan #{loan.id}</h3>
-          <span className={`inline-block px-2 py-1 text-xs rounded-full mt-1 ${badge.className}`}>
-            {badge.label}
-          </span>
+          {badge ? (
+            <span className={`inline-block px-2 py-1 text-xs rounded-full mt-1 ${badge.className}`}>
+              {badge.label}
+            </span>
+          ) : (
+            <LoanStatusBadge status={loan.status} className="mt-1" />
+          )}
         </div>
         <div className="text-right">
           <p className="text-sm text-gray-600">Total Owed</p>

--- a/frontend/src/app/components/ui/LoanStatusBadge.tsx
+++ b/frontend/src/app/components/ui/LoanStatusBadge.tsx
@@ -1,0 +1,28 @@
+type LoanStatus = "active" | "pending" | "repaid" | "defaulted";
+
+const STATUS_STYLES: Record<LoanStatus, string> = {
+  active:
+    "bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-400",
+  repaid:
+    "bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-400",
+  defaulted:
+    "bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-400",
+  pending:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-400",
+};
+
+interface LoanStatusBadgeProps {
+  status: LoanStatus | string;
+  className?: string;
+}
+
+export function LoanStatusBadge({ status, className = "" }: LoanStatusBadgeProps) {
+  const styles = STATUS_STYLES[status as LoanStatus] ?? "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
+  return (
+    <span
+      className={`inline-block rounded-full px-3 py-1 text-xs font-medium capitalize ${styles} ${className}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/app/components/ui/LoanStatusBadge.tsx
+++ b/frontend/src/app/components/ui/LoanStatusBadge.tsx
@@ -1,14 +1,10 @@
 type LoanStatus = "active" | "pending" | "repaid" | "defaulted";
 
 const STATUS_STYLES: Record<LoanStatus, string> = {
-  active:
-    "bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-400",
-  repaid:
-    "bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-400",
-  defaulted:
-    "bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-400",
-  pending:
-    "bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-400",
+  active: "bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-400",
+  repaid: "bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-400",
+  defaulted: "bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-400",
+  pending: "bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-400",
 };
 
 interface LoanStatusBadgeProps {
@@ -17,7 +13,9 @@ interface LoanStatusBadgeProps {
 }
 
 export function LoanStatusBadge({ status, className = "" }: LoanStatusBadgeProps) {
-  const styles = STATUS_STYLES[status as LoanStatus] ?? "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
+  const styles =
+    STATUS_STYLES[status as LoanStatus] ??
+    "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
   return (
     <span
       className={`inline-block rounded-full px-3 py-1 text-xs font-medium capitalize ${styles} ${className}`}

--- a/frontend/src/app/lend/page.tsx
+++ b/frontend/src/app/lend/page.tsx
@@ -14,6 +14,7 @@ import {
 import { ErrorBoundary } from "../components/global_ui/ErrorBoundary";
 import { YieldEarningsChart } from "../components/charts/YieldEarningsChart";
 import { useDepositorPortfolio, useLoans, usePoolStats, useYieldHistory } from "../hooks/useApi";
+import { LoanStatusBadge } from "../components/ui/LoanStatusBadge";
 import { selectWalletAddress, useWalletStore } from "../stores/useWalletStore";
 
 function formatCurrency(value: number) {
@@ -257,9 +258,7 @@ export default function LendPage() {
                     <span>{formatCurrency(loan.amount)}</span>
                     <span>{loan.interestRate.toFixed(2)}% APR</span>
                     <span>{loan.termDays} days</span>
-                    <span className="rounded-full bg-zinc-100 px-3 py-1 font-medium capitalize text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                      {loan.status}
-                    </span>
+                    <LoanStatusBadge status={loan.status} />
                   </div>
                   <Link
                     href={`/loans/${loan.id}`}

--- a/frontend/src/app/loans/[loanId]/page.tsx
+++ b/frontend/src/app/loans/[loanId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { ChevronRight, ExternalLink, Wallet } from "lucide-react";
 import { LoanDetailSkeleton } from "../../components/skeletons/LoanDetailSkeleton";
 import { useLoan } from "../../hooks/useApi";
+import { LoanStatusBadge } from "../../components/ui/LoanStatusBadge";
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
@@ -49,12 +50,6 @@ export default function LoanDetailsPage() {
       ? Math.min((loan.totalRepaid / (loan.totalRepaid + loan.totalOwed)) * 100, 100)
       : 100;
   const latestTxHash = loan.events.find((event) => Boolean(event.txHash))?.txHash;
-  const statusTone =
-    loan.status === "repaid"
-      ? "text-green-600 dark:text-green-400"
-      : loan.status === "defaulted"
-        ? "text-red-600 dark:text-red-400"
-        : "text-indigo-600 dark:text-indigo-400";
 
   return (
     <section className="space-y-6">
@@ -97,9 +92,10 @@ export default function LoanDetailsPage() {
             <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-800">
               <div className="h-2 rounded-full bg-indigo-600" style={{ width: `${progress}%` }} />
             </div>
-            <p className={`mt-3 text-sm font-semibold capitalize ${statusTone}`}>
-              Status: {loan.status}
-            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <p className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Status:</p>
+              <LoanStatusBadge status={loan.status} />
+            </div>
           </div>
 
           <div className="mt-6">

--- a/frontend/src/app/loans/page.tsx
+++ b/frontend/src/app/loans/page.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, CalendarRange, CircleDollarSign, ShieldCheck } from "lucide
 import { ErrorBoundary } from "../components/global_ui/ErrorBoundary";
 import { LoansListSkeleton } from "../components/skeletons/LoansListSkeleton";
 import { useBorrowerLoans } from "../hooks/useApi";
+import { LoanStatusBadge } from "../components/ui/LoanStatusBadge";
 import { useWalletStore, selectWalletAddress } from "../stores/useWalletStore";
 
 const PAGE_SIZE = 6;
@@ -173,9 +174,7 @@ export default function LoansPage() {
                     <p className="text-sm text-zinc-500 dark:text-zinc-400">{loan.borrower}</p>
                   </div>
                   <div className="flex flex-wrap items-center gap-3 text-sm">
-                    <span className="rounded-full bg-zinc-100 px-3 py-1 font-medium capitalize text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-                      {loan.displayStatus}
-                    </span>
+                    <LoanStatusBadge status={loan.displayStatus} />
                     <span className="text-zinc-600 dark:text-zinc-400">
                       {formatCurrency(loan.totalOwed)}
                     </span>


### PR DESCRIPTION
Closes #324

## Summary
- Created `LoanStatusBadge` component in `components/ui/` with consistent color-coding: green=active, blue=repaid, red=defaulted, yellow=pending — with full dark mode support
- Replaced all inline status badge implementations across `LoanCard`, `loans/page`, `loans/[loanId]/page`, and `lend/page` with the new component

## Test plan
- [ ] Verify badge colors render correctly for all four statuses (active, repaid, defaulted, pending)
- [ ] Verify dark mode variants display correctly
- [ ] Confirm `LoanCard` compact variant shows `LoanStatusBadge` and detailed variant still shows urgency badge (Overdue/Due Soon/On Track)
- [ ] Check loans list page, loan detail page, and lender portfolio all display consistent badges