### PR TITLE
fix(backend): optimise getPoolStats() with single query and Redis cac…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,3 +34,5 @@ INTERNAL_API_KEY=change-me
 
 # Sentry (leave blank to disable; set SENTRY_DSN in staging/production)
 SENTRY_DSN=
+
+REDIS_URL=redis://localhost:6379

--- a/backend/src/db/migrations/1700000000000_add-loan-events-type-index.sql
+++ b/backend/src/db/migrations/1700000000000_add-loan-events-type-index.sql
@@ -1,0 +1,9 @@
+-- Migration: add index on loan_events (event_type, created_at)
+-- Speeds up the conditional-aggregation query in getPoolStats()
+
+-- Up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_loan_events_type_created_at
+  ON loan_events (event_type, created_at);
+
+-- Down
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_loan_events_type_created_at;

--- a/backend/src/utils/cache.ts
+++ b/backend/src/utils/cache.ts
@@ -1,0 +1,51 @@
+import { createClient } from "redis";
+import logger from "../utils/logger.js";
+
+const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+export const redisClient = createClient({ url: redisUrl });
+
+redisClient.on("error", (err: Error) =>
+  logger.error("Redis client error", err),
+);
+
+redisClient.on("connect", () => logger.info("Redis client connected"));
+
+// Connect lazily on first use so the app doesn't crash if Redis is absent
+let _connected = false;
+export const ensureConnected = async (): Promise<void> => {
+  if (!_connected) {
+    await redisClient.connect();
+    _connected = true;
+  }
+};
+
+/**
+ * Get a cached JSON value. Returns null on miss or Redis unavailability.
+ */
+export const getCache = async <T>(key: string): Promise<T | null> => {
+  try {
+    await ensureConnected();
+    const raw = await redisClient.get(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch (err) {
+    logger.warn("Redis getCache error — bypassing cache", { key, err });
+    return null;
+  }
+};
+
+/**
+ * Store a JSON value with an optional TTL in seconds (default: 30 s).
+ */
+export const setCache = async (
+  key: string,
+  value: unknown,
+  ttlSeconds = 30,
+): Promise<void> => {
+  try {
+    await ensureConnected();
+    await redisClient.set(key, JSON.stringify(value), { EX: ttlSeconds });
+  } catch (err) {
+    logger.warn("Redis setCache error — skipping cache write", { key, err });
+  }
+};


### PR DESCRIPTION
## Summary
Fixes #476  — `getPoolStats()` full-table-scan bottleneck.

### Changes
**`backend/src/controllers/poolController.ts`**
- Replaces two `Promise.all` queries with a single conditional aggregation
  query covering all four event types in one scan.

**`backend/src/utils/cache.ts`** *(new file)*
- Redis v5 `createClient` wrapper exposing `getCache<T>` / `setCache`.
- Errors are caught and logged; cache misses fall through to the DB
  transparently so the app works even if Redis is down.

**`backend/src/db/migrations/1700000000000_add-loan-events-type-index.sql`** *(new file)*
- Adds `idx_loan_events_type_created_at` on `(event_type, created_at)`
  using `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — safe to run on live data.

### Behaviour
- First request after cold start hits the DB and warms the cache.
- All subsequent requests within 30 s are served from Redis.
- No change to the response shape — fully backwards compatible.

Closes #476