### PR TITLE
fix(contracts): remove TransferCooldown in mint() to prevent stale

### DIFF
--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -389,6 +389,9 @@ impl RemittanceNFT {
             env.storage()
                 .persistent()
                 .remove(&DataKey::Seized(user.clone()));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::TransferCooldown(user.clone()));
         }
 
         let metadata = RemittanceMetadata {


### PR DESCRIPTION

## Summary
- Added explicit removal of `TransferCooldown` key in [burn_internal()] function
- Added clarifying comment to document the purpose of this cleanup



closes #461