### PR TITLE
feat: Add API versioning with v1 prefix

### DIFF
--- a/backend/src/__tests__/apiVersioning.test.ts
+++ b/backend/src/__tests__/apiVersioning.test.ts
@@ -1,0 +1,54 @@
+import request from "supertest";
+import app from "../app.js";
+
+describe("API Versioning", () => {
+  describe("Legacy API routes (backward compatibility)", () => {
+    it("should respond to /api/score endpoint", async () => {
+      const response = await request(app).get("/api/score/test-user");
+      // Should return 401 for missing auth, not 404 for missing route
+      expect(response.status).not.toBe(404);
+    });
+
+    it("should respond to /api/loans endpoint", async () => {
+      const response = await request(app).get("/api/loans/borrower/test-user");
+      // Should return 401 for missing auth, not 404 for missing route
+      expect(response.status).not.toBe(404);
+    });
+
+    it("should respond to /api/docs endpoint", async () => {
+      const response = await request(app).get("/api/docs");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Versioned API routes (v1)", () => {
+    it("should respond to /api/v1/score endpoint", async () => {
+      const response = await request(app).get("/api/v1/score/test-user");
+      // Should return 401 for missing auth, not 404 for missing route
+      expect(response.status).not.toBe(404);
+    });
+
+    it("should respond to /api/v1/loans endpoint", async () => {
+      const response = await request(app).get("/api/v1/loans/borrower/test-user");
+      // Should return 401 for missing auth, not 404 for missing route
+      expect(response.status).not.toBe(404);
+    });
+
+    it("should respond to /api/v1/docs endpoint", async () => {
+      const response = await request(app).get("/api/v1/docs");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Non-existent routes", () => {
+    it("should return 404 for non-existent versioned routes", async () => {
+      const response = await request(app).get("/api/v2/score/test-user");
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for completely non-existent routes", async () => {
+      const response = await request(app).get("/api/nonexistent");
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -119,6 +119,18 @@ app.get(
   }),
 );
 
+// Versioned API routes (v1)
+app.use("/api/v1", simulationRoutes);
+app.use("/api/v1/score", scoreRoutes);
+app.use("/api/v1/loans", loanRoutes);
+app.use("/api/v1/pool", poolRoutes);
+app.use("/api/v1/indexer", indexerRoutes);
+app.use("/api/v1/admin", adminRoutes);
+app.use("/api/v1/auth", authRoutes);
+app.use("/api/v1/notifications", notificationsRoutes);
+app.use("/api/v1/events", eventRoutes);
+
+// Legacy API routes (aliases for backward compatibility)
 app.use("/api", simulationRoutes);
 app.use("/api/score", scoreRoutes);
 app.use("/api/loans", loanRoutes);
@@ -154,6 +166,7 @@ if (process.env.NODE_ENV === "test") {
 }
 
 app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // ── 404 Catch-All ────────────────────────────────────────────────
 // Must be placed after all route definitions so that only truly


### PR DESCRIPTION
- Add /api/v1/ prefix to all API routes
- Maintain backward compatibility with legacy /api/ routes
- Include versioned Swagger documentation endpoint
- Add comprehensive tests for API versioning
- Enable future breaking changes without disrupting integrations

Fixes #226