### PR TITLE
feat(frontend): unify empty states and auth/session UX

### DIFF
--- a/frontend/src/app/[locale]/activity/page.tsx
+++ b/frontend/src/app/[locale]/activity/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useTranslations } from "next-intl";
-import { Clock, ArrowUpRight, ArrowDownLeft, ExternalLink, X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { Clock, ArrowUpRight, ArrowDownLeft, ExternalLink } from "lucide-react";
 import { useWalletStore, selectIsWalletConnected } from "../../stores/useWalletStore";
 import { useLoans, useRemittances } from "../../hooks/useApi";
 import { ErrorBoundary } from "../../components/global_ui/ErrorBoundary";
 import { StatusIndicator } from "../../components/ui/StatusIndicator";
+import { EmptyState } from "../../components/ui/EmptyState";
 
 type FilterType = "all" | "loan" | "remittance";
 
@@ -24,6 +25,7 @@ const ITEMS_PER_PAGE = 20;
 
 export default function ActivityPage() {
   const t = useTranslations("ActivityPage");
+  const locale = useLocale();
   const isConnected = useWalletStore(selectIsWalletConnected);
   const [currentPage, setCurrentPage] = useState(1);
   const [filterType, setFilterType] = useState<FilterType>("all");
@@ -34,9 +36,10 @@ export default function ActivityPage() {
   });
 
   const isLoading = loansLoading || remittancesLoading;
+  const isFilteredView = filterType !== "all";
 
   const allActivity = useMemo(() => {
-    const loanEvents: ActivityItem[] = loans.map((loan, idx) => ({
+    const loanEvents: ActivityItem[] = loans.map((loan) => ({
       id: `loan-${loan.id}`,
       type:
         loan.status === "repaid"
@@ -53,7 +56,7 @@ export default function ActivityPage() {
       txHash: undefined,
     }));
 
-    const remittanceEvents: ActivityItem[] = remittances.map((remittance, idx) => ({
+    const remittanceEvents: ActivityItem[] = remittances.map((remittance) => ({
       id: `remittance-${remittance.id}`,
       type: "Remittance",
       description: `To ${remittance.recipientAddress.slice(0, 6)}...${remittance.recipientAddress.slice(-4)}`,
@@ -142,9 +145,18 @@ export default function ActivityPage() {
               ))}
             </div>
           ) : paginatedActivity.length === 0 ? (
-            <div className="p-12 text-center">
-              <Clock className="h-12 w-12 mx-auto text-zinc-300 dark:text-zinc-700 mb-4" />
-              <p className="text-zinc-500 dark:text-zinc-400">{t("emptyState")}</p>
+            <div className="p-6">
+              <EmptyState
+                icon={Clock}
+                title={isFilteredView ? "No matching activity" : "No activity yet"}
+                description={
+                  isFilteredView
+                    ? "Try a different filter to see more loan and remittance history."
+                    : t("emptyState")
+                }
+                actionLabel={isFilteredView ? undefined : "Send your first remittance"}
+                actionHref={isFilteredView ? undefined : `/${locale}/send-remittance`}
+              />
             </div>
           ) : (
             <div className="divide-y divide-zinc-200 dark:divide-zinc-800">

--- a/frontend/src/app/[locale]/lend/LendPageClient.tsx
+++ b/frontend/src/app/[locale]/lend/LendPageClient.tsx
@@ -30,6 +30,7 @@ import { OperationProgress } from "../../components/ui/OperationProgress";
 import { useDepositOperation, useWithdrawalOperation } from "../../hooks/useRepaymentOperation";
 import { selectWalletAddress, useWalletStore } from "../../stores/useWalletStore";
 import { useSSE } from "../../hooks/useSSE";
+import { EmptyState } from "../../components/ui/EmptyState";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
@@ -385,12 +386,11 @@ export function LendPageClient() {
 
             {!isLoading &&
               (loans ?? []).filter((loan) => loan.status === "active").length === 0 && (
-                <div className="rounded-2xl border border-dashed border-zinc-300 px-6 py-8 text-center dark:border-zinc-700">
-                  <PiggyBank className="mx-auto h-6 w-6 text-zinc-400" />
-                  <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-                    No active pool-funded loans available yet.
-                  </p>
-                </div>
+                <EmptyState
+                  icon={PiggyBank}
+                  title="No active pool-funded loans yet"
+                  description="Active loans funded by the pool will appear here once borrowers draw against available liquidity."
+                />
               )}
           </div>
         </section>
@@ -403,6 +403,12 @@ export function LendPageClient() {
               <Skeleton className="h-5 w-40" />
               <Skeleton className="h-[300px] w-full rounded-xl" />
             </div>
+          ) : chartData.length === 0 ? (
+            <EmptyState
+              icon={Activity}
+              title="No yield history yet"
+              description="Yield performance will appear here after the pool records deposits, loans, and earnings."
+            />
           ) : (
             <YieldEarningsChart data={chartData} />
           )}

--- a/frontend/src/app/[locale]/loans/LoansPageClient.tsx
+++ b/frontend/src/app/[locale]/loans/LoansPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowRight, CalendarRange, CircleDollarSign, ShieldCheck } from "lucide-react";
+import { ArrowRight, CalendarRange, CircleDollarSign, HandCoins, ShieldCheck } from "lucide-react";
 import { ErrorBoundary } from "../../components/global_ui/ErrorBoundary";
 import { LoansListSkeleton } from "../../components/skeletons/LoansListSkeleton";
 import { useBorrowerLoansPage } from "../../hooks/useApi";
@@ -10,6 +10,7 @@ import { LoanStatusBadge } from "../../components/ui/LoanStatusBadge";
 import { PaginationControls } from "../../components/ui/PaginationControls";
 import { useWalletStore, selectWalletAddress } from "../../stores/useWalletStore";
 import { useTranslations, useLocale } from "next-intl";
+import { EmptyState } from "../../components/ui/EmptyState";
 
 const PAGE_SIZE = 20;
 
@@ -162,21 +163,14 @@ export function LoansPageClient() {
           </div>
 
           {displayedLoans.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-              <p className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
-                {t("empty.title")}
-              </p>
-              <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-                {t("empty.description")}
-              </p>
-              <Link
-                href={`/${locale}`}
-                className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
-              >
-                {t("empty.action")}
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </div>
+            <EmptyState
+              icon={HandCoins}
+              title={t("empty.title")}
+              description={t("empty.description")}
+              actionLabel={t("empty.action")}
+              actionHref={`/${locale}/request-loan`}
+              actionIcon={<ArrowRight className="h-4 w-4" />}
+            />
           ) : (
             <div className="space-y-3">
               {displayedLoans.map((loan) => (

--- a/frontend/src/app/[locale]/remittances/page.tsx
+++ b/frontend/src/app/[locale]/remittances/page.tsx
@@ -13,6 +13,7 @@ import {
   DollarSign,
   Search,
 } from "lucide-react";
+import { useLocale } from "next-intl";
 import {
   useWalletStore,
   selectIsWalletConnected,
@@ -24,6 +25,7 @@ import { ErrorBoundary } from "../../components/global_ui/ErrorBoundary";
 import { Spinner } from "../../components/global_ui/Spinner";
 import { PaginationControls } from "../../components/ui/PaginationControls";
 import Link from "next/link";
+import { EmptyState } from "../../components/ui/EmptyState";
 
 function formatCurrency(value: number): string {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
@@ -67,33 +69,6 @@ type StatusFilter = "all" | Remittance["status"];
 
 const PAGE_SIZE = 20;
 
-function EmptyState({ filtered }: { filtered: boolean }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-20 text-center">
-      <div className="mb-4 rounded-2xl bg-zinc-50 p-6 dark:bg-zinc-900">
-        <SendHorizontal className="h-10 w-10 text-indigo-400" />
-      </div>
-      <h3 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-        {filtered ? "No remittances match this status" : "No remittances yet"}
-      </h3>
-      <p className="max-w-xs text-sm text-zinc-500 dark:text-zinc-400">
-        {filtered
-          ? "Try a different status filter to see more results."
-          : "Your cross-border transfers will appear here once you send your first remittance."}
-      </p>
-      {!filtered && (
-        <Link
-          href="/"
-          className="mt-6 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
-        >
-          <ArrowUpRight className="h-4 w-4" />
-          New Remittance
-        </Link>
-      )}
-    </div>
-  );
-}
-
 function ConnectWalletPrompt() {
   return (
     <main className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-8">
@@ -111,6 +86,7 @@ function ConnectWalletPrompt() {
 }
 
 export default function RemittancesPage() {
+  const locale = useLocale();
   const isConnected = useWalletStore(selectIsWalletConnected);
   const address = useWalletStore(selectWalletAddress);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -188,7 +164,7 @@ export default function RemittancesPage() {
           </p>
         </div>
         <Link
-          href="/"
+          href={`/${locale}/send-remittance`}
           className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
         >
           <ArrowUpRight className="h-4 w-4" />
@@ -348,7 +324,18 @@ export default function RemittancesPage() {
               </p>
             </div>
           ) : remittances.length === 0 ? (
-            <EmptyState filtered={statusFilter !== "all"} />
+            <EmptyState
+              icon={SendHorizontal}
+              title={statusFilter !== "all" ? "No remittances match this status" : "No remittances yet"}
+              description={
+                statusFilter !== "all"
+                  ? "Try a different filter to see more transfer history."
+                  : "Your cross-border transfers will appear here once you send your first remittance."
+              }
+              actionLabel={statusFilter !== "all" ? undefined : "Send your first remittance"}
+              actionHref={statusFilter !== "all" ? undefined : `/${locale}/send-remittance`}
+              actionIcon={<ArrowUpRight className="h-4 w-4" />}
+            />
           ) : (
             <div className="rounded-xl border border-zinc-200 bg-white overflow-hidden dark:border-zinc-800 dark:bg-zinc-950">
               <div className="grid grid-cols-12 gap-4 border-b border-zinc-100 bg-zinc-50 px-6 py-3 dark:border-zinc-800 dark:bg-zinc-900/50">

--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -24,6 +24,7 @@ import {
   selectWalletNetwork,
 } from "../../stores/useWalletStore";
 import { useUserStore, selectUser } from "../../stores/useUserStore";
+import { logoutUser } from "../../lib/session";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -478,6 +479,7 @@ function DisplaySection() {
 
 export default function SettingsPage() {
   const [activeSection, setActiveSection] = useState<SectionId>("profile");
+  const handleLogout = () => logoutUser("manual");
 
   const renderSection = () => {
     switch (activeSection) {
@@ -498,12 +500,22 @@ export default function SettingsPage() {
 
   return (
     <main className="space-y-8 min-h-screen p-8 lg:p-12 max-w-5xl mx-auto">
-      <header>
-        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Account</p>
-        <h1 className="mt-1 text-3xl font-bold text-zinc-900 dark:text-zinc-50">Settings</h1>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-          Manage your profile, wallet, notifications, and preferences.
-        </p>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Account</p>
+          <h1 className="mt-1 text-3xl font-bold text-zinc-900 dark:text-zinc-50">Settings</h1>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Manage your profile, wallet, notifications, and preferences.
+          </p>
+        </div>
+        <Button
+          variant="danger"
+          onClick={handleLogout}
+          leftIcon={<LogOut className="h-4 w-4" />}
+          className="sm:mt-1"
+        >
+          Log out
+        </Button>
       </header>
 
       <div className="flex flex-col lg:flex-row gap-8">

--- a/frontend/src/app/components/borrower/LoanList.tsx
+++ b/frontend/src/app/components/borrower/LoanList.tsx
@@ -2,11 +2,12 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Card } from "../ui/Card";
-import { Button } from "../ui/Button";
+import { ArrowRight, Landmark } from "lucide-react";
+import { useLocale } from "next-intl";
 import { LoanCard } from "./LoanCard";
 import { PaginationControls } from "../ui/PaginationControls";
 import type { BorrowerLoan } from "../../hooks/useApi";
+import { EmptyState } from "../ui/EmptyState";
 
 interface LoanListProps {
   loans: BorrowerLoan[];
@@ -27,6 +28,7 @@ export function LoanList({
   showRequestLoanButton = false,
 }: LoanListProps) {
   const router = useRouter();
+  const locale = useLocale();
   const [page, setPage] = useState(1);
 
   const totalPages = Math.max(1, Math.ceil(loans.length / PAGE_SIZE));
@@ -38,15 +40,16 @@ export function LoanList({
 
   if (loans.length === 0) {
     return (
-      <Card className="p-8">
-        <div className="text-center">
-          <h3 className="text-xl font-semibold mb-2">{emptyTitle}</h3>
-          <p className="text-gray-600 mb-4">{emptyDescription}</p>
-          {showRequestLoanButton && (
-            <Button onClick={() => router.push("/request-loan")}>Request a Loan</Button>
-          )}
-        </div>
-      </Card>
+      <EmptyState
+        icon={Landmark}
+        title={emptyTitle}
+        description={emptyDescription}
+        actionLabel={showRequestLoanButton ? "Request your first loan" : undefined}
+        onAction={
+          showRequestLoanButton ? () => router.push(`/${locale}/request-loan`) : undefined
+        }
+        actionIcon={<ArrowRight className="h-4 w-4" />}
+      />
     );
   }
 

--- a/frontend/src/app/components/gamification/LevelUpModal.tsx
+++ b/frontend/src/app/components/gamification/LevelUpModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Crown, Sparkles, Gift } from "lucide-react";
 import { useGamificationStore } from "@/app/stores/useGamificationStore";
 import { useSoundEffect } from "@/app/utils/soundManager";
 import { Button } from "../ui/Button";
+import { useModalFocusTrap } from "../../hooks/useModalFocusTrap";
 
 export function LevelUpModal() {
   const showModal = useGamificationStore((state) => state.showLevelUpModal);
@@ -13,6 +14,8 @@ export function LevelUpModal() {
   const dismissLevelUp = useGamificationStore((state) => state.dismissLevelUp);
   const soundEnabled = useGamificationStore((state) => state.soundEnabled);
   const animationsEnabled = useGamificationStore((state) => state.animationsEnabled);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const sound = useSoundEffect();
 
@@ -31,6 +34,13 @@ export function LevelUpModal() {
     dismissLevelUp();
   };
 
+  useModalFocusTrap({
+    isOpen: showModal,
+    onClose: handleClose,
+    containerRef: modalRef,
+    initialFocusRef: closeButtonRef,
+  });
+
   return (
     <AnimatePresence>
       {showModal && (
@@ -46,10 +56,15 @@ export function LevelUpModal() {
 
           {/* Modal */}
           <motion.div
+            ref={modalRef}
             initial={animationsEnabled ? { scale: 0.5, opacity: 0, y: 50 } : { opacity: 0 }}
             animate={animationsEnabled ? { scale: 1, opacity: 1, y: 0 } : { opacity: 1 }}
             exit={animationsEnabled ? { scale: 0.8, opacity: 0, y: 20 } : { opacity: 0 }}
             transition={{ type: "spring", duration: 0.5 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="level-up-modal-title"
+            tabIndex={-1}
             className="relative w-full max-w-md overflow-hidden rounded-2xl bg-gradient-to-br from-purple-50 to-blue-50 shadow-2xl dark:from-purple-950/30 dark:to-blue-950/30 dark:border dark:border-purple-800"
           >
             {/* Animated background sparkles */}
@@ -88,7 +103,9 @@ export function LevelUpModal() {
 
             {/* Close button */}
             <button
+              ref={closeButtonRef}
               onClick={handleClose}
+              aria-label="Close level up modal"
               className="absolute top-4 right-4 z-10 rounded-full p-2 text-gray-600 hover:bg-white/50 dark:text-gray-400 dark:hover:bg-black/20"
             >
               <X size={20} />
@@ -108,6 +125,7 @@ export function LevelUpModal() {
 
               {/* Level up text */}
               <motion.h2
+                id="level-up-modal-title"
                 initial={animationsEnabled ? { opacity: 0, y: 20 } : {}}
                 animate={animationsEnabled ? { opacity: 1, y: 0 } : {}}
                 transition={{ delay: 0.3 }}

--- a/frontend/src/app/components/loan-wizard/RepaymentScheduleTable.tsx
+++ b/frontend/src/app/components/loan-wizard/RepaymentScheduleTable.tsx
@@ -3,6 +3,7 @@
 import { CalendarDays } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/Card";
 import type { LoanAmortization, LoanAmortizationScheduleRow } from "../../hooks/useApi";
+import { EmptyState } from "../ui/EmptyState";
 
 function formatMoney(value: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -91,66 +92,77 @@ export function RepaymentScheduleTable({
           </div>
         )}
 
-        <div className="overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-800">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
-                <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
-                  Period
-                </th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
-                  Due Date
-                </th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
-                  Principal
-                </th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
-                  Interest
-                </th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
-                  Total
-                </th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
-                  Balance
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {schedule.map((row) => (
-                <tr key={row.period} className="border-b border-zinc-100 dark:border-zinc-800/50">
-                  <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400">{row.period}</td>
-                  <td className="px-4 py-3 text-zinc-900 dark:text-zinc-50">{row.dueDate}</td>
-                  <td className="px-4 py-3 text-right text-zinc-900 dark:text-zinc-50">
-                    {formatMoney(row.principal)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-amber-600 dark:text-amber-400">
-                    {formatMoney(row.interest)}
-                  </td>
-                  <td className="px-4 py-3 text-right font-semibold text-zinc-900 dark:text-zinc-50">
-                    {formatMoney(row.total)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-zinc-500 dark:text-zinc-400">
-                    {formatMoney(row.balance)}
-                  </td>
+        {schedule.length === 0 ? (
+          <EmptyState
+            icon={CalendarDays}
+            title="No repayment schedule available"
+            description="Generate or load a loan preview to see installment dates and balances."
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-800">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
+                  <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                    Period
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                    Due Date
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
+                    Principal
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
+                    Interest
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
+                    Total
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400">
+                    Balance
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-            <tfoot>
-              <tr className="bg-zinc-50 dark:bg-zinc-900">
-                <td
-                  colSpan={4}
-                  className="px-4 py-3 text-right font-semibold text-zinc-700 dark:text-zinc-300"
-                >
-                  Total Cost of Loan
-                </td>
-                <td className="px-4 py-3 text-right font-semibold text-indigo-600 dark:text-indigo-400">
-                  {formatMoney(amortization.totalDue)}
-                </td>
-                <td />
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {schedule.map((row) => (
+                  <tr
+                    key={row.period}
+                    className="border-b border-zinc-100 dark:border-zinc-800/50"
+                  >
+                    <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400">{row.period}</td>
+                    <td className="px-4 py-3 text-zinc-900 dark:text-zinc-50">{row.dueDate}</td>
+                    <td className="px-4 py-3 text-right text-zinc-900 dark:text-zinc-50">
+                      {formatMoney(row.principal)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-amber-600 dark:text-amber-400">
+                      {formatMoney(row.interest)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-zinc-900 dark:text-zinc-50">
+                      {formatMoney(row.total)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-500 dark:text-zinc-400">
+                      {formatMoney(row.balance)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="bg-zinc-50 dark:bg-zinc-900">
+                  <td
+                    colSpan={4}
+                    className="px-4 py-3 text-right font-semibold text-zinc-700 dark:text-zinc-300"
+                  >
+                    Total Cost of Loan
+                  </td>
+                  <td className="px-4 py-3 text-right font-semibold text-indigo-600 dark:text-indigo-400">
+                    {formatMoney(amortization.totalDue)}
+                  </td>
+                  <td />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/app/components/ui/EmptyState.tsx
+++ b/frontend/src/app/components/ui/EmptyState.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ElementType, ReactNode } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+interface EmptyStateProps {
+  icon: ElementType<{ className?: string }>;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  actionHref?: string;
+  onAction?: () => void;
+  actionIcon?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  actionHref,
+  onAction,
+  actionIcon,
+  className,
+}: EmptyStateProps) {
+  const actionClasses =
+    "mt-6 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500";
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700",
+        className,
+      )}
+    >
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+        <Icon className="h-8 w-8" />
+      </div>
+      <p className="mt-5 text-base font-semibold text-zinc-900 dark:text-zinc-50">{title}</p>
+      <p className="mx-auto mt-2 max-w-md text-sm text-zinc-500 dark:text-zinc-400">
+        {description}
+      </p>
+      {actionLabel && actionHref ? (
+        <Link href={actionHref} className={actionClasses}>
+          {actionLabel}
+          {actionIcon ?? <ArrowRight className="h-4 w-4" />}
+        </Link>
+      ) : null}
+      {actionLabel && onAction ? (
+        <button type="button" onClick={onAction} className={actionClasses}>
+          {actionLabel}
+          {actionIcon ?? <ArrowRight className="h-4 w-4" />}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/components/ui/Modal.tsx
+++ b/frontend/src/app/components/ui/Modal.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { motion, AnimatePresence } from "framer-motion";
+import { useModalFocusTrap } from "../../hooks/useModalFocusTrap";
 
 /** Tool to merge Tailwind classes safely */
 function cn(...inputs: ClassValue[]) {
@@ -36,74 +37,15 @@ const Modal: React.FC<ModalProps> = ({
   size = "lg",
 }) => {
   const modalRef = React.useRef<HTMLDivElement>(null);
-  const triggerRef = React.useRef<HTMLElement | null>(null);
+  const closeButtonRef = React.useRef<HTMLButtonElement>(null);
+  const titleId = React.useId();
 
-  React.useEffect(() => {
-    if (isOpen) {
-      triggerRef.current = document.activeElement as HTMLElement;
-      document.body.style.overflow = "hidden";
-
-      // Delay slightly to ensure elements are rendered before focusing
-      requestAnimationFrame(() => {
-        if (!modalRef.current) return;
-        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        );
-        if (focusableElements.length) {
-          focusableElements[0].focus();
-        }
-      });
-    }
-
-    return () => {
-      document.body.style.overflow = "unset";
-      if (!isOpen && triggerRef.current) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [isOpen]);
-
-  React.useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!isOpen) return;
-
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-
-      if (e.key === "Tab") {
-        if (!modalRef.current) return;
-
-        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        );
-
-        if (focusableElements.length === 0) {
-          e.preventDefault();
-          return;
-        }
-
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
+  useModalFocusTrap({
+    isOpen,
+    onClose,
+    containerRef: modalRef,
+    initialFocusRef: closeButtonRef,
+  });
 
   return (
     <AnimatePresence>
@@ -127,7 +69,8 @@ const Modal: React.FC<ModalProps> = ({
             ref={modalRef}
             role="dialog"
             aria-modal="true"
-            aria-labelledby={title ? "modal-title" : undefined}
+            aria-labelledby={title ? titleId : undefined}
+            tabIndex={-1}
             className={cn(
               "relative w-full overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-zinc-950 dark:border dark:border-zinc-800 focus:outline-none",
               sizeClasses[size],
@@ -137,13 +80,14 @@ const Modal: React.FC<ModalProps> = ({
             <div className="flex items-center justify-between border-b border-gray-100 p-6 dark:border-zinc-800">
               {title && (
                 <h3
-                  id="modal-title"
+                  id={titleId}
                   className="text-xl font-semibold text-gray-900 dark:text-zinc-100"
                 >
                   {title}
                 </h3>
               )}
               <button
+                ref={closeButtonRef}
                 onClick={onClose}
                 aria-label="Close modal"
                 className="rounded-full p-2 text-gray-400 hover:bg-gray-100 dark:hover:bg-zinc-900 dark:text-zinc-500"
@@ -160,3 +104,4 @@ const Modal: React.FC<ModalProps> = ({
 };
 
 export { Modal };
+export default Modal;

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -18,6 +18,7 @@ import {
   type UseMutationOptions,
 } from "@tanstack/react-query";
 import { useUserStore } from "../stores/useUserStore";
+import { isJwtExpired, logoutUser, SessionExpiredError } from "../lib/session";
 
 // NEXT_PUBLIC_API_URL is required in production.
 // In development it falls back to localhost — but never silently in production.
@@ -100,11 +101,26 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
   // Attach JWT token if available (reads directly from Zustand store state,
   // safe to call outside React render since Zustand stores are singletons).
   const token = useUserStore.getState().authToken;
-  if (token && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${token}`);
+  if (token) {
+    if (isJwtExpired(token)) {
+      logoutUser("expired");
+      throw new SessionExpiredError();
+    }
+
+    if (!headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
   }
 
   const response = await fetch(`${API_URL}${path}`, { ...options, headers });
+
+  if (response.status === 401 && token) {
+    const error = await response
+      .json()
+      .catch(() => ({ message: "Session expired. Please sign in again." }));
+    logoutUser("expired");
+    throw new SessionExpiredError(error.message);
+  }
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ message: response.statusText }));

--- a/frontend/src/app/hooks/useModalFocusTrap.ts
+++ b/frontend/src/app/hooks/useModalFocusTrap.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import * as React from "react";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true",
+  );
+}
+
+interface UseModalFocusTrapOptions {
+  isOpen: boolean;
+  onClose: () => void;
+  containerRef: React.RefObject<HTMLElement | null>;
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+export function useModalFocusTrap({
+  isOpen,
+  onClose,
+  containerRef,
+  initialFocusRef,
+}: UseModalFocusTrapOptions) {
+  const triggerRef = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    triggerRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const frameId = requestAnimationFrame(() => {
+      const explicitTarget = initialFocusRef?.current;
+      if (explicitTarget) {
+        explicitTarget.focus();
+        return;
+      }
+
+      const focusableElements = getFocusableElements(containerRef.current);
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+        return;
+      }
+
+      containerRef.current?.focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      document.body.style.overflow = previousOverflow;
+
+      if (triggerRef.current?.isConnected) {
+        triggerRef.current.focus();
+      }
+    };
+  }, [containerRef, initialFocusRef, isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(containerRef.current);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        containerRef.current?.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [containerRef, isOpen, onClose]);
+}

--- a/frontend/src/app/lib/session.ts
+++ b/frontend/src/app/lib/session.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useUserStore } from "../stores/useUserStore";
+import { useWalletStore } from "../stores/useWalletStore";
+
+const USER_STORAGE_KEY = "remitlend-user";
+const WALLET_STORAGE_KEY = "remitlend-wallet";
+
+let logoutTriggered = false;
+
+export class SessionExpiredError extends Error {
+  constructor(message = "Session expired. Please sign in again.") {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const [, payload] = token.split(".");
+  if (!payload || typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    return JSON.parse(window.atob(padded)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function isJwtExpired(token: string): boolean {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+
+  return typeof exp === "number" && exp * 1000 <= Date.now();
+}
+
+export function clearSessionState() {
+  useUserStore.getState().clearUser();
+  useWalletStore.getState().disconnect();
+
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem(USER_STORAGE_KEY);
+    window.localStorage.removeItem(WALLET_STORAGE_KEY);
+  }
+}
+
+export function logoutUser(reason: "manual" | "expired" = "manual") {
+  clearSessionState();
+
+  if (typeof window === "undefined" || logoutTriggered) {
+    return;
+  }
+
+  logoutTriggered = true;
+  const destination = reason === "expired" ? "/" : "/";
+  window.setTimeout(() => {
+    logoutTriggered = false;
+  }, 0);
+  window.location.assign(destination);
+}


### PR DESCRIPTION
## Summary
- add a shared empty-state pattern and apply it across loans, lend, activity, remittances, and repayment schedule views
- add a visible logout button in settings plus centralized client-side session expiry handling for expired JWTs
- finish modal accessibility with focus trap, initial focus, and focus restoration for shared and custom dialogs

## Testing
- `git diff --check`
- frontend dependency install is not present in this workspace, so `prettier`/`tsc` could not be run locally

Closes #580
Closes #562
Closes #567
Closes #553