### PR TITLE
fix: extract borrower address from LoanApproved event

### DIFF
--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -452,6 +452,7 @@ export class EventIndexer {
       if (!event.topic[1]) return null;
       loanId = this.decodeLoanId(event.topic[1]);
       if (loanId === undefined) return null;
+      borrower = this.decodeAddress(event.value);
       interestRateBps = 1200;
       termLedgers = 17280;
     } else if (type === "LoanRepaid") {


### PR DESCRIPTION
## Summary

- The `LoanApproved` branch in `eventIndexer.ts` `parseEvent()` correctly decoded `loanId` from `event.topic[1]` but never extracted the borrower address, leaving it as an empty string in every approved-loan record.
- Fix: call `this.decodeAddress(event.value)` after the loanId decode — the same pattern already used for `LoanDefaulted` events.

## Test plan

- [ ] Index a `LoanApproved` event and verify the returned record has a non-empty `borrower` field matching the expected Stellar address.
- [ ] Confirm `LoanDefaulted`, `LoanRepaid`, and `LoanRequested` event parsing is unaffected.

Closes #379