### PR TITLE
#315 [Backend] enforce unique LoanApproved events per loan

### DIFF
--- a/backend/migrations/1782000000012_ensure-unique-loan-approved-events.js
+++ b/backend/migrations/1782000000012_ensure-unique-loan-approved-events.js
@@ -1,0 +1,63 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+  // Keep only the earliest LoanApproved event per loan before enforcing uniqueness.
+  pgm.sql(`
+    DELETE FROM loan_events le
+    USING (
+      SELECT id
+      FROM (
+        SELECT
+          id,
+          ROW_NUMBER() OVER (
+            PARTITION BY loan_id
+            ORDER BY ledger ASC, id ASC
+          ) AS row_num
+        FROM loan_events
+        WHERE loan_id IS NOT NULL
+          AND event_type = 'LoanApproved'
+      ) ranked
+      WHERE ranked.row_num > 1
+    ) duplicates
+    WHERE le.id = duplicates.id
+  `);
+
+  // Some environments may have missed the broader status-event index rollout.
+  // In that case, enforce LoanApproved uniqueness directly.
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND indexname = 'loan_events_unique_status_event_per_loan'
+      ) AND NOT EXISTS (
+        SELECT 1
+        FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND indexname = 'loan_events_unique_approved_event_per_loan'
+      ) THEN
+        CREATE UNIQUE INDEX loan_events_unique_approved_event_per_loan
+        ON loan_events (loan_id)
+        WHERE loan_id IS NOT NULL
+          AND event_type = 'LoanApproved';
+      END IF;
+    END $$;
+  `);
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+  pgm.sql("DROP INDEX IF EXISTS loan_events_unique_approved_event_per_loan");
+};

--- a/backend/src/__tests__/eventIndexer.test.ts
+++ b/backend/src/__tests__/eventIndexer.test.ts
@@ -270,6 +270,66 @@ describe("EventIndexer", () => {
     expect(mockGetScoreConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores duplicate LoanApproved rows for the same loan and emits side effects once", async () => {
+    const borrower = makeAddress();
+    let approvedInsertCount = 0;
+
+    mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql === "BEGIN" || sql === "COMMIT") {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (sql.includes("INSERT INTO loan_events")) {
+        if (params[1] === "LoanApproved" && params[2] === 42) {
+          approvedInsertCount += 1;
+          const inserted = approvedInsertCount === 1;
+          return {
+            rows: inserted ? [{ event_id: params[0] }] : [],
+            rowCount: inserted ? 1 : 0,
+          };
+        }
+
+        return { rows: [{ event_id: params[0] }], rowCount: 1 };
+      }
+
+      return { rows: [], rowCount: 0 };
+    });
+
+    const indexer = new EventIndexer({
+      rpcUrl: "https://rpc.test",
+      contractId: "CINDEXERTEST",
+    });
+
+    (indexer as unknown as { rpc: { getEvents: unknown } }).rpc = {
+      getEvents: async () => ({
+        events: [
+          makeRawEvent({
+            id: "evt-approved-001",
+            ledger: 31,
+            type: "LoanApproved",
+            borrower,
+            loanId: 42,
+          }),
+          makeRawEvent({
+            id: "evt-approved-002",
+            ledger: 32,
+            type: "LoanApproved",
+            borrower,
+            loanId: 42,
+          }),
+        ],
+      }),
+    };
+
+    await indexer.processEvents(31, 32);
+
+    expect(approvedInsertCount).toBe(2);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockGetScoreConfig).not.toHaveBeenCalled();
+  });
+
   it("initializes missing indexer state and persists the last indexed ledger during polling", async () => {
     const stateWrites: number[] = [];
 


### PR DESCRIPTION
## Summary
- add a defensive migration that de-duplicates historical LoanApproved rows per loan_id
- enforce database-level uniqueness for LoanApproved status events in environments that missed the prior status-index rollout
- add regression coverage in eventIndexer tests to verify duplicate approval replays only trigger side effects once

## Why
Issue #315 reports that replay/re-index flows can insert duplicate LoanApproved rows for the same loan and skew downstream calculations. This PR guarantees uniqueness at the DB layer and verifies ingest behavior for duplicate approvals.

Fixes #315
