### PR TITLE
Add Playwright E2E test for critical user flow (wallet → dashboard → loan → repay → score)…

### DIFF
--- a/frontend/e2e/criticalFlows.spec.ts
+++ b/frontend/e2e/criticalFlows.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+test("critical user flow: connect wallet → dashboard → loan → repay → score", async ({ page }) => {
+  // Go to homepage
+  await page.goto("/"); // baseURL from config is http://localhost:3000
+
+  // Mock wallet connection immediately (if using a wallet popup)
+  await page.evaluate(() => {
+    localStorage.setItem("mockWalletConnected", "true");
+  });
+
+  // Dashboard should now be visible
+  const dashboard = page.locator("text=Dashboard"); // fallback: adjust if your app uses a different text
+  await dashboard.waitFor({ timeout: 60000 });
+  await expect(dashboard).toBeVisible();
+
+  // Request loan
+  const requestLoanButton = page.locator('button:has-text("Request Loan")'); // uses button element containing text
+  await requestLoanButton.waitFor({ timeout: 60000 });
+  await requestLoanButton.click();
+  await expect(page.locator("text=Loan Requested")).toBeVisible();
+
+  // Repay loan
+  const repayButton = page.locator('button:has-text("Repay Loan")'); // safer than text=
+  await repayButton.waitFor({ timeout: 60000 });
+  await repayButton.click();
+  await expect(page.locator("text=Loan Repaid")).toBeVisible();
+
+  // Check score
+  const checkScoreButton = page.locator('button:has-text("Check Score")'); // button containing text
+  await checkScoreButton.waitFor({ timeout: 60000 });
+  await checkScoreButton.click();
+  await expect(page.locator("text=Score")).toBeVisible();
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,16 +1,21 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
+  // 🔑 Relative to the folder you run Playwright from (frontend/)
   testDir: "./e2e",
+
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
+
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
+    headless: true, // good for CI
   },
+
   projects: [
     {
       name: "chromium",
@@ -25,9 +30,11 @@ export default defineConfig({
       use: { ...devices["Desktop Safari"] },
     },
   ],
+
   webServer: {
     command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    // timeout: 120000, // optional if dev server is slow
   },
 });


### PR DESCRIPTION
closes #328 

This PR adds a Playwright end-to-end (E2E) test for the critical user flow:
Connect Wallet → Dashboard → Request Loan → Repay Loan → Check Score.

Notes:
- Wallet connection is currently mocked using localStorage.
- Some button selectors may need adjustment once data-test attributes are added.
- The test structure and Playwright config follow the repo conventions.

This implements the E2E test as requested in issue #328 .