### PR TITLE
API: Implement standard pagination and filtering #148

### DIFF
--- a/backend/src/__tests__/paginationFiltering.test.ts
+++ b/backend/src/__tests__/paginationFiltering.test.ts
@@ -1,0 +1,222 @@
+import request from "supertest";
+import { jest } from "@jest/globals";
+import { Keypair } from "@stellar/stellar-sdk";
+import { generateJwtToken } from "../services/authService.js";
+
+type MockQueryResult = { rows: unknown[]; rowCount?: number };
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-jwt-secret-min-32-chars-long!!";
+process.env.INTERNAL_API_KEY = "test-internal-key";
+
+const mockQuery: jest.MockedFunction<
+  (text: string, params?: unknown[]) => Promise<MockQueryResult>
+> = jest.fn();
+const mockCacheGet = jest.fn<() => Promise<unknown | null>>().mockResolvedValue(null);
+const mockCacheSet = jest.fn<() => Promise<void>>().mockResolvedValue();
+
+jest.unstable_mockModule("../db/connection.js", () => ({
+  default: { query: mockQuery },
+  query: mockQuery,
+  getClient: jest.fn(),
+  closePool: jest.fn(),
+}));
+
+jest.unstable_mockModule("../services/cacheService.js", () => ({
+  cacheService: {
+    get: mockCacheGet,
+    set: mockCacheSet,
+    delete: jest.fn(),
+    invalidatePattern: jest.fn(),
+    ping: jest.fn().mockResolvedValue("ok"),
+    close: jest.fn(),
+  },
+}));
+
+await import("../db/connection.js");
+const { default: app } = await import("../app.js");
+
+const borrower = Keypair.random().publicKey();
+
+const authHeaders = () => ({
+  Authorization: `Bearer ${generateJwtToken(borrower)}`,
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  mockCacheGet.mockResolvedValue(null);
+  mockCacheSet.mockResolvedValue();
+});
+
+afterAll(() => {
+  delete process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+  delete process.env.INTERNAL_API_KEY;
+});
+
+describe("pagination and filtering", () => {
+  it("paginates and filters borrower loans with a consistent response envelope", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            loan_id: 1,
+            borrower,
+            principal: "100",
+            approved_at: "2024-02-01T00:00:00.000Z",
+            approved_ledger: 80,
+            rate_bps: 1200,
+            term_ledgers: 17280,
+            total_repaid: "0",
+            is_defaulted: "0",
+          },
+          {
+            loan_id: 2,
+            borrower,
+            principal: "200",
+            approved_at: "2024-02-10T00:00:00.000Z",
+            approved_ledger: 90,
+            rate_bps: 1200,
+            term_ledgers: 17280,
+            total_repaid: "0",
+            is_defaulted: "0",
+          },
+          {
+            loan_id: 3,
+            borrower,
+            principal: "250",
+            approved_at: "2024-02-20T00:00:00.000Z",
+            approved_ledger: 95,
+            rate_bps: 1200,
+            term_ledgers: 17280,
+            total_repaid: "0",
+            is_defaulted: "0",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ last_indexed_ledger: 100 }],
+      });
+
+    const response = await request(app)
+      .get(
+        `/api/loans/borrower/${borrower}?status=active&amount_range=150,300&date_range=2024-02-01,2024-03-01&sort=principal&limit=1&offset=1`,
+      )
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.total_count).toBe(2);
+    expect(response.body.page_info).toEqual({
+      limit: 1,
+      offset: 1,
+      count: 1,
+      has_previous: true,
+      has_next: false,
+    });
+    expect(response.body.data.borrower).toBe(borrower);
+    expect(response.body.data.loans).toHaveLength(1);
+    expect(response.body.data.loans[0].loanId).toBe(3);
+    expect(response.body.data.loans[0].principal).toBe(250);
+  });
+
+  it("applies event filters and returns page_info for borrower transaction history", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            event_id: "evt_2",
+            event_type: "LoanRepaid",
+            loan_id: 42,
+            borrower,
+            amount: "250",
+            ledger: 200,
+            ledger_closed_at: "2024-02-15T12:00:00.000Z",
+            tx_hash: "tx_2",
+            created_at: "2024-02-15T12:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ count: "3" }],
+      });
+
+    const response = await request(app)
+      .get(
+        `/api/indexer/events/borrower/${borrower}?status=LoanRepaid&amount_range=100,500&date_range=2024-02-01,2024-03-01&sort=amount&limit=1&offset=1`,
+      )
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.total_count).toBe(3);
+    expect(response.body.page_info).toEqual({
+      limit: 1,
+      offset: 1,
+      count: 1,
+      has_previous: true,
+      has_next: true,
+    });
+    expect(response.body.data.borrower).toBe(borrower);
+    expect(response.body.data.events[0].event_type).toBe("LoanRepaid");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[0]?.[0]).toContain("event_type = $2");
+    expect(mockQuery.mock.calls[0]?.[0]).toContain(
+      "CAST(amount AS NUMERIC) BETWEEN $3 AND $4",
+    );
+    expect(mockQuery.mock.calls[0]?.[0]).toContain(
+      "ledger_closed_at BETWEEN $5 AND $6",
+    );
+    expect(mockQuery.mock.calls[0]?.[0]).toContain("ORDER BY amount ASC");
+  });
+
+  it("supports paginated recent events for admin dashboards", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            event_id: "evt_9",
+            event_type: "LoanDefaulted",
+            loan_id: 77,
+            borrower,
+            amount: "900",
+            ledger: 400,
+            ledger_closed_at: "2024-03-02T09:00:00.000Z",
+            tx_hash: "tx_9",
+            created_at: "2024-03-02T09:00:00.000Z",
+          },
+          {
+            event_id: "evt_8",
+            event_type: "LoanDefaulted",
+            loan_id: 76,
+            borrower,
+            amount: "850",
+            ledger: 399,
+            ledger_closed_at: "2024-03-01T09:00:00.000Z",
+            tx_hash: "tx_8",
+            created_at: "2024-03-01T09:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ count: "5" }],
+      });
+
+    const response = await request(app)
+      .get("/api/indexer/events/recent?status=LoanDefaulted&limit=2&offset=1&sort=-amount")
+      .set("x-api-key", process.env.INTERNAL_API_KEY as string);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total_count).toBe(5);
+    expect(response.body.page_info).toEqual({
+      limit: 2,
+      offset: 1,
+      count: 2,
+      has_previous: true,
+      has_next: true,
+    });
+    expect(response.body.data.events).toHaveLength(2);
+    expect(mockQuery.mock.calls[0]?.[0]).toContain("ORDER BY amount DESC");
+  });
+});

