### PR TITLE
feat(contracts): add get_depositor_yield() view function to LendingPool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 .idea
 create_issues.sh
 .claude
+.kiro/

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -479,6 +479,25 @@ impl LendingPool {
         Ok(())
     }
 
+    /// Returns `(shares, current_asset_value)` for `provider` in the `token` pool.
+    ///
+    /// Net yield = `current_asset_value - original_deposit`.  Since original
+    /// deposit amounts are not stored per-depositor, callers derive yield by
+    /// comparing `current_asset_value` against their own recorded cost basis.
+    pub fn get_depositor_yield(env: Env, provider: Address, token: Address) -> (i128, i128) {
+        let shares = Self::read_shares(&env, &provider, &token);
+        if shares == 0 {
+            return (0, 0);
+        }
+        let cur_total_shares = Self::total_shares(&env, &token);
+        if cur_total_shares == 0 {
+            return (shares, 0);
+        }
+        let asset_value =
+            Self::calc_assets_to_redeem(shares, Self::read_pool_balance(&env, &token), cur_total_shares);
+        (shares, asset_value)
+    }
+
     /// Underlying asset value of `provider`'s LP shares (principal + yield).
     pub fn get_deposit(env: Env, provider: Address, token: Address) -> i128 {
         let shares = Self::read_shares(&env, &provider, &token);

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -493,8 +493,11 @@ impl LendingPool {
         if cur_total_shares == 0 {
             return (shares, 0);
         }
-        let asset_value =
-            Self::calc_assets_to_redeem(shares, Self::read_pool_balance(&env, &token), cur_total_shares);
+        let asset_value = Self::calc_assets_to_redeem(
+            shares,
+            Self::read_pool_balance(&env, &token),
+            cur_total_shares,
+        );
         (shares, asset_value)
     }
 

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -831,3 +831,48 @@ fn test_get_admin_returns_initialized_admin() {
 
     assert_eq!(pool_client.get_admin(), admin);
 }
+
+#[test]
+fn test_get_depositor_yield_no_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _, _) = create_token_contract(&env, &admin);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+
+    let provider = Address::generate(&env);
+    assert_eq!(pool_client.get_depositor_yield(&provider, &token_id), (0, 0));
+}
+
+#[test]
+fn test_get_depositor_yield_reflects_accrued_interest() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _) = create_token_contract(&env, &admin);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &1000);
+    pool_client.deposit(&provider, &token_id, &1000);
+
+    // Before any yield: asset_value == deposit amount.
+    let (shares, asset_value) = pool_client.get_depositor_yield(&provider, &token_id);
+    assert_eq!(shares, 1000);
+    assert_eq!(asset_value, 1000);
+
+    // Simulate interest repaid into the pool (increases pool balance without
+    // minting new shares, so each share is now worth more).
+    stellar_asset_client.mint(&pool_id, &200);
+
+    let (shares2, asset_value2) = pool_client.get_depositor_yield(&provider, &token_id);
+    assert_eq!(shares2, 1000);
+    assert_eq!(asset_value2, 1200); // 1000 shares * 1200 assets / 1000 total_shares
+}

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -844,7 +844,10 @@ fn test_get_depositor_yield_no_deposit() {
     pool_client.initialize(&admin);
 
     let provider = Address::generate(&env);
-    assert_eq!(pool_client.get_depositor_yield(&provider, &token_id), (0, 0));
+    assert_eq!(
+        pool_client.get_depositor_yield(&provider, &token_id),
+        (0, 0)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #458

## Problem
The LendingPool contract had no on-chain way for depositors to query their current yield. They had to fetch share price externally and do manual math.

## Solution
Added `get_depositor_yield(env, provider, token) -> (i128, i128)` which returns:
- `shares` — LP shares held by the provider
- `asset_value` — current redemption value of those shares (principal + accrued yield)

Net yield = `asset_value - original_deposit`. Since original deposit amounts are not stored per-depositor, callers compare `asset_value` against their own recorded cost basis.

The implementation reuses existing private helpers (`read_shares`, `total_shares`, `read_pool_balance`, `calc_assets_to_redeem`) with no new storage.

## Tests
Added 2 tests to `test.rs`:
- `test_get_depositor_yield_no_deposit` — returns `(0, 0)` for a provider with no position
- `test_get_depositor_yield_reflects_accrued_interest` — verifies asset_value increases when interest is repaid into the pool without new shares being minted

@ogazboiz Pls review Conflict