### PR TITLE
fix(frontend): format code to pass prettier lint checks

### DIFF
--- a/frontend/src/app/[locale]/kingdom/page.tsx
+++ b/frontend/src/app/[locale]/kingdom/page.tsx
@@ -19,7 +19,10 @@ const KingdomProgressWidget = dynamic(
 );
 
 const AchievementsPanel = dynamic(
-  () => import("../../components/gamification/AchievementsPanel").then((m) => m.AchievementsPanel),
+  () =>
+    import("../../components/gamification/AchievementsPanel").then(
+      (m) => m.AchievementsPanel,
+    ),
   { ssr: false, loading: () => <AchievementsSkeleton /> },
 );
 
@@ -50,7 +53,9 @@ export default function KingdomPage() {
       </header>
 
       {/* Welcome card */}
-      <Card className="bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-950/30 dark:to-blue-950/30 border-purple-200 dark:border-purple-800">
+      <Card
+        className="bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-950/30 dark:to-blue-950/30 border-purple-200 dark:border-purple-800"
+      >
         <div className="p-6">
           <div className="flex items-center justify-between">
             <div>

--- a/frontend/src/app/components/borrower/LoanCard.tsx
+++ b/frontend/src/app/components/borrower/LoanCard.tsx
@@ -29,7 +29,13 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
   const badge =
     variant === "detailed"
       ? {
-          label: isDefaulted ? "Defaulted" : isOverdue ? "Overdue" : isUrgent ? "Due Soon" : "On Track",
+          label: isDefaulted
+            ? "Defaulted"
+            : isOverdue
+              ? "Overdue"
+              : isUrgent
+                ? "Due Soon"
+                : "On Track",
           className: isDefaulted
             ? "bg-red-900 text-white"
             : isOverdue
@@ -41,7 +47,13 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
       : null;
 
   // ── Deadline colours ───────────────────────────────────────────────────────
-  const deadlineBg = isDefaulted ? "bg-red-900/20" : isOverdue ? "bg-red-50" : isUrgent ? "bg-yellow-50" : "bg-gray-50";
+  const deadlineBg = isDefaulted
+    ? "bg-red-900/20"
+    : isOverdue
+      ? "bg-red-50"
+      : isUrgent
+        ? "bg-yellow-50"
+        : "bg-gray-50";
   const deadlineTextColor = isDefaulted
     ? "text-red-900"
     : isOverdue

--- a/frontend/src/app/components/skeletons/AchievementsSkeleton.tsx
+++ b/frontend/src/app/components/skeletons/AchievementsSkeleton.tsx
@@ -7,7 +7,10 @@ export function AchievementsSkeleton() {
       <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-zinc-800" />
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="rounded-lg border border-gray-200 dark:border-zinc-800 p-4 space-y-3">
+          <div
+            key={i}
+            className="rounded-lg border border-gray-200 dark:border-zinc-800 p-4 space-y-3"
+          >
             <div className="flex items-start gap-3">
               <div className="h-12 w-12 rounded-full bg-gray-200 dark:bg-zinc-800 flex-shrink-0" />
               <div className="flex-1 space-y-2 min-w-0">


### PR DESCRIPTION
Fixes formatting issues that were causing prettier lint failures in the frontend.

## Changes

- Wrap long import statements to stay within the 100-character line limit
- Break long ternary operators across multiple lines for better readability
- Adjust classNames to fit within prettier's print width setting

The merge of PR #692 introduced code that didn't comply with prettier's formatting rules, causing CI to fail. This PR fixes those formatting issues.