### PR TITLE
test(contracts): add regression test for burn_internal TransferCooldown cleanup (#296)

### DIFF
--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -1306,3 +1306,33 @@ fn test_admin_remint_clears_seized_flag() {
 
     assert!(!client.is_seized(&user));
 }
+
+#[test]
+fn test_burn_clears_transfer_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    env.ledger().set_sequence_number(100);
+
+    client.initialize(&admin);
+    client.mint(&from, &500, &create_test_hash(&env, 40), &None);
+
+    // Transfer sets a cooldown on the destination
+    client.transfer(&from, &to, &None);
+    assert!(client.get_transfer_cooldown_remaining(&to) > 0);
+
+    // Burn should clear the cooldown
+    client.burn(&to, &None);
+    assert_eq!(client.get_transfer_cooldown_remaining(&to), 0);
+
+    // After remint the cooldown must not resurface
+    client.approve_remint(&to);
+    client.admin_remint(&to, &300, &create_test_hash(&env, 41));
+    assert_eq!(client.get_transfer_cooldown_remaining(&to), 0);
+}


### PR DESCRIPTION
## Linked Issue
Closes #296

## Description
The fix for issue #296 (adding `TransferCooldown` removal to [burn_internal()](cci:1://file:///home/dsotec/Documents/remitlend/contracts/remittance_nft/src/lib.rs:250:4-275:5)) was
already applied in commit afd66b0. This PR adds a **regression test** —
[test_burn_clears_transfer_cooldown](cci:1://file:///home/dsotec/Documents/remitlend/contracts/remittance_nft/src/test.rs:1309:0-1337:1) — to ensure the behavior is permanently
covered and cannot silently regress.

The test verifies:
1. A transfer sets a cooldown on the destination address
2. Burning that NFT clears the cooldown (returns 0)
3. After admin remint, the cooldown does not resurface

## Testing
- `cargo fmt --check` — ✅ passes
- `cargo clippy -- -D warnings` — ✅ passes
- `cargo test -p remittance_nft` — ✅ 58/58 tests pass (including the new test)

## Checklist
- [x] Code follows project style guides
- [x] Tests have been added/updated and pass
- [x] Commit messages follow Conventional Commits standards