### PR TITLE
Fix theme persistence on reload

### DIFF
--- a/frontend/src/app/components/ui/ThemeToggle.tsx
+++ b/frontend/src/app/components/ui/ThemeToggle.tsx
@@ -1,73 +1,39 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Sun, Moon, Monitor } from "lucide-react";
-
-type Theme = "light" | "dark" | "system";
-
-const STORAGE_KEY = "remitlend-theme";
-
-function getSystemTheme(): "light" | "dark" {
-  if (typeof window === "undefined") return "light";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function applyTheme(theme: Theme) {
-  const resolved = theme === "system" ? getSystemTheme() : theme;
-  const root = document.documentElement;
-  if (resolved === "dark") {
-    root.classList.add("dark");
-  } else {
-    root.classList.remove("dark");
-  }
-}
+import { useEffect } from "react";
+import { Sun, Moon } from "lucide-react";
+import { useThemeStore } from "../../stores/useThemeStore";
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>("system");
-  const [mounted, setMounted] = useState(false);
+  const theme = useThemeStore((state) => state.theme);
+  const hydrated = useThemeStore((state) => state.hydrated);
+  const initializeTheme = useThemeStore((state) => state.initializeTheme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    const initial = stored ?? "system";
-    setTheme(initial);
-    applyTheme(initial);
-    setMounted(true);
-  }, []);
-
-  // Listen for system theme changes when in system mode
-  useEffect(() => {
-    if (theme !== "system") return;
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = () => applyTheme("system");
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, [theme]);
-
-  const cycle = useCallback(() => {
-    const order: Theme[] = ["light", "dark", "system"];
-    const next = order[(order.indexOf(theme) + 1) % order.length];
-    setTheme(next);
-    localStorage.setItem(STORAGE_KEY, next);
-    applyTheme(next);
-  }, [theme]);
+    if (!hydrated) {
+      initializeTheme();
+    }
+  }, [hydrated, initializeTheme]);
 
   // Prevent hydration mismatch
-  if (!mounted) {
+  if (!hydrated) {
     return (
       <button className="p-2 text-zinc-500" aria-label="Toggle theme">
-        <Monitor className="h-5 w-5" />
+        <Sun className="h-5 w-5" />
       </button>
     );
   }
 
-  const Icon = theme === "light" ? Sun : theme === "dark" ? Moon : Monitor;
-  const label = theme === "light" ? "Light mode" : theme === "dark" ? "Dark mode" : "System theme";
+  const Icon = theme === "dark" ? Moon : Sun;
+  const label = theme === "dark" ? "Dark mode" : "Light mode";
+  const nextLabel = theme === "dark" ? "light" : "dark";
 
   return (
     <button
-      onClick={cycle}
+      onClick={toggleTheme}
       className="p-2 text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900 rounded-lg transition-colors"
-      aria-label={`${label} — click to change`}
+      aria-label={`${label} active, switch to ${nextLabel} mode`}
       aria-live="polite"
       title={label}
     >

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { LevelUpModal } from "./components/gamification/LevelUpModal";
 import { GlobalXPGain } from "./components/global_ui/GlobalXPGain";
 import { ErrorBoundary } from "./components/global_ui/ErrorBoundary";
 import { NextIntlClientProvider } from "next-intl";
+import { THEME_STORAGE_KEY } from "./lib/theme";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,7 +38,7 @@ export default async function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem("remitlend-theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})()`,
+            __html: `(function(){try{var root=document.documentElement;var stored=localStorage.getItem("${THEME_STORAGE_KEY}");var theme=stored==="dark"||stored==="light"?stored:(matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");root.dataset.theme=theme;root.classList.toggle("dark",theme==="dark")}catch(e){}})()`,
           }}
         />
       </head>

--- a/frontend/src/app/lib/theme.ts
+++ b/frontend/src/app/lib/theme.ts
@@ -1,0 +1,3 @@
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "remitlend-theme";

--- a/frontend/src/app/stores/index.ts
+++ b/frontend/src/app/stores/index.ts
@@ -57,3 +57,8 @@ export type {
   LevelUpReward,
   GamificationStore,
 } from "./useGamificationStore";
+
+export { useThemeStore, selectTheme, selectThemeHydrated } from "./useThemeStore";
+export { THEME_STORAGE_KEY } from "../lib/theme";
+export type { ThemeStore } from "./useThemeStore";
+export type { Theme } from "../lib/theme";

--- a/frontend/src/app/stores/stores.test.ts
+++ b/frontend/src/app/stores/stores.test.ts
@@ -8,6 +8,8 @@
 import { useUserStore } from "./useUserStore";
 import { useWalletStore } from "./useWalletStore";
 import { useUIStore } from "./useUIStore";
+import { THEME_STORAGE_KEY } from "../lib/theme";
+import { useThemeStore } from "./useThemeStore";
 import type { ModalId } from "./useUIStore";
 
 // Reset store state between tests
@@ -27,6 +29,13 @@ beforeEach(() => {
     isGlobalLoading: false,
     globalLoadingMessage: null,
   }));
