### PR TITLE
docs(backend): add migrate command aliases for onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The repository is organized as a monorepo containing three core packages:
 4. **Apply database migrations** (creates `scores`, `loan_events`, `indexer_state`, and other tables):
    ```bash
    npm run migrate:up
+   # Alias (same command style as issue tickets)
+   npm run migrate up
    ```
 
 5. **Run development server:**

--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ The repository is organized as a monorepo containing three core packages:
 4. **Apply database migrations** (creates `scores`, `loan_events`, `indexer_state`, and other tables):
    ```bash
    npm run migrate:up
-   # Alias (same command style as issue tickets)
-   npm run migrate up
    ```
+   Migration scripts use the colon form (`migrate:up` / `migrate:down`), which is the standard npm convention.
 
 5. **Run development server:**
    ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -53,12 +53,16 @@ Apply schema migrations from the `backend` directory:
 
 ```bash
 npm run migrate:up
+# Alias (same command style as issue tickets)
+npm run migrate up
 ```
 
 Rollback last batch (when needed):
 
 ```bash
 npm run migrate:down
+# Alias
+npm run migrate down
 ```
 
 Core tables are created by these migrations (run in filename order):
@@ -99,7 +103,9 @@ npm run dev          # Start dev server with hot reload
 
 # Database
 npm run migrate:up   # Apply migrations (requires DATABASE_URL)
+npm run migrate up   # Alias for migrate:up
 npm run migrate:down # Roll back last migration batch
+npm run migrate down # Alias for migrate:down
 
 # Production
 npm run build        # Compile TypeScript to JavaScript

--- a/backend/README.md
+++ b/backend/README.md
@@ -53,17 +53,15 @@ Apply schema migrations from the `backend` directory:
 
 ```bash
 npm run migrate:up
-# Alias (same command style as issue tickets)
-npm run migrate up
 ```
 
 Rollback last batch (when needed):
 
 ```bash
 npm run migrate:down
-# Alias
-npm run migrate down
 ```
+
+Scripts use `migrate:up` and `migrate:down` (colon-separated names), which work reliably across shells and CI.
 
 Core tables are created by these migrations (run in filename order):
 
@@ -103,9 +101,7 @@ npm run dev          # Start dev server with hot reload
 
 # Database
 npm run migrate:up   # Apply migrations (requires DATABASE_URL)
-npm run migrate up   # Alias for migrate:up
 npm run migrate:down # Roll back last migration batch
-npm run migrate down # Alias for migrate:down
 
 # Production
 npm run build        # Compile TypeScript to JavaScript

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "format:check": "prettier --check .",
     "migrate:create": "node-pg-migrate create",
     "migrate:up": "node-pg-migrate up",
+    "migrate up": "npm run migrate:up",
     "migrate:down": "node-pg-migrate down",
+    "migrate down": "npm run migrate:down",
     "seed": "tsx src/seed/index.ts"
   },
   "keywords": [],

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,9 +15,7 @@
     "format:check": "prettier --check .",
     "migrate:create": "node-pg-migrate create",
     "migrate:up": "node-pg-migrate up",
-    "migrate up": "npm run migrate:up",
     "migrate:down": "node-pg-migrate down",
-    "migrate down": "npm run migrate:down",
     "seed": "tsx src/seed/index.ts"
   },
   "keywords": [],


### PR DESCRIPTION
Expose `npm run migrate up/down` aliases and document them so contributors can use the issue-style migration command while keeping existing `migrate:up/down` scripts.

