### PR TITLE
fix(backend): complete SIGTERM/SIGINT graceful shutdown for missing b…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -75,6 +75,7 @@ const shutdown = async (signal: "SIGTERM" | "SIGINT") => {
   stopIndexer();
   stopDefaultCheckerScheduler();
   stopNotificationCleanupScheduler();
+  stopWebhookRetryProcessor();
   
   if (typeof (eventStreamService as any).closeAll === 'function') {
     (eventStreamService as any).closeAll("Server shutting down");


### PR DESCRIPTION
…ackground services

Closes #433

## Problem
The backend `index.ts` had a partial graceful shutdown implementation, but `stopWebhookRetryProcessor` was missing, which could cause webhook retry jobs and tasks to keep running after termination signals `SIGTERM` / `SIGINT`.

## Solution
- Appended `stopWebhookRetryProcessor()` to the graceful shutdown sequence in `backend/src/index.ts`.
- Verified previous cleanup steps (`server.close()`, `stopIndexer()`, `stopDefaultCheckerScheduler()`, `stopNotificationCleanupScheduler()`, Event Stream SSE closures, and DB pool draining) remain intact to ensure zero hanging connections on redeploys.