+  useThemeStore.setState({
+    theme: "light",
+    hydrated: false,
+  });
+  window.localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  delete document.documentElement.dataset.theme;
 });
 
 // ─── useUserStore ────────────────────────────────────────────────────────────
@@ -199,5 +208,56 @@ describe("useUIStore", () => {
     useUIStore.getState().hideGlobalLoading();
     expect(useUIStore.getState().isGlobalLoading).toBe(false);
     expect(useUIStore.getState().globalLoadingMessage).toBeNull();
+  });
+});
+
+// ─── useThemeStore ───────────────────────────────────────────────────────────
+
+describe("useThemeStore", () => {
+  it("uses the system preference on first visit when nothing is stored", () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    useThemeStore.getState().initializeTheme();
+
+    const { theme, hydrated } = useThemeStore.getState();
+    expect(theme).toBe("dark");
+    expect(hydrated).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+  });
+
+  it("persists an explicit theme selection and applies it to the document", () => {
+    useThemeStore.getState().setTheme("dark");
+
+    const { theme, hydrated } = useThemeStore.getState();
+    expect(theme).toBe("dark");
+    expect(hydrated).toBe(true);
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("toggles between light and dark themes", () => {
+    useThemeStore.setState({ theme: "dark", hydrated: true });
+    document.documentElement.classList.add("dark");
+
+    useThemeStore.getState().toggleTheme();
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });

--- a/frontend/src/app/stores/useThemeStore.ts
+++ b/frontend/src/app/stores/useThemeStore.ts
@@ -1,0 +1,106 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { THEME_STORAGE_KEY, type Theme } from "../lib/theme";
+
+interface ThemeState {
+  theme: Theme;
+  hydrated: boolean;
+}
+
+interface ThemeActions {
+  initializeTheme: () => void;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export type ThemeStore = ThemeState & ThemeActions;
+
+let hasAttachedSystemThemeListener = false;
+
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return storedTheme === "dark" || storedTheme === "light" ? storedTheme : null;
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.classList.toggle("dark", theme === "dark");
+}
+
+function resolveInitialTheme(): Theme {
+  if (typeof document !== "undefined") {
+    const presetTheme = document.documentElement.dataset.theme;
+    if (presetTheme === "dark" || presetTheme === "light") {
+      return presetTheme;
+    }
+  }
+
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+export const useThemeStore = create<ThemeStore>()(
+  devtools(
+    (set, get) => ({
+      theme: "light",
+      hydrated: false,
+
+      initializeTheme: () => {
+        const theme = resolveInitialTheme();
+        applyTheme(theme);
+        set({ theme, hydrated: true }, false, "theme/initializeTheme");
+
+        if (typeof window === "undefined" || hasAttachedSystemThemeListener) {
+          return;
+        }
+
+        hasAttachedSystemThemeListener = true;
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        const handleSystemThemeChange = () => {
+          if (getStoredTheme() !== null) {
+            return;
+          }
+
+          const nextTheme = mediaQuery.matches ? "dark" : "light";
+          applyTheme(nextTheme);
+          set({ theme: nextTheme }, false, "theme/syncSystemTheme");
+        };
+
+        mediaQuery.addEventListener("change", handleSystemThemeChange);
+      },
+
+      setTheme: (theme) => {
+        applyTheme(theme);
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+        }
+        set({ theme, hydrated: true }, false, "theme/setTheme");
+      },
+
+      toggleTheme: () => {
+        const nextTheme = get().theme === "dark" ? "light" : "dark";
+        get().setTheme(nextTheme);
+      },
+    }),
+    { name: "ThemeStore" },
+  ),
+);
+
+export const selectTheme = (state: ThemeStore) => state.theme;
+export const selectThemeHydrated = (state: ThemeStore) => state.hydrated;


### PR DESCRIPTION
## Summary
- add a shared theme store for persistent light/dark selection
- preload the resolved theme before hydration to avoid a flash on reload
- update the toggle and tests to use the shared persistence flow

## Testing
- `git diff --check`
- frontend Jest/Prettier checks not run because `node_modules` are not installed in this workspace

Closes #380 
