### PR TITLE
feat: real-time pool stats via SSE on lend page

### DIFF
--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -444,6 +444,17 @@ export function usePoolStats(options?: Omit<UseQueryOptions<PoolStats>, "queryKe
   });
 }
 
+/**
+ * Returns a callback that invalidates the pool stats cache, forcing a refetch.
+ * Useful for SSE handlers that receive a pool-update event.
+ */
+export function useInvalidatePoolStats() {
+  const queryClient = useQueryClient();
+  return () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.pool.stats() });
+  };
+}
+
 export function useDepositorPortfolio(
   address: string | undefined,
   options?: Omit<UseQueryOptions<DepositorPortfolio>, "queryKey" | "queryFn">,

--- a/frontend/src/app/hooks/useSSE.ts
+++ b/frontend/src/app/hooks/useSSE.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type SSEStatus = "connecting" | "connected" | "disconnected";
+
+interface UseSSEOptions<T> {
+  /** Full URL of the SSE endpoint. Pass null/undefined to disable. */
+  url: string | null | undefined;
+  /** Called for every parsed message from the stream. */
+  onMessage: (data: T) => void;
+  /** Called when the connection opens (backoff reset point). */
+  onOpen?: () => void;
+  /** Called when the connection closes with an error. */
+  onError?: (event: Event) => void;
+}
+
+/**
+ * Generic SSE hook with exponential backoff reconnection.
+ *
+ * Connects to `url` and calls `onMessage` with each parsed JSON payload.
+ * Automatically reconnects on error, backing off up to 30 s.
+ * Returns the current connection status for UI indicators.
+ */
+export function useSSE<T = unknown>({
+  url,
+  onMessage,
+  onOpen,
+  onError,
+}: UseSSEOptions<T>): SSEStatus {
+  const [status, setStatus] = useState<SSEStatus>("connecting");
+  const retryDelay = useRef(1_000);
+  const esRef = useRef<EventSource | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep callback refs stable so the effect doesn't need to re-run when they
+  // change, which would needlessly restart the connection.
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+  const onOpenRef = useRef(onOpen);
+  onOpenRef.current = onOpen;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    if (!url) return;
+
+    let cancelled = false;
+
+    function connect() {
+      if (cancelled) return;
+      setStatus("connecting");
+
+      const es = new EventSource(url as string, { withCredentials: true });
+      esRef.current = es;
+
+      es.onopen = () => {
+        retryDelay.current = 1_000;
+        setStatus("connected");
+        onOpenRef.current?.();
+      };
+
+      es.onmessage = (event: MessageEvent<string>) => {
+        try {
+          const data = JSON.parse(event.data) as T;
+          onMessageRef.current(data);
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      es.onerror = (event) => {
+        es.close();
+        esRef.current = null;
+        setStatus("disconnected");
+        onErrorRef.current?.(event);
+
+        if (!cancelled) {
+          const delay = Math.min(retryDelay.current, 30_000);
+          retryDelay.current = Math.min(delay * 2, 30_000);
+          timeoutRef.current = setTimeout(connect, delay);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      esRef.current?.close();
+      esRef.current = null;
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [url]);
+
+  return status;
+}

--- a/frontend/src/app/lend/page.tsx
+++ b/frontend/src/app/lend/page.tsx
@@ -10,16 +10,27 @@ import {
   HandCoins,
   Percent,
   PiggyBank,
+  Wifi,
+  WifiOff,
 } from "lucide-react";
 import { ErrorBoundary } from "../components/global_ui/ErrorBoundary";
 import { Skeleton } from "../components/ui/Skeleton";
 import { YieldEarningsChart } from "../components/charts/YieldEarningsChart";
-import { useDepositorPortfolio, useLoans, usePoolStats, useYieldHistory } from "../hooks/useApi";
+import {
+  useDepositorPortfolio,
+  useInvalidatePoolStats,
+  useLoans,
+  usePoolStats,
+  useYieldHistory,
+} from "../hooks/useApi";
 import { LoanStatusBadge } from "../components/ui/LoanStatusBadge";
 import { DepositWithdrawSkeleton } from "../components/skeletons/DepositWithdrawSkeleton";
 import { OperationProgress } from "../components/ui/OperationProgress";
 import { useDepositOperation, useWithdrawalOperation } from "../hooks/useRepaymentOperation";
 import { selectWalletAddress, useWalletStore } from "../stores/useWalletStore";
+import { useSSE } from "../hooks/useSSE";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
@@ -36,6 +47,17 @@ export default function LendPage() {
 
   const depositOp = useDepositOperation();
   const withdrawalOp = useWithdrawalOperation();
+
+  const invalidatePoolStats = useInvalidatePoolStats();
+  const sseUrl = address ? `${API_URL}/pool/events` : null;
+  const sseStatus = useSSE<{ type: string }>({
+    url: sseUrl,
+    onMessage: (data) => {
+      if (data?.type === "pool_updated") {
+        invalidatePoolStats();
+      }
+    },
+  });
 
   const handleDeposit = async () => {
     const amount = parseFloat(depositAmount);
@@ -107,14 +129,45 @@ export default function LendPage() {
 
   return (
     <main className="space-y-6">
-      <header>
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600">
-          Lender Portal
-        </p>
-        <h1 className="mt-2 text-3xl font-bold text-zinc-900 dark:text-zinc-50">Lend</h1>
-        <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
-          Track pool performance, manage deposits, and monitor yield growth.
-        </p>
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600">
+            Lender Portal
+          </p>
+          <h1 className="mt-2 text-3xl font-bold text-zinc-900 dark:text-zinc-50">Lend</h1>
+          <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
+            Track pool performance, manage deposits, and monitor yield growth.
+          </p>
+        </div>
+        {address && (
+          <div
+            className={`mt-1 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium ${
+              sseStatus === "connected"
+                ? "bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-400"
+                : sseStatus === "connecting"
+                  ? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                  : "bg-red-50 text-red-600 dark:bg-red-500/10 dark:text-red-400"
+            }`}
+            title={
+              sseStatus === "connected"
+                ? "Live pool updates connected"
+                : sseStatus === "connecting"
+                  ? "Connecting to live updates…"
+                  : "Live updates disconnected — retrying"
+            }
+          >
+            {sseStatus === "connected" ? (
+              <Wifi className="h-3.5 w-3.5" />
+            ) : (
+              <WifiOff className="h-3.5 w-3.5" />
+            )}
+            {sseStatus === "connected"
+              ? "Live"
+              : sseStatus === "connecting"
+                ? "Connecting…"
+                : "Offline"}
+          </div>
+        )}
       </header>
 
       <ErrorBoundary scope="lender overview" variant="section">


### PR DESCRIPTION
## Summary

- Add a generic `useSSE<T>` hook (`frontend/src/app/hooks/useSSE.ts`) that opens an `EventSource` connection and reconnects automatically with exponential backoff (1 s → 30 s cap). Returns the current connection status (`connecting` / `connected` / `disconnected`).
- Add `useInvalidatePoolStats()` to `useApi.ts` so SSE message handlers can trigger a TanStack Query refetch without importing `queryClient` directly.
- Update `lend/page.tsx` to subscribe to the `/pool/events` SSE stream; when a `pool_updated` event is received the pool stats card refreshes automatically.
- Add a Live / Connecting… / Offline status badge in the page header that reflects the SSE connection state in real time.

## Test plan

- [ ] On the lend page, the header shows a green "Live" badge when the SSE connection is established.
- [ ] Triggering a pool event from the backend causes the pool stats (Total Pool Size, Utilization, APY, Active Loans) to update without a manual page refresh.
- [ ] Stopping the SSE server shows the badge switch to "Offline" and the hook reconnects after the backoff delay.
- [ ] With no wallet connected the SSE connection is not initiated (no spurious requests).

Closes #377