### PR TITLE
contracts: assert insufficient liquidity error on approve_loan

### DIFF
--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -28,7 +28,7 @@ fn test_version_is_initialized() {
     let pool_client = LendingPoolClient::new(&env, &pool_id);
 
     pool_client.initialize(&admin);
-    assert_eq!(pool_client.version(), 2);
+    assert_eq!(pool_client.version(), 3);
 }
 
 #[test]

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -488,7 +488,6 @@ fn test_approve_already_approved_loan() {
 }
 
 #[test]
-#[should_panic]
 fn test_approve_loan_insufficient_pool_liquidity() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();
@@ -499,11 +498,13 @@ fn test_approve_loan_insufficient_pool_liquidity() {
     let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
     nft_client.mint(&borrower, &650, &history_hash, &None);
 
+    // Mint only 100 tokens into pool, but loan requests 1000
     let stellar_token = StellarAssetClient::new(&env, &token_id);
     stellar_token.mint(&pool_address, &100);
 
     let loan_id = manager.request_loan(&borrower, &1000);
-    manager.approve_loan(&loan_id);
+    let result = manager.try_approve_loan(&loan_id);
+    assert_eq!(result, Err(Ok(LoanError::InsufficientPoolLiquidity)));
 }
 
 #[test]


### PR DESCRIPTION
## enforce and verify insufficient pool liquidity path in approve_loan

Closes #369 


This PR finalizes the LoanManager insufficient-liquidity behavior by ensuring tests explicitly validate the contract error returned when pool liquidity is below the requested loan amount.

It also includes a small unrelated test expectation update in LendingPool to match the current on-chain contract version and keep CI green.