### PR TITLE
Stellar RPC calls

### DIFF
--- a/backend/src/__tests__/sorobanService.test.ts
+++ b/backend/src/__tests__/sorobanService.test.ts
@@ -1,0 +1,86 @@
+import { jest } from "@jest/globals";
+
+const mockGetAccount = jest.fn();
+const mockPrepareTransaction = jest.fn();
+const mockSendTransaction = jest.fn();
+const mockPollTransaction = jest.fn();
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  BASE_FEE: "100",
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  Operation: { invokeContractFunction: jest.fn(() => ({})) },
+  TransactionBuilder: class {
+    addOperation() { return this; }
+    setTimeout() { return this; }
+    build() { return { toXDR: () => "xdr" }; }
+    static fromXDR() { return {}; }
+  },
+  nativeToScVal: jest.fn(() => ({})),
+  Address: { fromString: jest.fn(() => ({})) },
+  xdr: {},
+  rpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getAccount: mockGetAccount,
+      prepareTransaction: mockPrepareTransaction,
+      sendTransaction: mockSendTransaction,
+      pollTransaction: mockPollTransaction,
+    })),
+  },
+}));
+
+const { sorobanService } = await import("../services/sorobanService.js");
+
+// Flush all pending microtasks then advance fake timers past the timeout
+async function triggerTimeout(promise: Promise<unknown>, advanceMs: number): Promise<string> {
+  const result = promise.then(() => "resolved", (e: Error) => e.message);
+  await Promise.resolve(); // flush microtasks so intermediate awaits settle
+  jest.advanceTimersByTime(advanceMs);
+  return result;
+}
+
+describe("sorobanService – RPC timeout enforcement", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    process.env.LOAN_MANAGER_CONTRACT_ID = "CONTRACT_ID";
+    process.env.LENDING_POOL_CONTRACT_ID = "POOL_ID";
+    process.env.POOL_TOKEN_ADDRESS = "TOKEN_ADDR";
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("times out buildRequestLoanTx when getAccount hangs", async () => {
+    mockGetAccount.mockReturnValue(new Promise(() => {}));
+    const msg = await triggerTimeout(sorobanService.buildRequestLoanTx("GBORROWER", 1000), 15_001);
+    expect(msg).toMatch(/timed out/i);
+  });
+
+  it("times out buildRequestLoanTx when prepareTransaction hangs", async () => {
+    mockGetAccount.mockResolvedValue({});
+    mockPrepareTransaction.mockReturnValue(new Promise(() => {}));
+    // flush getAccount resolution before advancing timers
+    const promise = sorobanService.buildRequestLoanTx("GBORROWER", 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    jest.advanceTimersByTime(15_001);
+    await expect(promise).rejects.toThrow(/timed out/i);
+  });
+
+  it("times out submitSignedTx when sendTransaction hangs", async () => {
+    mockSendTransaction.mockReturnValue(new Promise(() => {}));
+    const msg = await triggerTimeout(sorobanService.submitSignedTx("signedXdr"), 15_001);
+    expect(msg).toMatch(/timed out/i);
+  });
+
+  it("times out submitSignedTx when pollTransaction hangs", async () => {
+    mockSendTransaction.mockResolvedValue({ hash: "abc123", status: "PENDING" });
+    mockPollTransaction.mockReturnValue(new Promise(() => {}));
+    const promise = sorobanService.submitSignedTx("signedXdr");
+    await Promise.resolve();
+    await Promise.resolve();
+    jest.advanceTimersByTime(60_001);
+    await expect(promise).rejects.toThrow(/timed out/i);
+  });
+});

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -11,6 +11,17 @@ import {
 import logger from "../utils/logger.js";
 import { AppError } from "../errors/AppError.js";
 
+const RPC_TIMEOUT_MS = 15_000;
+
+function withTimeout<T>(promise: Promise<T>, ms = RPC_TIMEOUT_MS): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`RPC call timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
 /**
  * Service for building and submitting Soroban contract transactions.
  * Handles the transaction lifecycle: build → (frontend signs) → submit.
@@ -69,7 +80,7 @@ class SorobanService {
     const contractId = this.getLoanManagerContractId();
     const passphrase = this.getNetworkPassphrase();
 
-    const account = await server.getAccount(borrowerPublicKey);
+    const account = await withTimeout(server.getAccount(borrowerPublicKey));
 
     const borrowerScVal = nativeToScVal(
       Address.fromString(borrowerPublicKey),
@@ -91,7 +102,7 @@ class SorobanService {
       .setTimeout(30)
       .build();
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withTimeout(server.prepareTransaction(tx));
     const unsignedTxXdr = prepared.toXDR();
 
     logger.info("Built request_loan transaction", {
@@ -115,7 +126,7 @@ class SorobanService {
     const contractId = this.getLoanManagerContractId();
     const passphrase = this.getNetworkPassphrase();
 
-    const account = await server.getAccount(borrowerPublicKey);
+    const account = await withTimeout(server.getAccount(borrowerPublicKey));
 
     const borrowerScVal = nativeToScVal(
       Address.fromString(borrowerPublicKey),
@@ -138,7 +149,7 @@ class SorobanService {
       .setTimeout(30)
       .build();
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withTimeout(server.prepareTransaction(tx));
     const unsignedTxXdr = prepared.toXDR();
 
     logger.info("Built repay transaction", {
@@ -163,7 +174,7 @@ class SorobanService {
     const contractId = this.getLendingPoolContractId();
     const passphrase = this.getNetworkPassphrase();
 
-    const account = await server.getAccount(depositorPublicKey);
+    const account = await withTimeout(server.getAccount(depositorPublicKey));
 
     const providerScVal = nativeToScVal(
       Address.fromString(depositorPublicKey),
@@ -189,7 +200,7 @@ class SorobanService {
       .setTimeout(30)
       .build();
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withTimeout(server.prepareTransaction(tx));
     const unsignedTxXdr = prepared.toXDR();
 
     logger.info("Built deposit transaction", {
@@ -213,7 +224,7 @@ class SorobanService {
     const contractId = this.getLendingPoolContractId();
     const passphrase = this.getNetworkPassphrase();
 
-    const account = await server.getAccount(depositorPublicKey);
+    const account = await withTimeout(server.getAccount(depositorPublicKey));
 
     const providerScVal = nativeToScVal(
       Address.fromString(depositorPublicKey),
@@ -239,7 +250,7 @@ class SorobanService {
       .setTimeout(30)
       .build();
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withTimeout(server.prepareTransaction(tx));
     const unsignedTxXdr = prepared.toXDR();
 
     logger.info("Built withdraw transaction", {
@@ -263,7 +274,7 @@ class SorobanService {
     const contractId = this.getLoanManagerContractId();
     const passphrase = this.getNetworkPassphrase();
 
-    const account = await server.getAccount(adminPublicKey);
+    const account = await withTimeout(server.getAccount(adminPublicKey));
 
     const loanIdScVal = nativeToScVal(loanId, { type: "u32" });
 
@@ -281,7 +292,7 @@ class SorobanService {
       .setTimeout(30)
       .build();
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withTimeout(server.prepareTransaction(tx));
     const unsignedTxXdr = prepared.toXDR();
 
     logger.info("Built approve_loan transaction", {
@@ -308,7 +319,7 @@ class SorobanService {
       this.getNetworkPassphrase(),
     );
 
-    const sendResult = await server.sendTransaction(tx);
+    const sendResult = await withTimeout(server.sendTransaction(tx));
     const txHash = sendResult.hash;
 
     if (!txHash) {
@@ -321,10 +332,13 @@ class SorobanService {
     });
 
     // Poll for final result
-    const polled = await server.pollTransaction(txHash, {
-      attempts: 30,
-      sleepStrategy: () => 1000,
-    });
+    const polled = await withTimeout(
+      server.pollTransaction(txHash, {
+        attempts: 30,
+        sleepStrategy: () => 1000,
+      }),
+      60_000,
+    );
 
     const resultXdr =
       polled.status === "SUCCESS" && polled.resultXdr


### PR DESCRIPTION
Closed #473 

Backend Stellar RPC calls in sorobanService.ts use the SDK's default 30-second transaction timeout but do not configure socket-level connection timeouts. If the RPC node is slow or hangs after accepting the connection, the request never times out and the caller waits indefinitely. This can exhaust the Node.js event loop and cause all subsequent requests to queue up.

@ogazboiz pls review Pr