### PR TITLE
docs(api): add swagger response schemas

### DIFF
--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -2,6 +2,7 @@ import swaggerJSDoc from "swagger-jsdoc";
 import path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
+import { swaggerSchemas } from "./swaggerSchemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -36,58 +37,7 @@ const swaggerDefinition = {
           "JWT issued by POST /api/auth/login after POST /api/auth/challenge + signed message; use on GET /api/auth/verify and protected routes. Payload includes Stellar `publicKey`.",
       },
     },
-    schemas: {
-      ErrorResponse: {
-        type: "object",
-        properties: {
-          success: { type: "boolean", example: false },
-          message: { type: "string" },
-          error: {
-            type: "object",
-            properties: {
-              code: { type: "string" },
-              details: { type: "object" },
-            },
-          },
-        },
-      },
-      UserScore: {
-        type: "object",
-        properties: {
-          success: { type: "boolean", example: true },
-          userId: { type: "string" },
-          score: { type: "integer", example: 700 },
-          band: { type: "string", example: "Good" },
-          factors: {
-            type: "object",
-            properties: {
-              repaymentHistory: { type: "string" },
-              creditMix: { type: "string" },
-            },
-          },
-        },
-      },
-      RemittanceHistory: {
-        type: "object",
-        properties: {
-          userId: { type: "string" },
-          score: { type: "integer" },
-          streak: { type: "integer" },
-          history: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                paymentId: { type: "string" },
-                amount: { type: "number" },
-                status: { type: "string" },
-                timestamp: { type: "string", format: "date-time" },
-              },
-            },
-          },
-        },
-      },
-    },
+    schemas: swaggerSchemas,
   },
 };
 