--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -1,13 +1,86 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { query } from "../db/connection.js";
-import logger from "../utils/logger.js";
 import { EventIndexer } from "../services/eventIndexer.js";
+import { cacheService } from "../services/cacheService.js";
 import {
   SUPPORTED_WEBHOOK_EVENT_TYPES,
   webhookService,
   type WebhookEventType,
 } from "../services/webhookService.js";
-import { cacheService } from "../services/cacheService.js";
+import {
+  createPaginatedResponse,
+  getSortConfig,
+  parseQueryParams,
+} from "../utils/pagination.js";
+import logger from "../utils/logger.js";
+
+const EVENT_SORT_FIELDS = [
+  "event_type",
+  "amount",
+  "ledger",
+  "ledger_closed_at",
+] as const;
+
+const buildEventFilters = (
+  req: Request,
+  baseParams: unknown[],
+  initialWhereClause: string,
+) => {
+  const { status, dateRange, amountRange } = parseQueryParams(req);
+  const params = [...baseParams];
+  let whereClause = initialWhereClause;
+
+  const appendCondition = (condition: string) => {
+    whereClause += whereClause.includes("WHERE")
+      ? ` AND ${condition}`
+      : ` WHERE ${condition}`;
+  };
+
+  const requestedStatus =
+    status && status !== "all"
+      ? status
+      : typeof req.query.eventType === "string"
+        ? req.query.eventType
+        : null;
+
+  if (requestedStatus) {
+    params.push(requestedStatus);
+    appendCondition(`event_type = $${params.length}`);
+  }
+
+  if (amountRange) {
+    params.push(amountRange.min, amountRange.max);
+    appendCondition(
+      `CAST(amount AS NUMERIC) BETWEEN $${params.length - 1} AND $${params.length}`,
+    );
+  }
+
+  if (dateRange) {
+    params.push(dateRange.start.toISOString(), dateRange.end.toISOString());
+    appendCondition(
+      `ledger_closed_at BETWEEN $${params.length - 1} AND $${params.length}`,
+    );
+  }
+
+  return { params, whereClause };
+};
+
+const buildEventsCacheKey = (
+  scope: string,
+  resourceId: string | number,
+  req: Request,
+) =>
+  [
+    "events",
+    scope,
+    String(resourceId),
+    `limit:${req.query.limit ?? "default"}`,
+    `offset:${req.query.offset ?? "default"}`,
+    `sort:${req.query.sort ?? "default"}`,
+    `status:${req.query.status ?? req.query.eventType ?? "all"}`,
+    `date:${req.query.date_range ?? "all"}`,
+    `amount:${req.query.amount_range ?? "all"}`,
+  ].join(":");
 
 /**
  * Get indexer status
@@ -27,15 +100,12 @@ export const getIndexerStatus = async (req: Request, res: Response) => {
     }
 
     const state = result.rows[0];
-
-    // Get event counts
     const eventCounts = await query(
-      `SELECT event_type, COUNT(*) as count 
-       FROM loan_events 
+      `SELECT event_type, COUNT(*) as count
+       FROM loan_events
        GROUP BY event_type`,
       [],
     );
-
     const totalEvents = await query(
       "SELECT COUNT(*) as total FROM loan_events",
       [],
@@ -47,10 +117,10 @@ export const getIndexerStatus = async (req: Request, res: Response) => {
         lastIndexedLedger: state.last_indexed_ledger,
         lastIndexedCursor: state.last_indexed_cursor,
         lastUpdated: state.updated_at,
-        totalEvents: parseInt(totalEvents.rows[0].total),
+        totalEvents: Number.parseInt(totalEvents.rows[0].total, 10),
         eventsByType: eventCounts.rows.reduce(
           (acc, row) => {
-            acc[row.event_type] = parseInt(row.count);
+            acc[row.event_type] = Number.parseInt(row.count, 10);
             return acc;
           },
           {} as Record<string, number>,
@@ -72,49 +142,53 @@ export const getIndexerStatus = async (req: Request, res: Response) => {
 export const getBorrowerEvents = async (req: Request, res: Response) => {
   try {
     const { borrower } = req.params;
-    const { limit = 50, offset = 0 } = req.query;
-
-    const cacheKey = `events:borrower:${borrower}:limit:${limit}:offset:${offset}`;
+    const { limit, offset, sort } = parseQueryParams(req);
+    const cacheKey = buildEventsCacheKey("borrower", borrower, req);
     const cachedData = await cacheService.get(cacheKey);
 
     if (cachedData) {
-      res.json({
-        success: true,
-        data: cachedData,
-      });
+      res.json(cachedData);
       return;
     }
 
-    const result = await query(
-      `SELECT event_id, event_type, loan_id, borrower, amount, 
-              ledger, ledger_closed_at, tx_hash, created_at
-       FROM loan_events
-       WHERE borrower = $1
-       ORDER BY ledger DESC
-       LIMIT $2 OFFSET $3`,
-      [borrower, limit, offset],
+    const { params, whereClause } = buildEventFilters(req, [borrower], "WHERE borrower = $1");
+    const sortConfig = getSortConfig(
+      sort,
+      EVENT_SORT_FIELDS,
+      "ledger",
+      "DESC",
     );
 
-    const total = await query(
-      "SELECT COUNT(*) as count FROM loan_events WHERE borrower = $1",
-      [borrower],
-    );
+    const queryText = `
+      SELECT event_id, event_type, loan_id, borrower, amount,
+             ledger, ledger_closed_at, tx_hash, created_at
+      FROM loan_events
+      ${whereClause}
+      ORDER BY ${sortConfig.field} ${sortConfig.direction}
+      LIMIT $${params.length + 1} OFFSET $${params.length + 2}
+    `;
 
-    const data = {
-      events: result.rows,
-      pagination: {
-        total: parseInt(total.rows[0].count),
-        limit: parseInt(limit as string),
-        offset: parseInt(offset as string),
+    const [result, totalCount] = await Promise.all([
+      query(queryText, [...params, limit, offset]),
+      query(
+        `SELECT COUNT(*) as count FROM loan_events ${whereClause}`,
+        params,
+      ),
+    ]);
+
+    const response = createPaginatedResponse(
+      {
+        borrower,
+        events: result.rows,
       },
-    };
+      Number.parseInt(totalCount.rows[0].count, 10),
+      limit,
+      offset,
+      result.rows.length,
+    );
 
-    await cacheService.set(cacheKey, data, 300); // 5 minutes TTL
-
-    res.json({
-      success: true,
-      data,
-    });
+    await cacheService.set(cacheKey, response, 300);
+    res.json(response);
   } catch (error) {
     logger.error("Failed to get borrower events", { error });
     res.status(500).json({
@@ -130,6 +204,7 @@ export const getBorrowerEvents = async (req: Request, res: Response) => {
 export const getLoanEvents = async (req: Request, res: Response) => {
   try {
     const { loanId } = req.params;
+    const { limit, offset, sort } = parseQueryParams(req);
 
     if (!loanId) {
       return res.status(400).json({
@@ -138,37 +213,52 @@ export const getLoanEvents = async (req: Request, res: Response) => {
       });
     }
 
-    const cacheKey = `events:loan:${loanId}`;
+    const cacheKey = buildEventsCacheKey("loan", loanId, req);
     const cachedData = await cacheService.get(cacheKey);
 
     if (cachedData) {
-      res.json({
-        success: true,
-        data: cachedData,
-      });
+      res.json(cachedData);
       return;
     }
 
-    const result = await query(
-      `SELECT event_id, event_type, loan_id, borrower, amount, 
-              ledger, ledger_closed_at, tx_hash, created_at
-       FROM loan_events
-       WHERE loan_id = $1
-       ORDER BY ledger ASC`,
-      [loanId],
+    const { params, whereClause } = buildEventFilters(req, [loanId], "WHERE loan_id = $1");
+    const sortConfig = getSortConfig(
+      sort,
+      EVENT_SORT_FIELDS,
+      "ledger",
+      "ASC",
     );
 
-    const data = {
-      loanId: parseInt(loanId as string),
-      events: result.rows,
-    };
+    const queryText = `
+      SELECT event_id, event_type, loan_id, borrower, amount,
+             ledger, ledger_closed_at, tx_hash, created_at
+      FROM loan_events
+      ${whereClause}
+      ORDER BY ${sortConfig.field} ${sortConfig.direction}
+      LIMIT $${params.length + 1} OFFSET $${params.length + 2}
+    `;
 
-    await cacheService.set(cacheKey, data, 300); // 5 minutes TTL
+    const [result, totalCount] = await Promise.all([
+      query(queryText, [...params, limit, offset]),
+      query(
+        `SELECT COUNT(*) as count FROM loan_events ${whereClause}`,
+        params,
+      ),
+    ]);
 
-    res.json({
-      success: true,
-      data,
-    });
+    const response = createPaginatedResponse(
+      {
+        loanId: Number.parseInt(loanId, 10),
+        events: result.rows,
+      },
+      Number.parseInt(totalCount.rows[0].count, 10),
+      limit,
+      offset,
+      result.rows.length,
+    );
+
+    await cacheService.set(cacheKey, response, 300);
+    res.json(response);
   } catch (error) {
     logger.error("Failed to get loan events", { error });
     res.status(500).json({
@@ -183,47 +273,52 @@ export const getLoanEvents = async (req: Request, res: Response) => {
  */
 export const getRecentEvents = async (req: Request, res: Response) => {
   try {
-    const { limit = 20, eventType } = req.query;
-
-    const cacheKey = `events:recent:limit:${limit}:type:${eventType || "all"}`;
+    const { limit, offset, sort } = parseQueryParams(req);
+    const cacheKey = buildEventsCacheKey("recent", "all", req);
     const cachedData = await cacheService.get(cacheKey);
 
     if (cachedData) {
-      res.json({
-        success: true,
-        data: cachedData,
-      });
+      res.json(cachedData);
       return;
     }
 
-    let queryText = `
-      SELECT event_id, event_type, loan_id, borrower, amount, 
+    const { params, whereClause } = buildEventFilters(req, [], "");
+    const sortConfig = getSortConfig(
+      sort,
+      EVENT_SORT_FIELDS,
+      "ledger",
+      "DESC",
+    );
+
+    const queryText = `
+      SELECT event_id, event_type, loan_id, borrower, amount,
              ledger, ledger_closed_at, tx_hash, created_at
       FROM loan_events
+      ${whereClause}
+      ORDER BY ${sortConfig.field} ${sortConfig.direction}
+      LIMIT $${params.length + 1} OFFSET $${params.length + 2}
     `;
 
-    const params: unknown[] = [];
+    const [result, totalCount] = await Promise.all([
+      query(queryText, [...params, limit, offset]),
+      query(
+        `SELECT COUNT(*) as count FROM loan_events ${whereClause}`,
+        params,
+      ),
+    ]);
 
-    if (eventType) {
-      queryText += " WHERE event_type = $1";
-      params.push(eventType);
-    }
+    const response = createPaginatedResponse(
+      {
+        events: result.rows,
+      },
+      Number.parseInt(totalCount.rows[0].count, 10),
+      limit,
+      offset,
+      result.rows.length,
+    );
 
-    queryText += ` ORDER BY ledger DESC LIMIT $${params.length + 1}`;
-    params.push(limit);
-
-    const result = await query(queryText, params);
-
-    const data = {
-      events: result.rows,
-    };
-
-    await cacheService.set(cacheKey, data, 120); // 2 minutes TTL for recent events
-
-    res.json({
-      success: true,
-      data,
-    });
+    await cacheService.set(cacheKey, response, 120);
+    res.json(response);
   } catch (error) {
     logger.error("Failed to get recent events", { error });
     res.status(500).json({

--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -1,20 +1,70 @@
 import type { Request, Response } from "express";
-import { asyncHandler } from "../middleware/asyncHandler.js";
 import { query } from "../db/connection.js";
-import logger from "../utils/logger.js";
 import { AppError } from "../errors/AppError.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 import { sorobanService } from "../services/sorobanService.js";
+import {
+  createPaginatedResponse,
+  getSortConfig,
+  parseQueryParams,
+} from "../utils/pagination.js";
+import logger from "../utils/logger.js";
 
 const LEDGER_CLOSE_SECONDS = 5;
 const DEFAULT_TERM_LEDGERS = 17280; // 1 day in ledgers
 const DEFAULT_INTEREST_RATE_BPS = 1200; // 12%
+const LOAN_SORT_FIELDS = [
+  "loanId",
+  "principal",
+  "accruedInterest",
+  "totalRepaid",
+  "totalOwed",
+  "status",
+  "approvedAt",
+  "nextPaymentDeadline",
+] as const;
+
+type BorrowerLoan = {
+  loanId: number;
+  principal: number;
+  accruedInterest: number;
+  totalRepaid: number;
+  totalOwed: number;
+  nextPaymentDeadline: string;
+  status: "active" | "repaid" | "defaulted";
+  borrower: string;
+  approvedAt: string | null;
+};
 
 const getLatestLedger = async (): Promise<number> => {
   const result = await query(
     "SELECT last_indexed_ledger FROM indexer_state ORDER BY id DESC LIMIT 1",
     [],
   );
+
   return result.rows[0]?.last_indexed_ledger ?? 0;
+};
+
+const compareLoanValues = (
+  left: BorrowerLoan,
+  right: BorrowerLoan,
+  field: (typeof LOAN_SORT_FIELDS)[number],
+  direction: "ASC" | "DESC",
+) => {
+  const leftValue = left[field];
+  const rightValue = right[field];
+
+  let comparison = 0;
+
+  if (typeof leftValue === "number" && typeof rightValue === "number") {
+    comparison = leftValue - rightValue;
+  } else {
+    const normalizedLeft = leftValue ?? "";
+    const normalizedRight = rightValue ?? "";
+    comparison = String(normalizedLeft).localeCompare(String(normalizedRight));
+  }
+
+  return direction === "DESC" ? comparison * -1 : comparison;
 };
 
 /**
@@ -25,11 +75,12 @@ const getLatestLedger = async (): Promise<number> => {
 export const getBorrowerLoans = asyncHandler(
   async (req: Request, res: Response) => {
     const { borrower } = req.params;
-    const { status = "all" } = req.query;
+    const { limit, offset, sort, status, dateRange, amountRange } =
+      parseQueryParams(req);
 
     const loansQuery = `
-      SELECT 
-        loan_id, 
+      SELECT
+        loan_id,
         borrower,
         MAX(CASE WHEN event_type = 'LoanRequested' THEN amount END) as principal,
         MAX(CASE WHEN event_type = 'LoanApproved' THEN ledger_closed_at END) as approved_at,
@@ -43,26 +94,24 @@ export const getBorrowerLoans = asyncHandler(
       GROUP BY loan_id, borrower
     `;
 
-    const result = await query(loansQuery, [borrower]);
-    const currentLedger = await getLatestLedger();
+    const [result, currentLedger] = await Promise.all([
+      query(loansQuery, [borrower]),
+      getLatestLedger(),
+    ]);
 
-    const loans = result.rows.map((row: any) => {
-      const principal = parseFloat(row.principal || "0");
-      const totalRepaid = parseFloat(row.total_repaid || "0");
-
+    const loans: BorrowerLoan[] = result.rows.map((row: any) => {
+      const principal = Number.parseFloat(row.principal || "0");
+      const totalRepaid = Number.parseFloat(row.total_repaid || "0");
       const rateBps = row.rate_bps || DEFAULT_INTEREST_RATE_BPS;
       const termLedgers = row.term_ledgers || DEFAULT_TERM_LEDGERS;
       const approvedLedger = row.approved_ledger || 0;
-
       const elapsedLedgers = Math.max(0, currentLedger - approvedLedger);
       const accruedInterest =
         (principal * rateBps * elapsedLedgers) / (10000 * termLedgers);
-
       const totalOwed = principal + accruedInterest - totalRepaid;
       const isActive = totalOwed > 0.01;
-      const isDefaulted = parseInt(row.is_defaulted || "0", 10) === 1;
+      const isDefaulted = Number.parseInt(row.is_defaulted || "0", 10) === 1;
 
-      // Calculate next payment deadline using approximate calendar time for display
       const nextPaymentDeadline = row.approved_at
         ? new Date(
             new Date(row.approved_at).getTime() +
@@ -71,7 +120,7 @@ export const getBorrowerLoans = asyncHandler(
         : new Date().toISOString();
 
       return {
-        loanId: row.loan_id,
+        loanId: Number(row.loan_id),
         principal,
         accruedInterest,
         totalRepaid,
@@ -83,17 +132,60 @@ export const getBorrowerLoans = asyncHandler(
       };
     });
 
-    // Filter by status if specified
-    const filteredLoans =
-      status === "all"
-        ? loans
-        : loans.filter((loan: any) => loan.status === status);
+    let filteredLoans = loans;
 
-    res.json({
-      success: true,
-      borrower,
-      loans: filteredLoans,
-    });
+    if (status && status !== "all") {
+      filteredLoans = filteredLoans.filter((loan) => loan.status === status);
+    }
+
+    if (amountRange) {
+      filteredLoans = filteredLoans.filter(
+        (loan) =>
+          loan.principal >= amountRange.min && loan.principal <= amountRange.max,
+      );
+    }
+
+    if (dateRange) {
+      filteredLoans = filteredLoans.filter((loan) => {
+        if (!loan.approvedAt) {
+          return false;
+        }
+
+        const approvedAt = new Date(loan.approvedAt);
+        return approvedAt >= dateRange.start && approvedAt <= dateRange.end;
+      });
+    }
+
+    const sortConfig = getSortConfig(
+      sort,
+      LOAN_SORT_FIELDS,
+      "approvedAt",
+      "DESC",
+    );
+
+    const sortedLoans = [...filteredLoans].sort((left, right) =>
+      compareLoanValues(
+        left,
+        right,
+        sortConfig.field as (typeof LOAN_SORT_FIELDS)[number],
+        sortConfig.direction,
+      ),
+    );
+
+    const paginatedLoans = sortedLoans.slice(offset, offset + limit);
+
+    res.json(
+      createPaginatedResponse(
+        {
+          borrower,
+          loans: paginatedLoans,
+        },
+        sortedLoans.length,
+        limit,
+        offset,
+        paginatedLoans.length,
+      ),
+    );
   },
 );
 
@@ -106,7 +198,6 @@ export const getLoanDetails = asyncHandler(
   async (req: Request, res: Response) => {
     const { loanId } = req.params;
 
-    // Fetch all events for this loan
     const eventsResult = await query(
       `SELECT event_type, amount, ledger, ledger_closed_at, tx_hash, interest_rate_bps, term_ledgers
        FROM loan_events
@@ -122,20 +213,19 @@ export const getLoanDetails = asyncHandler(
 
     const events = eventsResult.rows;
     const currentLedger = await getLatestLedger();
-
     const requestEvent = events.find(
-      (e: any) => e.event_type === "LoanRequested",
+      (event: any) => event.event_type === "LoanRequested",
     );
     const approvalEvent = events.find(
-      (e: any) => e.event_type === "LoanApproved",
+      (event: any) => event.event_type === "LoanApproved",
     );
     const repaymentEvents = events.filter(
-      (e: any) => e.event_type === "LoanRepaid",
+      (event: any) => event.event_type === "LoanRepaid",
     );
 
-    const principal = parseFloat(requestEvent?.amount || "0");
+    const principal = Number.parseFloat(requestEvent?.amount || "0");
     const totalRepaid = repaymentEvents.reduce(
-      (sum: number, e: any) => sum + parseFloat(e.amount || "0"),
+      (sum: number, event: any) => sum + Number.parseFloat(event.amount || "0"),
       0,
     );
 
@@ -143,13 +233,13 @@ export const getLoanDetails = asyncHandler(
       approvalEvent?.interest_rate_bps || DEFAULT_INTEREST_RATE_BPS;
     const termLedgers = approvalEvent?.term_ledgers || DEFAULT_TERM_LEDGERS;
     const approvedLedger = approvalEvent?.ledger || 0;
-
     const elapsedLedgers = Math.max(0, currentLedger - approvedLedger);
     const accruedInterest =
       (principal * rateBps * elapsedLedgers) / (10000 * termLedgers);
-
     const totalOwed = principal + accruedInterest - totalRepaid;
-    const isDefaulted = events.some((e: any) => e.event_type === "LoanDefaulted");
+    const isDefaulted = events.some(
+      (event: any) => event.event_type === "LoanDefaulted",
+    );
 
     res.json({
       success: true,
@@ -169,11 +259,11 @@ export const getLoanDetails = asyncHandler(
             : "repaid",
         requestedAt: requestEvent?.ledger_closed_at,
         approvedAt: approvalEvent?.ledger_closed_at,
-        events: events.map((e: any) => ({
-          type: e.event_type,
-          amount: e.amount,
-          timestamp: e.ledger_closed_at,
-          tx: e.tx_hash,
+        events: events.map((event: any) => ({
+          type: event.event_type,
+          amount: event.amount,
+          timestamp: event.ledger_closed_at,
+          tx: event.tx_hash,
         })),
       },
     });
@@ -182,11 +272,6 @@ export const getLoanDetails = asyncHandler(
 
 /**
  * POST /api/loans/request
- *
- * Builds an unsigned Soroban request_loan(borrower, amount) transaction XDR.
- * The frontend signs it with the user's wallet and submits via POST /api/loans/submit.
- *
- * Body: { amount: number, borrowerPublicKey: string }
  */
 export const requestLoan = asyncHandler(
   async (req: Request, res: Response) => {
@@ -201,7 +286,6 @@ export const requestLoan = asyncHandler(
       );
     }
 
-    // Ensure the borrowerPublicKey matches the authenticated wallet
     if (borrowerPublicKey !== req.user?.publicKey) {
       throw AppError.forbidden(
         "borrowerPublicKey must match your authenticated wallet",
@@ -228,12 +312,6 @@ export const requestLoan = asyncHandler(
 
 /**
  * POST /api/loans/:loanId/repay
- *
- * Builds an unsigned Soroban repay(borrower, loan_id, amount) transaction XDR.
- * The frontend signs it with the user's wallet and submits via
- * POST /api/loans/:loanId/submit.
- *
- * Body: { amount: number, borrowerPublicKey: string }
  */
 export const repayLoan = asyncHandler(
   async (req: Request, res: Response) => {
@@ -249,14 +327,13 @@ export const repayLoan = asyncHandler(
       );
     }
 
-    // Ensure the borrowerPublicKey matches the authenticated wallet
     if (borrowerPublicKey !== req.user?.publicKey) {
       throw AppError.forbidden(
         "borrowerPublicKey must match your authenticated wallet",
       );
     }
 
-    const loanIdNum = parseInt(loanId, 10);
+    const loanIdNum = Number.parseInt(loanId, 10);
     if (!Number.isFinite(loanIdNum) || loanIdNum <= 0) {
       throw AppError.badRequest("Invalid loan ID");
     }
@@ -285,10 +362,6 @@ export const repayLoan = asyncHandler(
 /**
  * POST /api/loans/submit
  * POST /api/loans/:loanId/submit
- *
- * Submits a signed transaction XDR to the Stellar network.
- *
- * Body: { signedTxXdr: string }
  */
 export const submitTransaction = asyncHandler(
   async (req: Request, res: Response) => {

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -1,0 +1,143 @@
+import type { Request } from "express";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+  sort: string | null;
+  status: string | null;
+  dateRange: { start: Date; end: Date } | null;
+  amountRange: { min: number; max: number } | null;
+}
+
+export interface SortConfig {
+  field: string;
+  direction: "ASC" | "DESC";
+}
+
+export function parseQueryParams(req: Request): PaginationParams {
+  const limit = parsePositiveInteger(req.query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = parsePositiveInteger(req.query.offset, 0);
+  const sort =
+    typeof req.query.sort === "string" && req.query.sort.trim().length > 0
+      ? req.query.sort.trim()
+      : null;
+  const status =
+    typeof req.query.status === "string" && req.query.status.trim().length > 0
+      ? req.query.status.trim()
+      : null;
+
+  return {
+    limit,
+    offset,
+    sort,
+    status,
+    dateRange: parseDateRange(req.query.date_range),
+    amountRange: parseAmountRange(req.query.amount_range),
+  };
+}
+
+export function getSortConfig(
+  sort: string | null,
+  allowedFields: readonly string[],
+  defaultField: string,
+  defaultDirection: "ASC" | "DESC",
+): SortConfig {
+  if (!sort) {
+    return { field: defaultField, direction: defaultDirection };
+  }
+
+  const requestedField = sort.replace(/^-/, "");
+  if (!allowedFields.includes(requestedField)) {
+    return { field: defaultField, direction: defaultDirection };
+  }
+
+  return {
+    field: requestedField,
+    direction: sort.startsWith("-") ? "DESC" : "ASC",
+  };
+}
+
+export function createPaginatedResponse<T>(
+  data: T,
+  totalCount: number,
+  limit: number,
+  offset: number,
+  currentCount: number,
+) {
+  return {
+    success: true,
+    data,
+    total_count: totalCount,
+    page_info: {
+      limit,
+      offset,
+      count: currentCount,
+      has_previous: offset > 0,
+      has_next: offset + currentCount < totalCount,
+    },
+  };
+}
+
+function parsePositiveInteger(
+  value: unknown,
+  fallback: number,
+  max?: number,
+): number {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  if (max !== undefined) {
+    return Math.min(parsed, max);
+  }
+
+  return parsed;
+}
+
+function parseDateRange(value: unknown): { start: Date; end: Date } | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const [startRaw, endRaw] = value.split(",").map((part) => part?.trim());
+  if (!startRaw || !endRaw) {
+    return null;
+  }
+
+  const start = new Date(startRaw);
+  const end = new Date(endRaw);
+
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return null;
+  }
+
+  return start <= end ? { start, end } : { start: end, end: start };
+}
+
+function parseAmountRange(value: unknown): { min: number; max: number } | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const [minRaw, maxRaw] = value.split(",").map((part) => part?.trim());
+  if (!minRaw || !maxRaw) {
+    return null;
+  }
+
+  const min = Number.parseFloat(minRaw);
+  const max = Number.parseFloat(maxRaw);
+
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return null;
+  }
+
+  return min <= max ? { min, max } : { min: max, max: min };
+}


### PR DESCRIPTION
Closes #148

## Changes
- added shared pagination/query parsing utilities for `limit`, `offset`, and `sort`
- added advanced filtering support for `status`, `date_range`, and `amount_range`
- standardized paginated API responses to include `total_count` and `page_info`
- updated borrower loan list endpoint to support filtering, sorting, and pagination
- updated borrower event history, loan event history, and recent event endpoints to support the same query contract
- added focused backend tests covering pagination, filtering, and response envelope consistency

## Testing
- added targeted test coverage in `backend/src/__tests__/paginationFiltering.test.ts`
- could not complete local Jest execution because backend dependency installation timed out during `npm ci`
