### PR TITLE
 add upper-bound validation to set_default_burn_threshold 

### DIFF
--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -73,6 +73,7 @@ impl RemittanceNFT {
     const MIN_CREDIT_SCORE: u32 = 300;
     const MAX_CREDIT_SCORE: u32 = 850;
     pub const MAX_SCORE: u32 = 850;
+    pub const MAX_ALLOWED_BURN_THRESHOLD: u32 = 1000; // Set as appropriate for your business logic
 
     fn admin_key() -> soroban_sdk::Symbol {
         symbol_short!("ADMIN")
@@ -776,7 +777,7 @@ impl RemittanceNFT {
     }
 
     pub fn set_default_burn_threshold(env: Env, threshold: u32) -> Result<(), NftError> {
-        if threshold == 0 {
+        if threshold == 0 || threshold > Self::MAX_ALLOWED_BURN_THRESHOLD {
             return Err(NftError::InvalidThreshold);
         }
         Self::admin(&env).require_auth();

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -1073,3 +1073,30 @@ fn test_new_admin_can_act_after_transfer() {
     client.mint(&user, &500, &create_test_hash(&env, 40), &None);
     assert_eq!(client.get_score(&user), 500);
 }
+
+#[test]
+fn test_set_default_burn_threshold_upper_bound_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Should succeed for valid threshold
+    client.set_default_burn_threshold(&RemittanceNFT::MAX_ALLOWED_BURN_THRESHOLD);
+}
+
+#[test]
+#[should_panic]
+fn test_set_default_burn_threshold_upper_bound_invalid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Should panic for threshold above max
+    client.set_default_burn_threshold(&(RemittanceNFT::MAX_ALLOWED_BURN_THRESHOLD + 1));
+}


### PR DESCRIPTION
This pull request introduces a configurable upper bound for the burn threshold in the `RemittanceNFT` contract, ensuring that the threshold cannot be set above a defined maximum. It also adds tests to verify this new constraint.

**Burn threshold validation improvements:**

* Added a new constant `MAX_ALLOWED_BURN_THRESHOLD` to `RemittanceNFT` to define the maximum allowed value for the burn threshold.
* Updated the `set_default_burn_threshold` method to reject values above `MAX_ALLOWED_BURN_THRESHOLD`, in addition to zero.

**Testing:**

* Added tests to verify that setting the burn threshold at the upper bound succeeds, and that exceeding the upper bound correctly triggers an error.…old in RemittanceNFT

close #533 