### PR TITLE
fix: EventIndexer has no validation or quarantine for malformed contr…

### DIFF
--- a/backend/migrations/1778000000008_quarantine-events.js
+++ b/backend/migrations/1778000000008_quarantine-events.js
@@ -1,0 +1,54 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * Creates the `quarantine_events` table to store malformed Soroban contract
+ * events that fail parsing in the EventIndexer.
+ *
+ * When an event cannot be parsed (e.g. a string where a u32 is expected),
+ * the raw XDR is preserved here for manual review and debugging instead of
+ * being silently discarded.
+ *
+ * Columns
+ * -------
+ * event_id       — Soroban event ID from the RPC response (unique per event)
+ * ledger         — Ledger sequence number the event was emitted in
+ * tx_hash        — Transaction hash that produced the event
+ * contract_id    — Contract address that emitted the event
+ * raw_xdr        — Full event payload serialised as JSON with base64-encoded
+ *                  topic and value XDR fields for offline debugging
+ * error_message  — Human-readable description of why parsing failed
+ * quarantined_at — Timestamp of when the event was quarantined
+ *
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const up = (pgm) => {
+  pgm.createTable("quarantine_events", {
+    id: { type: "serial", primaryKey: true },
+    event_id: { type: "varchar(255)", notNull: true, unique: true },
+    ledger: { type: "integer", notNull: true },
+    tx_hash: { type: "varchar(255)", notNull: true },
+    contract_id: { type: "varchar(255)", notNull: true },
+    raw_xdr: { type: "jsonb", notNull: true },
+    error_message: { type: "text", notNull: true },
+    quarantined_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("current_timestamp"),
+    },
+  });
+
+  pgm.createIndex("quarantine_events", "ledger");
+  pgm.createIndex("quarantine_events", "quarantined_at");
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const down = (pgm) => {
+  pgm.dropTable("quarantine_events");
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -128,6 +128,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2083,6 +2084,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2104,6 +2106,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2116,6 +2119,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2535,6 +2539,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
       "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2551,6 +2556,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
       "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -2568,6 +2574,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2691,6 +2698,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -3218,6 +3226,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3393,6 +3402,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3911,6 +3921,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4443,6 +4454,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5530,6 +5542,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5586,6 +5599,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6010,6 +6024,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7591,6 +7606,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9366,6 +9382,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -9557,6 +9574,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10765,6 +10783,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10923,6 +10942,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11158,6 +11178,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -338,6 +338,7 @@ export class EventIndexer {
           eventId: event.id,
           error,
         });
+        await this.quarantineEvent(event, error);
       }
     }
 
@@ -549,11 +550,23 @@ export class EventIndexer {
   }
 
   private decodeAddress(value: xdr.ScVal): string {
-    return scValToNative(value).toString();
+    const native = scValToNative(value);
+    if (typeof native !== "string") {
+      throw new Error(
+        `Expected address string, got ${typeof native}: ${String(native)}`,
+      );
+    }
+    return native;
   }
 
   private decodeAmount(value: xdr.ScVal): string {
-    return scValToNative(value).toString();
+    const native = scValToNative(value);
+    if (typeof native !== "bigint" && typeof native !== "number") {
+      throw new Error(
+        `Expected numeric amount, got ${typeof native}: ${String(native)}`,
+      );
+    }
+    return native.toString();
   }
 
   private decodeLoanId(value: xdr.ScVal): number | undefined {
@@ -561,6 +574,61 @@ export class EventIndexer {
       return Number(scValToNative(value));
     } catch {
       return undefined;
+    }
+  }
+
+  private async quarantineEvent(
+    event: SorobanRawEvent,
+    error: unknown,
+  ): Promise<void> {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    let rawTopics: string[] = [];
+    let rawValue = "";
+    try {
+      rawTopics = event.topic.map((t) => t.toXDR("base64"));
+      rawValue = event.value.toXDR("base64");
+    } catch {
+      // XDR serialisation itself failed; store empty strings so the row is
+      // still inserted and the error_message captures the original failure.
+    }
+
+    const rawXdr = {
+      id: event.id,
+      topics: rawTopics,
+      value: rawValue,
+      ledger: event.ledger,
+      txHash: event.txHash,
+      contractId: event.contractId,
+    };
+
+    logger.warn("Quarantining malformed event", {
+      eventId: event.id,
+      ledger: event.ledger,
+      txHash: event.txHash,
+      rawXdr,
+      error: errorMessage,
+    });
+
+    try {
+      await query(
+        `INSERT INTO quarantine_events (event_id, ledger, tx_hash, contract_id, raw_xdr, error_message)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (event_id) DO NOTHING`,
+        [
+          event.id,
+          event.ledger,
+          event.txHash,
+          event.contractId,
+          JSON.stringify(rawXdr),
+          errorMessage,
+        ],
+      );
+    } catch (dbError) {
+      logger.error("Failed to quarantine malformed event", {
+        eventId: event.id,
+        dbError,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
  - **Type assertions in decode methods** — `decodeAddress()` now throws if
    `scValToNative()` returns a non-string; `decodeAmount()` throws if the result
    is not a `bigint` or `number`. Previously both called `.toString()` on the
    raw return value, silently coercing garbage (e.g. `"[object Uint8Array]"`)
    into the borrower address or amount fields and storing it in the database
  - **Quarantine on parse failure** — the existing `catch` block in `storeEvents()`
    now calls `await this.quarantineEvent(event, error)` after logging. This method
    serialises the full raw event (base64-encoded topic and value XDR) into a
    `rawXdr` JSON object, logs it at `warn` level, and inserts a row into the new
    `quarantine_events` table. DB errors inside `quarantineEvent()` are caught and
    logged so they never block indexing of subsequent valid events
  - **Migration `1778000000008_quarantine-events.js`** — creates
    `quarantine_events(id, event_id UNIQUE, ledger, tx_hash, contract_id, raw_xdr JSONB,
    error_message, quarantined_at)` with indexes on `ledger` and `quarantined_at`
  - `ON CONFLICT (event_id) DO NOTHING` prevents duplicate rows on reindex runs

Closes #486