### PR TITLE
feat: add Stellar Explorer transaction hash links

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,8 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
 NODE_ENV=development
+
+# Stellar Explorer base URL (no trailing slash)
+# Mainnet: https://stellar.expert/explorer/public
+# Testnet: https://stellar.expert/explorer/testnet (default)
+NEXT_PUBLIC_STELLAR_EXPLORER_URL=https://stellar.expert/explorer/testnet

--- a/frontend/src/app/[locale]/loans/[loanId]/page.tsx
+++ b/frontend/src/app/[locale]/loans/[loanId]/page.tsx
@@ -2,10 +2,11 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ChevronRight, ExternalLink, Wallet } from "lucide-react";
+import { ChevronRight, Wallet } from "lucide-react";
 import { LoanDetailSkeleton } from "../../../components/skeletons/LoanDetailSkeleton";
 import { useLoan } from "../../../hooks/useApi";
 import { LoanStatusBadge } from "../../../components/ui/LoanStatusBadge";
+import { TxHashLink } from "../../../components/ui/TxHashLink";
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
@@ -122,6 +123,11 @@ export default function LoanDetailsPage() {
                     <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                       Amount: {formatCurrency(Number(event.amount) || 0)}
                     </p>
+                    {event.txHash && (
+                      <div className="mt-1">
+                        <TxHashLink txHash={event.txHash} />
+                      </div>
+                    )}
                   </div>
                 ))
               )}
@@ -147,15 +153,12 @@ export default function LoanDetailsPage() {
             </Link>
 
             {latestTxHash && (
-              <a
-                href={`https://stellar.expert/explorer/testnet/tx/${latestTxHash}`}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-3 inline-flex items-center gap-2 rounded-full border border-indigo-300 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
-              >
-                View on Explorer
-                <ExternalLink className="h-4 w-4" />
-              </a>
+              <div className="mt-3">
+                <p className="mb-1 text-xs font-medium text-indigo-700/70 dark:text-indigo-300/70">
+                  Latest transaction
+                </p>
+                <TxHashLink txHash={latestTxHash} />
+              </div>
             )}
           </div>
         </aside>

--- a/frontend/src/app/components/ui/TxHashLink.tsx
+++ b/frontend/src/app/components/ui/TxHashLink.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check, ExternalLink } from "lucide-react";
+import { getTxUrl, truncateHash } from "../../utils/stellar";
+
+interface TxHashLinkProps {
+  txHash: string;
+  chars?: number;
+  className?: string;
+}
+
+export function TxHashLink({ txHash, chars = 8, className = "" }: TxHashLinkProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(txHash);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 font-mono text-xs text-zinc-600 dark:text-zinc-400 ${className}`}
+      title={txHash}
+    >
+      <span>{truncateHash(txHash, chars)}</span>
+
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="Copy transaction hash"
+        className="rounded p-0.5 transition hover:text-zinc-900 dark:hover:text-zinc-100"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-green-500" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </button>
+
+      <a
+        href={getTxUrl(txHash)}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="View on Stellar Explorer"
+        className="rounded p-0.5 transition hover:text-indigo-600 dark:hover:text-indigo-400"
+      >
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </span>
+  );
+}

--- a/frontend/src/app/utils/stellar.ts
+++ b/frontend/src/app/utils/stellar.ts
@@ -1,0 +1,16 @@
+const EXPLORER_BASE_URL =
+  process.env.NEXT_PUBLIC_STELLAR_EXPLORER_URL ??
+  "https://stellar.expert/explorer/testnet";
+
+export function getTxUrl(txHash: string): string {
+  return `${EXPLORER_BASE_URL}/tx/${txHash}`;
+}
+
+export function getAccountUrl(address: string): string {
+  return `${EXPLORER_BASE_URL}/account/${address}`;
+}
+
+export function truncateHash(hash: string, chars = 8): string {
+  if (hash.length <= chars * 2 + 3) return hash;
+  return `${hash.slice(0, chars)}...${hash.slice(-chars)}`;
+}


### PR DESCRIPTION
## Summary

- Add `frontend/src/app/utils/stellar.ts` with `getTxUrl()`, `getAccountUrl()`, and `truncateHash()` helpers that read the base URL from `NEXT_PUBLIC_STELLAR_EXPLORER_URL` (defaults to the testnet explorer).
- Add `TxHashLink` component (`frontend/src/app/components/ui/TxHashLink.tsx`) that renders a truncated hash with a copy-to-clipboard button and an external link icon pointing to the Stellar Explorer.
- Document `NEXT_PUBLIC_STELLAR_EXPLORER_URL` in `.env.example` with both testnet and mainnet values.
- Use `TxHashLink` on the loan detail page: each timeline event now shows a clickable hash, and the latest transaction in the action panel is also linked.

## Test plan

- [ ] Each event with a `txHash` on the loan detail page shows the truncated hash, a copy button, and a link.
- [ ] Clicking the copy button writes the full hash to the clipboard.
- [ ] Clicking the external-link icon opens the correct Stellar Explorer URL in a new tab.
- [ ] Setting `NEXT_PUBLIC_STELLAR_EXPLORER_URL` to the mainnet URL causes links to point to mainnet.
- [ ] Events without a `txHash` render normally without any link component.

Closes #388