--- a/backend/src/config/swaggerSchemas.ts
+++ b/backend/src/config/swaggerSchemas.ts
@@ -1,0 +1,792 @@
+export const swaggerSchemas = {
+  ValidationError: {
+    type: "object",
+    properties: {
+      path: { type: "string", example: "body.publicKey" },
+      message: { type: "string", example: "Public key is required" },
+    },
+    required: ["path", "message"],
+  },
+  ErrorResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: false },
+      message: { type: "string", example: "Validation failed" },
+      errors: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ValidationError" },
+      },
+      stack: { type: "string" },
+    },
+    required: ["success", "message"],
+  },
+  SimpleSuccessResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+    },
+    required: ["success"],
+  },
+  SuccessMessageResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      message: { type: "string", example: "Webhook subscription deleted" },
+    },
+    required: ["success", "message"],
+  },
+  ServerSentEventStream: {
+    type: "string",
+    example: 'data: {"type":"init"}\n\n',
+  },
+  ChallengeMessage: {
+    type: "object",
+    properties: {
+      message: {
+        type: "string",
+        example:
+          "Sign this message to authenticate with RemitLend.\n\nNonce: abc123\nTimestamp: 1700000000000\n\nThis request will expire in 5 minutes.",
+      },
+      nonce: { type: "string", example: "abc123def456" },
+      timestamp: { type: "integer", example: 1700000000000 },
+      expiresIn: { type: "integer", example: 300000 },
+    },
+    required: ["message", "nonce", "timestamp", "expiresIn"],
+  },
+  AuthChallengeResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/ChallengeMessage" },
+    },
+    required: ["success", "data"],
+  },
+  AuthLoginData: {
+    type: "object",
+    properties: {
+      token: { type: "string" },
+      publicKey: { type: "string" },
+    },
+    required: ["token", "publicKey"],
+  },
+  AuthLoginResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/AuthLoginData" },
+    },
+    required: ["success", "data"],
+  },
+  AuthVerifyData: {
+    type: "object",
+    properties: {
+      publicKey: { type: "string", nullable: true },
+      role: {
+        type: "string",
+        enum: ["admin", "borrower", "lender"],
+        nullable: true,
+      },
+      scopes: {
+        type: "array",
+        items: { type: "string" },
+      },
+      valid: { type: "boolean", example: true },
+    },
+    required: ["valid"],
+  },
+  AuthVerifyResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/AuthVerifyData" },
+    },
+    required: ["success", "data"],
+  },
+  BorrowerLoan: {
+    type: "object",
+    properties: {
+      loanId: { type: "integer" },
+      principal: { type: "number" },
+      accruedInterest: { type: "number" },
+      totalRepaid: { type: "number" },
+      totalOwed: { type: "number" },
+      nextPaymentDeadline: { type: "string", format: "date-time" },
+      status: {
+        type: "string",
+        enum: ["active", "repaid", "defaulted"],
+      },
+      borrower: { type: "string" },
+      approvedAt: { type: "string", format: "date-time", nullable: true },
+    },
+    required: [
+      "loanId",
+      "principal",
+      "accruedInterest",
+      "totalRepaid",
+      "totalOwed",
+      "nextPaymentDeadline",
+      "status",
+      "borrower",
+    ],
+  },
+  BorrowerLoansResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      borrower: { type: "string" },
+      loans: {
+        type: "array",
+        items: { $ref: "#/components/schemas/BorrowerLoan" },
+      },
+    },
+    required: ["success", "borrower", "loans"],
+  },
+  LoanSummaryEvent: {
+    type: "object",
+    properties: {
+      type: { type: "string" },
+      amount: { type: "string", nullable: true },
+      timestamp: { type: "string", format: "date-time", nullable: true },
+      tx: { type: "string", nullable: true },
+    },
+    required: ["type"],
+  },
+  LoanDetailsSummary: {
+    type: "object",
+    properties: {
+      principal: { type: "number" },
+      accruedInterest: { type: "number" },
+      totalRepaid: { type: "number" },
+      totalOwed: { type: "number" },
+      interestRate: { type: "number" },
+      termLedgers: { type: "integer" },
+      elapsedLedgers: { type: "integer" },
+      status: {
+        type: "string",
+        enum: ["active", "repaid", "defaulted"],
+      },
+      requestedAt: { type: "string", format: "date-time", nullable: true },
+      approvedAt: { type: "string", format: "date-time", nullable: true },
+      events: {
+        type: "array",
+        items: { $ref: "#/components/schemas/LoanSummaryEvent" },
+      },
+    },
+    required: [
+      "principal",
+      "accruedInterest",
+      "totalRepaid",
+      "totalOwed",
+      "interestRate",
+      "termLedgers",
+      "elapsedLedgers",
+      "status",
+      "events",
+    ],
+  },
+  LoanDetailsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      loanId: { type: "string" },
+      summary: { $ref: "#/components/schemas/LoanDetailsSummary" },
+    },
+    required: ["success", "loanId", "summary"],
+  },
+  UnsignedTransactionResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      unsignedTxXdr: { type: "string" },
+      networkPassphrase: { type: "string" },
+    },
+    required: ["success", "unsignedTxXdr", "networkPassphrase"],
+  },
+  RepayTransactionResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      loanId: { type: "integer" },
+      unsignedTxXdr: { type: "string" },
+      networkPassphrase: { type: "string" },
+    },
+    required: ["success", "loanId", "unsignedTxXdr", "networkPassphrase"],
+  },
+  SubmittedTransactionResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      txHash: { type: "string" },
+      status: { type: "string" },
+      resultXdr: { type: "string" },
+    },
+    required: ["success", "txHash", "status"],
+  },
+  PoolStats: {
+    type: "object",
+    properties: {
+      totalDeposits: { type: "number" },
+      totalOutstanding: { type: "number" },
+      utilizationRate: { type: "number" },
+      apy: { type: "number" },
+      activeLoansCount: { type: "integer" },
+    },
+    required: [
+      "totalDeposits",
+      "totalOutstanding",
+      "utilizationRate",
+      "apy",
+      "activeLoansCount",
+    ],
+  },
+  PoolStatsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/PoolStats" },
+    },
+    required: ["success", "data"],
+  },
+  DepositorPortfolio: {
+    type: "object",
+    properties: {
+      address: { type: "string" },
+      depositAmount: { type: "number" },
+      sharePercent: { type: "number" },
+      estimatedYield: { type: "number" },
+      apy: { type: "number" },
+      firstDepositAt: { type: "string", format: "date-time", nullable: true },
+    },
+    required: [
+      "address",
+      "depositAmount",
+      "sharePercent",
+      "estimatedYield",
+      "apy",
+    ],
+  },
+  DepositorPortfolioResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/DepositorPortfolio" },
+    },
+    required: ["success", "data"],
+  },
+  UserScoreFactors: {
+    type: "object",
+    properties: {
+      repaymentHistory: { type: "string" },
+      latePaymentPenalty: { type: "string" },
+      range: { type: "string" },
+    },
+    required: ["repaymentHistory", "latePaymentPenalty", "range"],
+  },
+  UserScore: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      userId: { type: "string" },
+      score: { type: "integer", example: 700 },
+      band: {
+        type: "string",
+        enum: ["Excellent", "Good", "Fair", "Poor"],
+      },
+      factors: { $ref: "#/components/schemas/UserScoreFactors" },
+    },
+    required: ["success", "userId", "score", "band", "factors"],
+  },
+  ScoreUpdateResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      userId: { type: "string" },
+      repaymentAmount: { type: "number" },
+      onTime: { type: "boolean" },
+      oldScore: { type: "integer" },
+      delta: { type: "integer" },
+      newScore: { type: "integer" },
+      band: {
+        type: "string",
+        enum: ["Excellent", "Good", "Fair", "Poor"],
+      },
+    },
+    required: [
+      "success",
+      "userId",
+      "repaymentAmount",
+      "onTime",
+      "oldScore",
+      "delta",
+      "newScore",
+      "band",
+    ],
+  },
+  ScoreBreakdownMetrics: {
+    type: "object",
+    properties: {
+      totalLoans: { type: "integer" },
+      repaidOnTime: { type: "integer" },
+      repaidLate: { type: "integer" },
+      defaulted: { type: "integer" },
+      totalRepaid: { type: "number" },
+      averageRepaymentTime: { type: "string" },
+      longestStreak: { type: "integer" },
+      currentStreak: { type: "integer" },
+    },
+    required: [
+      "totalLoans",
+      "repaidOnTime",
+      "repaidLate",
+      "defaulted",
+      "totalRepaid",
+      "averageRepaymentTime",
+      "longestStreak",
+      "currentStreak",
+    ],
+  },
+  ScoreHistoryEntry: {
+    type: "object",
+    properties: {
+      date: { type: "string", nullable: true },
+      score: { type: "integer" },
+      event: { type: "string" },
+    },
+    required: ["date", "score", "event"],
+  },
+  ScoreBreakdownResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      userId: { type: "string" },
+      score: { type: "integer" },
+      band: {
+        type: "string",
+        enum: ["Excellent", "Good", "Fair", "Poor"],
+      },
+      breakdown: { $ref: "#/components/schemas/ScoreBreakdownMetrics" },
+      history: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ScoreHistoryEntry" },
+      },
+    },
+    required: ["success", "userId", "score", "band", "breakdown", "history"],
+  },
+  RemittanceHistoryEntry: {
+    type: "object",
+    properties: {
+      month: { type: "string" },
+      amount: { type: "number" },
+      status: { type: "string", enum: ["Completed", "Defaulted"] },
+    },
+    required: ["month", "amount", "status"],
+  },
+  RemittanceHistory: {
+    type: "object",
+    properties: {
+      userId: { type: "string" },
+      score: { type: "integer" },
+      streak: { type: "integer" },
+      history: {
+        type: "array",
+        items: { $ref: "#/components/schemas/RemittanceHistoryEntry" },
+      },
+    },
+    required: ["userId", "score", "streak", "history"],
+  },
+  SimulatePaymentResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      message: { type: "string" },
+      newScore: { type: "integer" },
+    },
+    required: ["success", "message", "newScore"],
+  },
+  Notification: {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      userId: { type: "string" },
+      type: {
+        type: "string",
+        enum: [
+          "loan_approved",
+          "repayment_due",
+          "repayment_confirmed",
+          "loan_defaulted",
+          "score_changed",
+        ],
+      },
+      title: { type: "string" },
+      message: { type: "string" },
+      loanId: { type: "integer" },
+      read: { type: "boolean" },
+      createdAt: { type: "string", format: "date-time" },
+    },
+    required: ["id", "userId", "type", "title", "message", "read", "createdAt"],
+  },
+  NotificationsData: {
+    type: "object",
+    properties: {
+      notifications: {
+        type: "array",
+        items: { $ref: "#/components/schemas/Notification" },
+      },
+      unreadCount: { type: "integer" },
+    },
+    required: ["notifications", "unreadCount"],
+  },
+  NotificationsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/NotificationsData" },
+    },
+    required: ["success", "data"],
+  },
+  EventConnectionCounts: {
+    type: "object",
+    properties: {
+      borrower: { type: "integer" },
+      admin: { type: "integer" },
+      total: { type: "integer" },
+    },
+    required: ["borrower", "admin", "total"],
+  },
+  EventStreamStatusResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/EventConnectionCounts" },
+    },
+    required: ["success", "data"],
+  },
+  LoanEventRecord: {
+    type: "object",
+    properties: {
+      eventId: { type: "string" },
+      eventType: {
+        type: "string",
+        enum: [
+          "LoanRequested",
+          "LoanApproved",
+          "LoanRepaid",
+          "LoanDefaulted",
+          "Seized",
+          "Paused",
+          "Unpaused",
+          "MinScoreUpdated",
+        ],
+      },
+      loanId: { type: "integer" },
+      borrower: { type: "string" },
+      amount: { type: "string" },
+      ledger: { type: "integer" },
+      ledgerClosedAt: { type: "string", format: "date-time" },
+      txHash: { type: "string" },
+      createdAt: { type: "string", format: "date-time" },
+      interestRateBps: { type: "integer" },
+      termLedgers: { type: "integer" },
+      contractId: { type: "string" },
+      topics: {
+        type: "array",
+        items: { type: "string" },
+      },
+      value: { type: "string" },
+    },
+    required: [
+      "eventId",
+      "eventType",
+      "borrower",
+      "ledger",
+      "ledgerClosedAt",
+      "txHash",
+    ],
+  },
+  Pagination: {
+    type: "object",
+    properties: {
+      total: { type: "integer" },
+      limit: { type: "integer" },
+      offset: { type: "integer" },
+    },
+    required: ["total", "limit", "offset"],
+  },
+  BorrowerEventsData: {
+    type: "object",
+    properties: {
+      events: {
+        type: "array",
+        items: { $ref: "#/components/schemas/LoanEventRecord" },
+      },
+      pagination: { $ref: "#/components/schemas/Pagination" },
+    },
+    required: ["events", "pagination"],
+  },
+  BorrowerEventsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/BorrowerEventsData" },
+    },
+    required: ["success", "data"],
+  },
+  LoanEventsData: {
+    type: "object",
+    properties: {
+      loanId: { type: "integer" },
+      events: {
+        type: "array",
+        items: { $ref: "#/components/schemas/LoanEventRecord" },
+      },
+    },
+    required: ["loanId", "events"],
+  },
+  LoanEventsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/LoanEventsData" },
+    },
+    required: ["success", "data"],
+  },
+  RecentEventsData: {
+    type: "object",
+    properties: {
+      events: {
+        type: "array",
+        items: { $ref: "#/components/schemas/LoanEventRecord" },
+      },
+    },
+    required: ["events"],
+  },
+  RecentEventsResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/RecentEventsData" },
+    },
+    required: ["success", "data"],
+  },
+  IndexerStatusData: {
+    type: "object",
+    properties: {
+      lastIndexedLedger: { type: "integer" },
+      lastIndexedCursor: { type: "string", nullable: true },
+      lastUpdated: { type: "string", format: "date-time" },
+      totalEvents: { type: "integer" },
+      eventsByType: {
+        type: "object",
+        additionalProperties: { type: "integer" },
+      },
+    },
+    required: [
+      "lastIndexedLedger",
+      "lastIndexedCursor",
+      "lastUpdated",
+      "totalEvents",
+      "eventsByType",
+    ],
+  },
+  IndexerStatusResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/IndexerStatusData" },
+    },
+    required: ["success", "data"],
+  },
+  WebhookSubscription: {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      callbackUrl: { type: "string", format: "uri" },
+      eventTypes: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "LoanRequested",
+            "LoanApproved",
+            "LoanRepaid",
+            "LoanDefaulted",
+            "Seized",
+            "Paused",
+            "Unpaused",
+            "MinScoreUpdated",
+          ],
+        },
+      },
+      secret: { type: "string" },
+      isActive: { type: "boolean" },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+    required: [
+      "id",
+      "callbackUrl",
+      "eventTypes",
+      "isActive",
+      "createdAt",
+      "updatedAt",
+    ],
+  },
+  WebhookSubscriptionListData: {
+    type: "object",
+    properties: {
+      subscriptions: {
+        type: "array",
+        items: { $ref: "#/components/schemas/WebhookSubscription" },
+      },
+    },
+    required: ["subscriptions"],
+  },
+  WebhookSubscriptionListResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/WebhookSubscriptionListData" },
+    },
+    required: ["success", "data"],
+  },
+  WebhookSubscriptionData: {
+    type: "object",
+    properties: {
+      subscription: { $ref: "#/components/schemas/WebhookSubscription" },
+    },
+    required: ["subscription"],
+  },
+  WebhookSubscriptionResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/WebhookSubscriptionData" },
+    },
+    required: ["success", "data"],
+  },
+  WebhookDelivery: {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      subscriptionId: { type: "integer" },
+      eventId: { type: "string" },
+      eventType: {
+        type: "string",
+        enum: [
+          "LoanRequested",
+          "LoanApproved",
+          "LoanRepaid",
+          "LoanDefaulted",
+          "Seized",
+          "Paused",
+          "Unpaused",
+          "MinScoreUpdated",
+        ],
+      },
+      attemptCount: { type: "integer" },
+      lastStatusCode: { type: "integer" },
+      lastError: { type: "string" },
+      deliveredAt: { type: "string", format: "date-time" },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+    required: [
+      "id",
+      "subscriptionId",
+      "eventId",
+      "eventType",
+      "attemptCount",
+      "createdAt",
+      "updatedAt",
+    ],
+  },
+  WebhookDeliveriesData: {
+    type: "object",
+    properties: {
+      subscriptionId: { type: "integer" },
+      deliveries: {
+        type: "array",
+        items: { $ref: "#/components/schemas/WebhookDelivery" },
+      },
+    },
+    required: ["subscriptionId", "deliveries"],
+  },
+  WebhookDeliveriesResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/WebhookDeliveriesData" },
+    },
+    required: ["success", "data"],
+  },
+  ReindexResult: {
+    type: "object",
+    properties: {
+      fromLedger: { type: "integer" },
+      toLedger: { type: "integer" },
+      fetchedEvents: { type: "integer" },
+      insertedEvents: { type: "integer" },
+      lastProcessedLedger: { type: "integer" },
+    },
+    required: [
+      "fromLedger",
+      "toLedger",
+      "fetchedEvents",
+      "insertedEvents",
+      "lastProcessedLedger",
+    ],
+  },
+  ReindexResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/ReindexResult" },
+    },
+    required: ["success", "data"],
+  },
+  DefaultCheckBatchResult: {
+    type: "object",
+    properties: {
+      loanIds: {
+        type: "array",
+        items: { type: "integer" },
+      },
+      txHash: { type: "string" },
+      submitStatus: { type: "string" },
+      txStatus: { type: "string" },
+      error: { type: "string" },
+    },
+    required: ["loanIds"],
+  },
+  DefaultCheckRunResult: {
+    type: "object",
+    properties: {
+      runId: { type: "string" },
+      currentLedger: { type: "integer" },
+      termLedgers: { type: "integer" },
+      overdueCount: { type: "integer" },
+      oldestDueLedger: { type: "integer" },
+      ledgersPastOldestDue: { type: "integer" },
+      batches: {
+        type: "array",
+        items: { $ref: "#/components/schemas/DefaultCheckBatchResult" },
+      },
+    },
+    required: [
+      "runId",
+      "currentLedger",
+      "termLedgers",
+      "overdueCount",
+      "batches",
+    ],
+  },
+  DefaultCheckResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: true },
+      data: { $ref: "#/components/schemas/DefaultCheckRunResult" },
+    },
+    required: ["success", "data"],
+  },
+} as const;

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -45,6 +45,10 @@ const checkDefaultsBodySchema = z.object({
  *     responses:
  *       200:
  *         description: Default check run completed (see batch errors in payload)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/DefaultCheckResponse'
  */
 router.post(
   "/check-defaults",
@@ -84,6 +88,10 @@ router.post(
  *     responses:
  *       200:
  *         description: Reindex completed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ReindexResponse'
  */
 router.post("/reindex", requireApiKey, strictRateLimiter, reindexLedgerRange);
 
@@ -114,6 +122,10 @@ router.post("/reindex", requireApiKey, strictRateLimiter, reindexLedgerRange);
  *     responses:
  *       201:
  *         description: Subscription created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebhookSubscriptionResponse'
  *   get:
  *     summary: List webhook subscriptions
  *     tags: [Admin]
@@ -122,8 +134,17 @@ router.post("/reindex", requireApiKey, strictRateLimiter, reindexLedgerRange);
  *     responses:
  *       200:
  *         description: List of subscriptions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebhookSubscriptionListResponse'
  */
-router.post("/webhooks", requireApiKey, strictRateLimiter, createWebhookSubscription);
+router.post(
+  "/webhooks",
+  requireApiKey,
+  strictRateLimiter,
+  createWebhookSubscription,
+);
 router.get("/webhooks", requireApiKey, listWebhookSubscriptions);
 
 /**
@@ -143,8 +164,17 @@ router.get("/webhooks", requireApiKey, listWebhookSubscriptions);
  *     responses:
  *       200:
  *         description: Subscription deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SuccessMessageResponse'
  */
-router.delete("/webhooks/:id", requireApiKey, strictRateLimiter, deleteWebhookSubscription);
+router.delete(
+  "/webhooks/:id",
+  requireApiKey,
+  strictRateLimiter,
+  deleteWebhookSubscription,
+);
 
 /**
  * @swagger
@@ -169,6 +199,10 @@ router.delete("/webhooks/:id", requireApiKey, strictRateLimiter, deleteWebhookSu
  *     responses:
  *       200:
  *         description: Delivery history returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebhookDeliveriesResponse'
  */
 router.get("/webhooks/:id/deliveries", requireApiKey, getWebhookDeliveries);
 

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -45,6 +45,10 @@ const loginSchema = z.object({
  *     responses:
  *       200:
  *         description: Challenge payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthChallengeResponse'
  */
 router.post(
   "/challenge",
@@ -78,6 +82,10 @@ router.post(
  *     responses:
  *       200:
  *         description: JWT issued
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthLoginResponse'
  */
 router.post("/login", verifyRateLimiter, validateBody(loginSchema), login);
 
@@ -92,6 +100,10 @@ router.post("/login", verifyRateLimiter, validateBody(loginSchema), login);
  *     responses:
  *       200:
  *         description: Token valid
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthVerifyResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  */

--- a/backend/src/routes/eventRoutes.ts
+++ b/backend/src/routes/eventRoutes.ts
@@ -42,6 +42,10 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Server-Sent Events stream (text/event-stream)
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/ServerSentEventStream'
  *       401:
  *         description: Missing or invalid authentication
  */
@@ -63,19 +67,7 @@ router.get("/stream", requireJwtAuth, streamEvents);
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: object
- *                   properties:
- *                     borrower:
- *                       type: integer
- *                     admin:
- *                       type: integer
- *                     total:
- *                       type: integer
+ *               $ref: '#/components/schemas/EventStreamStatusResponse'
  *       401:
  *         description: Missing or invalid API key
  */

--- a/backend/src/routes/indexerRoutes.ts
+++ b/backend/src/routes/indexerRoutes.ts
@@ -31,24 +31,7 @@ const router = Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: object
- *                   properties:
- *                     lastIndexedLedger:
- *                       type: integer
- *                     lastIndexedCursor:
- *                       type: string
- *                     lastUpdated:
- *                       type: string
- *                       format: date-time
- *                     totalEvents:
- *                       type: integer
- *                     eventsByType:
- *                       type: object
+ *               $ref: '#/components/schemas/IndexerStatusResponse'
  */
 router.get("/status", getIndexerStatus);
 
@@ -83,6 +66,10 @@ router.get("/status", getIndexerStatus);
  *     responses:
  *       200:
  *         description: Events retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BorrowerEventsResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  *       403:
@@ -116,6 +103,10 @@ router.get(
  *     responses:
  *       200:
  *         description: Events retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/LoanEventsResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  *       404:
@@ -154,6 +145,10 @@ router.get(
  *     responses:
  *       200:
  *         description: Events retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RecentEventsResponse'
  *       401:
  *         description: Missing or invalid API key
  */
@@ -170,6 +165,10 @@ router.get("/events/recent", requireApiKey, getRecentEvents);
  *     responses:
  *       200:
  *         description: Webhook subscriptions retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebhookSubscriptionListResponse'
  *       401:
  *         description: Missing or invalid API key
  *   post:
@@ -197,6 +196,10 @@ router.get("/events/recent", requireApiKey, getRecentEvents);
  *     responses:
  *       201:
  *         description: Webhook subscription created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebhookSubscriptionResponse'
  *       401:
  *         description: Missing or invalid API key
  */
@@ -220,6 +223,10 @@ router.post("/webhooks", requireApiKey, createWebhookSubscription);
  *     responses:
  *       200:
  *         description: Webhook subscription deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SuccessMessageResponse'
  *       401:
  *         description: Missing or invalid API key
  */

--- a/backend/src/routes/loanRoutes.ts
+++ b/backend/src/routes/loanRoutes.ts
@@ -44,6 +44,10 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Loans retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BorrowerLoansResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  *       403:
@@ -79,6 +83,10 @@ router.get(
  *     responses:
  *       200:
  *         description: Loan details retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/LoanDetailsResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  *       404:
@@ -126,14 +134,7 @@ router.get(
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 unsignedTxXdr:
- *                   type: string
- *                 networkPassphrase:
- *                   type: string
+ *               $ref: '#/components/schemas/UnsignedTransactionResponse'
  *       400:
  *         description: Validation error
  *       401:
@@ -169,14 +170,7 @@ router.post("/request", requireJwtAuth, requestLoan);
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 txHash:
- *                   type: string
- *                 status:
- *                   type: string
+ *               $ref: '#/components/schemas/SubmittedTransactionResponse'
  *       400:
  *         description: Validation error
  *       401:
@@ -226,16 +220,7 @@ router.post("/submit", requireJwtAuth, submitTransaction);
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 loanId:
- *                   type: integer
- *                 unsignedTxXdr:
- *                   type: string
- *                 networkPassphrase:
- *                   type: string
+ *               $ref: '#/components/schemas/RepayTransactionResponse'
  *       400:
  *         description: Validation error
  *       401:
@@ -282,6 +267,10 @@ router.post(
  *     responses:
  *       200:
  *         description: Transaction submitted and result returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SubmittedTransactionResponse'
  *       400:
  *         description: Validation error
  *       401:

--- a/backend/src/routes/notificationsRoutes.ts
+++ b/backend/src/routes/notificationsRoutes.ts
@@ -16,7 +16,7 @@ const router = Router();
  *     summary: Get notifications for the authenticated user
  *     tags: [Notifications]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - in: query
  *         name: limit
@@ -30,19 +30,14 @@ const router = Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: object
- *                   properties:
- *                     notifications:
- *                       type: array
- *                     unreadCount:
- *                       type: integer
+ *               $ref: '#/components/schemas/NotificationsResponse'
  */
-router.get("/", requireJwtAuth, requireScopes("read:notifications"), getNotifications);
+router.get(
+  "/",
+  requireJwtAuth,
+  requireScopes("read:notifications"),
+  getNotifications,
+);
 
 /**
  * @swagger
@@ -51,10 +46,14 @@ router.get("/", requireJwtAuth, requireScopes("read:notifications"), getNotifica
  *     summary: SSE stream for real-time notification push
  *     tags: [Notifications]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Server-Sent Events stream (text/event-stream)
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/ServerSentEventStream'
  */
 router.get(
   "/stream",
@@ -70,7 +69,7 @@ router.get(
  *     summary: Mark specific notifications as read
  *     tags: [Notifications]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -85,6 +84,10 @@ router.get(
  *     responses:
  *       200:
  *         description: Notifications marked as read
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleSuccessResponse'
  */
 router.post(
   "/mark-read",
@@ -100,10 +103,14 @@ router.post(
  *     summary: Mark all notifications as read
  *     tags: [Notifications]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: All notifications marked as read
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleSuccessResponse'
  */
 router.post(
   "/mark-all-read",

--- a/backend/src/routes/poolRoutes.ts
+++ b/backend/src/routes/poolRoutes.ts
@@ -31,27 +31,17 @@ const router = Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 data:
- *                   type: object
- *                   properties:
- *                     totalDeposits:
- *                       type: number
- *                     totalOutstanding:
- *                       type: number
- *                     utilizationRate:
- *                       type: number
- *                     apy:
- *                       type: number
- *                     activeLoansCount:
- *                       type: integer
+ *               $ref: '#/components/schemas/PoolStatsResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  */
-router.get("/stats", requireJwtAuth, requireLender, requireScopes("read:pool"), getPoolStats);
+router.get(
+  "/stats",
+  requireJwtAuth,
+  requireLender,
+  requireScopes("read:pool"),
+  getPoolStats,
+);
 
 /**
  * @swagger
@@ -74,6 +64,10 @@ router.get("/stats", requireJwtAuth, requireLender, requireScopes("read:pool"), 
  *     responses:
  *       200:
  *         description: Depositor portfolio retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/DepositorPortfolioResponse'
  *       401:
  *         description: Missing or invalid Bearer token
  *       403:

--- a/backend/src/routes/scoreRoutes.ts
+++ b/backend/src/routes/scoreRoutes.ts
@@ -87,47 +87,7 @@ router.get(
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                 userId:
- *                   type: string
- *                 score:
- *                   type: integer
- *                 band:
- *                   type: string
- *                 breakdown:
- *                   type: object
- *                   properties:
- *                     totalLoans:
- *                       type: integer
- *                     repaidOnTime:
- *                       type: integer
- *                     repaidLate:
- *                       type: integer
- *                     defaulted:
- *                       type: integer
- *                     totalRepaid:
- *                       type: number
- *                     averageRepaymentTime:
- *                       type: string
- *                     longestStreak:
- *                       type: integer
- *                     currentStreak:
- *                       type: integer
- *                 history:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       date:
- *                         type: string
- *                         format: date
- *                       score:
- *                         type: integer
- *                       event:
- *                         type: string
+ *               $ref: '#/components/schemas/ScoreBreakdownResponse'
  *       401:
  *         description: Missing or invalid Bearer token.
  *       403:
@@ -178,7 +138,7 @@ router.get(
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/UserScore'
+ *               $ref: '#/components/schemas/ScoreUpdateResponse'
  *       400:
  *         description: Validation error.
  *         content:

--- a/backend/src/routes/simulationRoutes.ts
+++ b/backend/src/routes/simulationRoutes.ts
@@ -75,7 +75,7 @@ router.get(
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/UserScore'
+ *               $ref: '#/components/schemas/SimulatePaymentResponse'
  *       400:
  *         description: Invalid input data.
  *         content:


### PR DESCRIPTION
## Summary
- add shared OpenAPI component schemas for backend success and error responses
- wire concrete `200`/`201` response bodies into the documented auth, loan, pool, score, simulation, notification, event, indexer, and admin endpoints
- keep the spec frontend-friendly so generated TypeScript clients can infer concrete response types instead of `Success` placeholders

## Verification
- `npm.cmd install`
- `npx.cmd tsx` import of `src/config/swagger.ts` confirmed `missingSuccessSchemas: []`
- `npx.cmd prettier --check src/config/swagger.ts src/config/swaggerSchemas.ts src/routes/authRoutes.ts src/routes/loanRoutes.ts src/routes/poolRoutes.ts src/routes/scoreRoutes.ts src/routes/simulationRoutes.ts src/routes/notificationsRoutes.ts src/routes/eventRoutes.ts src/routes/indexerRoutes.ts src/routes/adminRoutes.ts`
- `npm.cmd run build` currently fails on a pre-existing unrelated test typing error in `src/__tests__/eventStream.test.ts:128` (`Object is possibly 'undefined'`)

Closes #231
