### PR TITLE
fix(security): add per-IP and per-key rate limiting on auth endpoints (#467)

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -160,4 +160,53 @@ describe("Auth API", () => {
       expect(response.body.success).toBe(false);
     });
   });
+
+  describe("Rate limiting", () => {
+    it("should return 429 after 10 challenge requests from same IP", async () => {
+      const keypair = Keypair.random();
+      let lastResponse: any;
+      for (let i = 0; i < 11; i++) {
+        lastResponse = await request(app)
+          .post("/api/auth/challenge")
+          .set("X-Forwarded-For", "1.2.3.4")
+          .send({ publicKey: keypair.publicKey() });
+      }
+      expect(lastResponse.status).toBe(429);
+      expect(lastResponse.body.success).toBe(false);
+    });
+
+    it("should return 429 and Retry-After after 5 login attempts from same IP", async () => {
+      const keypair = Keypair.random();
+      let lastResponse: any;
+      for (let i = 0; i < 6; i++) {
+        lastResponse = await request(app)
+          .post("/api/auth/login")
+          .set("X-Forwarded-For", "5.6.7.8")
+          .send({
+            publicKey: keypair.publicKey(),
+            message: "fake-message",
+            signature: "fake-signature",
+          });
+      }
+      expect(lastResponse.status).toBe(429);
+      expect(lastResponse.headers["retry-after"]).toBeDefined();
+    });
+
+    it("should return 429 after 5 login attempts with same public key", async () => {
+      const keypair = Keypair.random();
+      let lastResponse: any;
+      for (let i = 0; i < 6; i++) {
+        lastResponse = await request(app)
+          .post("/api/auth/login")
+          .set("X-Forwarded-For", `9.9.9.${i}`)
+          .send({
+            publicKey: keypair.publicKey(),
+            message: "fake-message",
+            signature: "fake-signature",
+          });
+      }
+      expect(lastResponse.status).toBe(429);
+      expect(lastResponse.body.success).toBe(false);
+    });
+  });
 });

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -1,4 +1,4 @@
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 
 export const createRateLimiter = (max: number, windowMinutes: number = 15) =>
   rateLimit({
@@ -11,11 +11,38 @@ export const globalRateLimiter = createRateLimiter(100);
 export const strictRateLimiter = createRateLimiter(10, 45);
 
 export const challengeRateLimiter = rateLimit({
-  windowMs: 60 * 1000,
+  windowMs: 60 * 60 * 1000,
   max: 10,
-  message: { success: false, message: "Too many challenge requests" },
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "unknown"),
+  message: { success: false, message: "Too many challenge requests, please try again later." },
   standardHeaders: true,
   legacyHeaders: false,
+});
+
+export const loginRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  keyGenerator: (req) => `${ipKeyGenerator(req.ip ?? "unknown")}:${req.body?.publicKey ?? "unknown"}`,
+  message: { success: false, message: "Too many login attempts, please try again later." },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res, _next, options) => {
+    res.setHeader("Retry-After", Math.ceil(options.windowMs / 1000));
+    res.status(429).json(options.message);
+  },
+});
+
+export const ipLoginRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "unknown"),
+  message: { success: false, message: "Too many login attempts from this IP, please try again later." },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res, _next, options) => {
+    res.setHeader("Retry-After", Math.ceil(options.windowMs / 1000));
+    res.status(429).json(options.message);
+  },
 });
 
 export const verifyRateLimiter = rateLimit({

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -7,6 +7,8 @@ import {
 } from "../controllers/authController.js";
 import {
   challengeRateLimiter,
+  loginRateLimiter,
+  ipLoginRateLimiter,
   verifyRateLimiter,
 } from "../middleware/rateLimiter.js";
 import { requireJwtAuth } from "../middleware/jwtAuth.js";
@@ -87,7 +89,7 @@ router.post(
  *             schema:
  *               $ref: '#/components/schemas/AuthLoginResponse'
  */
-router.post("/login", verifyRateLimiter, validateBody(loginSchema), login);
+router.post("/login", ipLoginRateLimiter, loginRateLimiter, validateBody(loginSchema), login);
 
 /**
  * @swagger


### PR DESCRIPTION
- challengeRateLimiter: max 10 req/IP/hour using ipKeyGenerator
- loginRateLimiter: max 5 attempts per IP+publicKey per 15 minutes
- ipLoginRateLimiter: max 5 attempts per IP/hour with Retry-After header
- Updated authRoutes to apply ipLoginRateLimiter + loginRateLimiter on /login
- Added rate limiting tests covering 429 and Retry-After behaviour

Closes #467