### PR TITLE
Fix burn cleanup for transfer cooldown

### DIFF
--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -264,6 +264,9 @@ impl RemittanceNFT {
         env.storage()
             .persistent()
             .remove(&DataKey::RemintApproval(user.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::TransferCooldown(user.clone()));
 
         let burned_key = DataKey::Burned(user.clone());
         env.storage().persistent().set(&burned_key, &true);


### PR DESCRIPTION
closes #296  

## Summary

  This PR fixes a state cleanup gap in burn_internal() for the
  remittance_nft contract.

  Previously, burning a user removed metadata, score, score history,
  seized state, and remint approval, but left TransferCooldown
  behind. That stale cooldown could cause unexpected behavior after a
  remint by making the wallet still appear occupied or remain subject
  to an old transfer restriction.

  This change:

  - Removes DataKey::TransferCooldown(user.clone()) during
    burn_internal()
  - Adds a regression test covering the flow where a user receives a
    transferred NFT, is burned, remints, and can transfer again
    without inheriting the old cooldown

  ## Why it matters

  A burn should fully clear user-specific remittance state except for
  the explicit burned marker. Leaving TransferCooldown behind made
  post-burn/remint behavior inconsistent with that expectation.