### PR TITLE
feat: complete loan detail page with timeline, progress, and breadcrumb

### DIFF
--- a/frontend/src/app/[locale]/loans/[loanId]/page.tsx
+++ b/frontend/src/app/[locale]/loans/[loanId]/page.tsx
@@ -2,13 +2,30 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ChevronRight, ExternalLink, Wallet } from "lucide-react";
+import { ChevronRight, Clock, Wallet } from "lucide-react";
 import { LoanDetailSkeleton } from "../../../components/skeletons/LoanDetailSkeleton";
 import { useLoan } from "../../../hooks/useApi";
-import { LoanStatusBadge } from "../../../components/ui/LoanStatusBadge";
+import { RepaymentProgress } from "../../../components/ui/RepaymentProgress";
+import { LoanTimeline } from "../../../components/ui/LoanTimeline";
+import { TxHashLink } from "../../../components/ui/TxHashLink";
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatDate(iso: string | undefined) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function getDaysRemaining(deadline: string | undefined): number | null {
+  if (!deadline) return null;
+  const diff = new Date(deadline).getTime() - Date.now();
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
 }
 
 export default function LoanDetailsPage() {
@@ -33,11 +50,11 @@ export default function LoanDetailsPage() {
       <section className="rounded-3xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-950">
         <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Loan not found</h1>
         <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-          The requested loan could not be located.
+          Loan #{loanId} could not be located. It may have been removed or the ID is incorrect.
         </p>
         <Link
           href="/loans"
-          className="mt-4 inline-flex items-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:bg-zinc-100 dark:text-zinc-900"
+          className="mt-6 inline-flex items-center gap-2 rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-semibold text-white dark:bg-zinc-100 dark:text-zinc-900"
         >
           Back to loans
         </Link>
@@ -45,14 +62,30 @@ export default function LoanDetailsPage() {
     );
   }
 
-  const progress =
-    loan.totalOwed > 0
-      ? Math.min((loan.totalRepaid / (loan.totalRepaid + loan.totalOwed)) * 100, 100)
-      : 100;
   const latestTxHash = loan.events.find((event) => Boolean(event.txHash))?.txHash;
+  // Some API responses include nextPaymentDeadline in the extended loan object
+  const nextDeadline = (loan as unknown as { nextPaymentDeadline?: string }).nextPaymentDeadline;
+  const daysRemaining = getDaysRemaining(nextDeadline);
 
   return (
     <section className="space-y-6">
+      {/* Breadcrumb */}
+      <nav
+        aria-label="Breadcrumb"
+        className="flex items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400"
+      >
+        <Link href="/" className="hover:text-zinc-900 dark:hover:text-zinc-100 transition">
+          Home
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" />
+        <Link href="/loans" className="hover:text-zinc-900 dark:hover:text-zinc-100 transition">
+          Loans
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" />
+        <span className="font-medium text-zinc-900 dark:text-zinc-50">Loan #{loanId}</span>
+      </nav>
+
+      {/* Header */}
       <header className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600">
           Borrower Portal
@@ -61,11 +94,41 @@ export default function LoanDetailsPage() {
         <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
           Track repayment timing, lender terms, and the current outstanding balance for this loan.
         </p>
+
+        {/* Loan metadata row */}
+        <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm text-zinc-500 dark:text-zinc-400">
+          {loan.interestRate > 0 && (
+            <span>
+              Interest rate:{" "}
+              <strong className="text-zinc-900 dark:text-zinc-50">
+                {loan.interestRate.toFixed(2)}%
+              </strong>
+            </span>
+          )}
+          {loan.requestedAt && (
+            <span>
+              Requested:{" "}
+              <strong className="text-zinc-900 dark:text-zinc-50">
+                {formatDate(loan.requestedAt)}
+              </strong>
+            </span>
+          )}
+          {loan.approvedAt && (
+            <span>
+              Approved:{" "}
+              <strong className="text-zinc-900 dark:text-zinc-50">
+                {formatDate(loan.approvedAt)}
+              </strong>
+            </span>
+          )}
+        </div>
       </header>
 
       <div className="grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
+        {/* Main content */}
         <article className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Repayment plan</h2>
+
           <div className="mt-5 grid gap-4 sm:grid-cols-2">
             {[
               ["Principal", formatCurrency(loan.principal)],
@@ -82,81 +145,103 @@ export default function LoanDetailsPage() {
             ))}
           </div>
 
-          <div className="mt-6 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
-            <div className="mb-2 flex items-center justify-between">
-              <p className="text-sm text-zinc-500 dark:text-zinc-400">Repayment progress</p>
-              <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                {progress.toFixed(1)}%
-              </p>
-            </div>
-            <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-800">
-              <div className="h-2 rounded-full bg-indigo-600" style={{ width: `${progress}%` }} />
-            </div>
-            <div className="mt-3 flex items-center gap-2">
-              <p className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Status:</p>
-              <LoanStatusBadge status={loan.status} />
-            </div>
+          <div className="mt-6">
+            <RepaymentProgress
+              totalRepaid={loan.totalRepaid}
+              totalOwed={loan.totalOwed}
+              status={loan.status}
+            />
           </div>
 
           <div className="mt-6">
             <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
               Repayment timeline
             </h3>
-            <div className="mt-3 space-y-3">
-              {loan.events.length === 0 ? (
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">No events yet.</p>
-              ) : (
-                loan.events.map((event, index) => (
-                  <div
-                    key={`${event.type}-${event.timestamp}-${index}`}
-                    className="rounded-xl border border-zinc-200 p-3 dark:border-zinc-800"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                        {event.type}
-                      </p>
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {new Date(event.timestamp).toLocaleString()}
-                      </p>
-                    </div>
-                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                      Amount: {formatCurrency(Number(event.amount) || 0)}
-                    </p>
-                  </div>
-                ))
-              )}
+            <div className="mt-3">
+              <LoanTimeline events={loan.events} />
             </div>
           </div>
         </article>
 
-        <aside className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
-          <div className="rounded-2xl bg-indigo-50 p-5 dark:bg-indigo-500/10">
-            <div className="flex items-center gap-3 text-indigo-700 dark:text-indigo-300">
-              <Wallet className="h-5 w-5" />
-              <h2 className="text-lg font-semibold">Next action</h2>
-            </div>
-            <p className="mt-3 text-sm leading-6 text-indigo-700/80 dark:text-indigo-200">
-              Make a repayment before the next due date to keep your score trending upward.
-            </p>
-            <Link
-              href={`/repay/${loanId}`}
-              className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
-            >
-              Make Payment
-              <ChevronRight className="h-4 w-4" />
-            </Link>
-
-            {latestTxHash && (
-              <a
-                href={`https://stellar.expert/explorer/testnet/tx/${latestTxHash}`}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-3 inline-flex items-center gap-2 rounded-full border border-indigo-300 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+        {/* Sidebar */}
+        <aside className="space-y-4">
+          {/* Due date countdown */}
+          {loan.status === "active" && daysRemaining !== null && (
+            <div className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+              <div className="flex items-center gap-2 text-zinc-700 dark:text-zinc-300">
+                <Clock className="h-4 w-4" />
+                <h2 className="text-sm font-semibold">Next payment due</h2>
+              </div>
+              <p
+                className={`mt-2 text-2xl font-bold ${
+                  daysRemaining <= 3
+                    ? "text-red-600 dark:text-red-400"
+                    : daysRemaining <= 7
+                      ? "text-amber-600 dark:text-amber-400"
+                      : "text-zinc-900 dark:text-zinc-50"
+                }`}
               >
-                View on Explorer
-                <ExternalLink className="h-4 w-4" />
-              </a>
-            )}
+                {daysRemaining <= 0
+                  ? "Overdue"
+                  : daysRemaining === 1
+                    ? "Due tomorrow"
+                    : `${daysRemaining} days`}
+              </p>
+              {nextDeadline && (
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  {new Date(nextDeadline).toLocaleDateString(undefined, {
+                    weekday: "long",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Action panel */}
+          <div className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+            <div className="rounded-2xl bg-indigo-50 p-5 dark:bg-indigo-500/10">
+              <div className="flex items-center gap-3 text-indigo-700 dark:text-indigo-300">
+                <Wallet className="h-5 w-5" />
+                <h2 className="text-lg font-semibold">Next action</h2>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-indigo-700/80 dark:text-indigo-200">
+                Make a repayment before the next due date to keep your score trending upward.
+              </p>
+              {loan.status !== "repaid" && (
+                <Link
+                  href={`/repay/${loanId}`}
+                  className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
+                >
+                  Make Payment
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              )}
+
+              {latestTxHash && (
+                <div className="mt-3">
+                  <p className="mb-1 text-xs font-medium text-indigo-700/70 dark:text-indigo-300/70">
+                    Latest transaction
+                  </p>
+                  <TxHashLink txHash={latestTxHash} />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Collateral status */}
+          <div className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm shadow-zinc-200/50 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              Collateral status
+            </h2>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              {loan.status === "defaulted"
+                ? "Collateral has been seized."
+                : loan.status === "repaid"
+                  ? "Collateral released — loan fully repaid."
+                  : "Collateral is held in escrow for the duration of this loan."}
+            </p>
           </div>
         </aside>
       </div>

--- a/frontend/src/app/components/ui/LoanTimeline.tsx
+++ b/frontend/src/app/components/ui/LoanTimeline.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { TxHashLink } from "./TxHashLink";
+import type { LoanEvent } from "../../hooks/useApi";
+
+interface LoanTimelineProps {
+  events: LoanEvent[];
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+const EVENT_LABELS: Record<string, string> = {
+  LoanRequested: "Loan requested",
+  LoanApproved: "Loan approved",
+  LoanRepaid: "Repayment made",
+  LoanDefaulted: "Loan defaulted",
+  Seized: "Collateral seized",
+};
+
+export function LoanTimeline({ events }: LoanTimelineProps) {
+  if (events.length === 0) {
+    return <p className="text-sm text-zinc-500 dark:text-zinc-400">No events yet.</p>;
+  }
+
+  return (
+    <ol className="relative space-y-0">
+      {events.map((event, index) => {
+        const isLast = index === events.length - 1;
+        return (
+          <li key={`${event.type}-${event.timestamp}-${index}`} className="flex gap-3">
+            {/* Timeline spine */}
+            <div className="flex flex-col items-center">
+              <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-indigo-600 ring-2 ring-white dark:ring-zinc-950" />
+              {!isLast && (
+                <span className="mt-1 flex-1 w-px bg-zinc-200 dark:bg-zinc-800" />
+              )}
+            </div>
+
+            {/* Event card */}
+            <div className={`pb-4 w-full ${isLast ? "pb-0" : ""}`}>
+              <div className="rounded-xl border border-zinc-200 p-3 dark:border-zinc-800">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                    {EVENT_LABELS[event.type] ?? event.type}
+                  </p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    {new Date(event.timestamp).toLocaleString()}
+                  </p>
+                </div>
+                {Number(event.amount) > 0 && (
+                  <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                    Amount: {formatCurrency(Number(event.amount))}
+                  </p>
+                )}
+                {event.txHash && (
+                  <div className="mt-1.5">
+                    <TxHashLink txHash={event.txHash} />
+                  </div>
+                )}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/src/app/components/ui/RepaymentProgress.tsx
+++ b/frontend/src/app/components/ui/RepaymentProgress.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { LoanStatusBadge } from "./LoanStatusBadge";
+
+interface RepaymentProgressProps {
+  totalRepaid: number;
+  totalOwed: number;
+  status: "active" | "repaid" | "defaulted" | "pending";
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+export function RepaymentProgress({ totalRepaid, totalOwed, status }: RepaymentProgressProps) {
+  const total = totalRepaid + totalOwed;
+  const progress = total > 0 ? Math.min((totalRepaid / total) * 100, 100) : 100;
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">Repayment progress</p>
+        <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+          {progress.toFixed(1)}%
+        </p>
+      </div>
+
+      <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-800">
+        <div
+          className="h-2 rounded-full bg-indigo-600 transition-all duration-500"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
+        <span>
+          Paid: <strong className="text-zinc-900 dark:text-zinc-50">{formatCurrency(totalRepaid)}</strong>
+        </span>
+        <span>
+          Remaining: <strong className="text-zinc-900 dark:text-zinc-50">{formatCurrency(totalOwed)}</strong>
+        </span>
+        <LoanStatusBadge status={status} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `RepaymentProgress` component: renders the percentage progress bar, paid / remaining amounts, and status badge.
- Extract `LoanTimeline` component: renders loan events as a vertical spine list with human-readable event labels, currency amounts, and `TxHashLink` for each transaction hash.
- Rewrite the loan detail page:
  - Breadcrumb navigation: Home → Loans → Loan #N
  - Header metadata row: interest rate, requested date, approved date
  - Due date countdown card (overdue / days remaining) visible for active loans when `nextPaymentDeadline` is available
  - Collateral status card describing current escrow state based on loan status
  - "Make Payment" button is hidden for fully repaid loans
  - Improved 404 state with a descriptive message and "Back to loans" link

## Test plan

- [ ] Breadcrumb renders correctly and links to `/` and `/loans`.
- [ ] Loan header shows interest rate, requested date, and approved date when the API returns them.
- [ ] Repayment progress bar reflects the correct paid/owed ratio.
- [ ] Timeline spine shows each event with correct label, amount, timestamp, and a TxHashLink where a hash is available.
- [ ] Due-date card shows overdue (red), imminent (amber), or normal (default) styling.
- [ ] Collateral status card reflects defaulted / repaid / active states.
- [ ] Navigating to a non-existent loan ID shows the 404 message and back link.

Closes #372