### PR TITLE
fix(contracts): approve_loan() over-commits pool liquidity (#455)

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -117,6 +117,7 @@ pub enum DataKey {
     DefaultWindowLedgers,
     RateOracle,
     ProposedAdmin,
+    TotalOutstanding,
 }
 
 #[contract]
@@ -399,6 +400,23 @@ impl LoanManager {
         let next_count = current_count - 1;
         env.storage().persistent().set(&key, &next_count);
         Self::bump_persistent_ttl(env, &key);
+    }
+
+    fn total_outstanding(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalOutstanding)
+            .unwrap_or(0i128)
+    }
+
+    fn add_outstanding(env: &Env, amount: i128) {
+        let next = Self::total_outstanding(env).checked_add(amount).expect("outstanding overflow");
+        env.storage().instance().set(&DataKey::TotalOutstanding, &next);
+    }
+
+    fn sub_outstanding(env: &Env, amount: i128) {
+        let next = Self::total_outstanding(env).saturating_sub(amount);
+        env.storage().instance().set(&DataKey::TotalOutstanding, &next);
     }
 
     fn accrue_late_fee(env: &Env, loan: &mut Loan) -> i128 {
@@ -844,7 +862,8 @@ impl LoanManager {
             .expect("token not set");
         let pool_client = PoolClient::new(&env, &lending_pool);
         let pool_balance = pool_client.pool_balance(&token);
-        if pool_balance < loan.amount {
+        let available = pool_balance.saturating_sub(Self::total_outstanding(&env));
+        if available < loan.amount {
             return Err(LoanError::InsufficientPoolLiquidity);
         }
 
@@ -861,6 +880,7 @@ impl LoanManager {
         Self::bump_persistent_ttl(&env, &loan_key);
         let token_client = TokenClient::new(&env, &token);
 
+        Self::add_outstanding(&env, loan.amount);
         token_client.transfer(&lending_pool, &loan.borrower, &loan.amount);
 
         events::loan_approved(&env, loan_id, loan.borrower.clone());
@@ -997,6 +1017,7 @@ impl LoanManager {
         if completed {
             loan.status = LoanStatus::Repaid;
             loan.collateral_amount = 0;
+            Self::sub_outstanding(&env, loan.amount);
             Self::decrement_borrower_loan_count(&env, &loan.borrower);
             Self::release_collateral_internal(&env, loan_id, &loan.borrower);
         }
@@ -1756,6 +1777,7 @@ impl LoanManager {
         loan.status = LoanStatus::Defaulted;
         env.storage().persistent().set(&loan_key, &loan);
         Self::bump_persistent_ttl(&env, &loan_key);
+        Self::sub_outstanding(&env, loan.amount);
         Self::decrement_borrower_loan_count(&env, &loan.borrower);
         Self::seize_collateral_internal(&env, loan_id);
 
@@ -1801,6 +1823,7 @@ impl LoanManager {
             loan.status = LoanStatus::Defaulted;
             env.storage().persistent().set(&loan_key, &loan);
             Self::bump_persistent_ttl(&env, &loan_key);
+            Self::sub_outstanding(&env, loan.amount);
             Self::decrement_borrower_loan_count(&env, &loan.borrower);
             Self::seize_collateral_internal(&env, loan_id);
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1249,3 +1249,33 @@ fn test_pending_loans_count_against_cap() {
     let result = client.try_request_loan(&borrower, &500);
     assert_eq!(result, Err(Ok(LoanError::MaxLoansReached)));
 }
+
+#[test]
+fn test_concurrent_approvals_exceeding_pool_capacity_blocked() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower1 = Address::generate(&env);
+    let borrower2 = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(&borrower1, &600, &history_hash, &None);
+    nft_client.mint(&borrower2, &600, &history_hash, &None);
+
+    // Pool has 10_000; two loans of 6_000 each would exceed capacity
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &10_000);
+
+    let loan_id1 = manager.request_loan(&borrower1, &6_000);
+    let loan_id2 = manager.request_loan(&borrower2, &6_000);
+
+    // First approval succeeds
+    manager.approve_loan(&loan_id1);
+    assert_eq!(manager.get_loan(&loan_id1).status, LoanStatus::Approved);
+
+    // Second approval must fail: only 4_000 available, 6_000 requested
+    let result = manager.try_approve_loan(&loan_id2);
+    assert_eq!(result, Err(Ok(LoanError::InsufficientPoolLiquidity)));
+    assert_eq!(manager.get_loan(&loan_id2).status, LoanStatus::Pending);
+}


### PR DESCRIPTION
## Problem

approve_loan() checked pool_balance >= loan.amount but did not account for already-approved loans that had not yet been repaid. With a pool of 10,000 tokens, two sequential approvals of 6,000 each would both pass the check but only the first transfer would succeed. The second would panic at the token transfer step.

## Changes

contracts/loan_manager/src/lib.rs
- Added DataKey::TotalOutstanding to instance storage
- Added private helpers total_outstanding, add_outstanding, sub_outstanding
- approve_loan: checks pool_balance - outstanding >= loan.amount and increments outstanding before the transfer
- repay: decrements outstanding when a loan is fully repaid (LoanStatus::Repaid)
- check_default / check_defaults: decrements outstanding on default

contracts/loan_manager/src/test.rs
- Added test_concurrent_approvals_exceeding_pool_capacity_blocked: pool has 10,000, two loans of 6,000 each, first approval passes, second returns InsufficientPoolLiquidity and stays Pending

## Testing

Tests pass on Linux (CI). The export ordinal too large error seen locally is a Windows/mingw linker limitation unrelated to these changes. CI runs on ubuntu-latest.

Closes #455