### PR TITLE
[Frontend] useApi Hooks Missing Authorization Headers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12331,7 +12331,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -71,6 +71,7 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
 
   // Attach JWT token if available (reads directly from Zustand store state,
   // safe to call outside React render since Zustand stores are singletons).
+  // My task Issue #327 was already done by @leojay   yesterday (March 26th, 2026 3:02 AM)
   const token = useUserStore.getState().authToken;
   if (token && !headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${token}`);


### PR DESCRIPTION
closes #327 
[Frontend] useApi Hooks Missing Authorization Headers
Verified that authToken is being added correctly to the authorization header in fetch requests