### PR TITLE
Feat/contracts grace period loanmanager

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1192,7 +1192,6 @@ impl LoanManager {
         // Borrower must also sign.
         loan.borrower.require_auth();
 
-
         if loan.status != LoanStatus::Approved {
             return Err(LoanError::LoanNotActive);
         }

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -895,8 +895,19 @@ impl LoanManager {
         if loan.borrower != borrower {
             return Err(LoanError::BorrowerMismatch);
         }
+
         if loan.status != LoanStatus::Approved {
             return Err(LoanError::LoanNotActive);
+        }
+
+        // Allow repayment until end of default window
+        let current_ledger = env.ledger().sequence();
+        let default_ends = loan
+            .due_date
+            .checked_add(Self::default_window_ledgers(&env))
+            .expect("default window overflow");
+        if current_ledger > default_ends {
+            return Err(LoanError::LoanPastDue);
         }
 
         let (total_debt, late_fee_delta) = Self::current_total_debt(&env, &mut loan);
@@ -1181,13 +1192,18 @@ impl LoanManager {
         // Borrower must also sign.
         loan.borrower.require_auth();
 
+
         if loan.status != LoanStatus::Approved {
             return Err(LoanError::LoanNotActive);
         }
 
-        // Good-standing check: must not be past due.
+        // Allow refinance until end of default window
         let current_ledger = env.ledger().sequence();
-        if current_ledger > loan.due_date {
+        let default_ends = loan
+            .due_date
+            .checked_add(Self::default_window_ledgers(&env))
+            .expect("default window overflow");
+        if current_ledger > default_ends {
             return Err(LoanError::LoanPastDue);
         }
 

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -73,6 +73,7 @@ impl RemittanceNFT {
     const MIN_CREDIT_SCORE: u32 = 300;
     const MAX_CREDIT_SCORE: u32 = 850;
     pub const MAX_SCORE: u32 = 850;
+    pub const MAX_ALLOWED_BURN_THRESHOLD: u32 = 1000; // Set as appropriate for your business logic
 
     fn admin_key() -> soroban_sdk::Symbol {
         symbol_short!("ADMIN")
@@ -776,7 +777,7 @@ impl RemittanceNFT {
     }
 
     pub fn set_default_burn_threshold(env: Env, threshold: u32) -> Result<(), NftError> {
-        if threshold == 0 {
+        if threshold == 0 || threshold > Self::MAX_ALLOWED_BURN_THRESHOLD {
             return Err(NftError::InvalidThreshold);
         }
         Self::admin(&env).require_auth();

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -1073,3 +1073,30 @@ fn test_new_admin_can_act_after_transfer() {
     client.mint(&user, &500, &create_test_hash(&env, 40), &None);
     assert_eq!(client.get_score(&user), 500);
 }
+
+#[test]
+fn test_set_default_burn_threshold_upper_bound_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Should succeed for valid threshold
+    client.set_default_burn_threshold(&RemittanceNFT::MAX_ALLOWED_BURN_THRESHOLD);
+}
+
+#[test]
+#[should_panic]
+fn test_set_default_burn_threshold_upper_bound_invalid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Should panic for threshold above max
+    client.set_default_burn_threshold(&(RemittanceNFT::MAX_ALLOWED_BURN_THRESHOLD + 1));
+}


### PR DESCRIPTION
This pull request introduces stricter validation and handling for loan repayments, refinancing, and NFT burn thresholds, along with new tests to ensure these constraints are enforced. The main themes are improved loan lifecycle management and enhanced configuration safety for NFT burn thresholds.

**Loan lifecycle enforcement:**
- Extended the repayment and refinance eligibility period to allow actions up until the end of the default window, rather than strictly at the due date, by checking `current_ledger` against `due_date + default_window` in `LoanManager` methods. This prevents repayments or refinancing after the default window has expired. [[1]](diffhunk://#diff-52c62e6921e5bf7dcdaf57a35ad73c5a76fcc4f3a2ab38f5734a8cb5a3c07856R898-R912) [[2]](diffhunk://#diff-52c62e6921e5bf7dcdaf57a35ad73c5a76fcc4f3a2ab38f5734a8cb5a3c07856R1195-R1206)

**NFT burn threshold validation:**
- Introduced `MAX_ALLOWED_BURN_THRESHOLD` constant and updated the `set_default_burn_threshold` method in `RemittanceNFT` to reject thresholds above this value, preventing misconfiguration. [[1]](diffhunk://#diff-7a4e737ace52e7b29919ddb470307c1c40db1f03aa00b5933ed0fde7410e3e28R76) [[2]](diffhunk://#diff-7a4e737ace52e7b29919ddb470307c1c40db1f03aa00b5933ed0fde7410e3e28L779-R780)

**Testing enhancements:**
- Added tests to verify that setting the default burn threshold at the upper bound succeeds, and that exceeding the maximum allowed value correctly results in a panic, ensuring the new validation logic is enforced.
close #536 