### PR TITLE
Fix liquidation, caps, and webhook safeguards

### DIFF
--- a/backend/src/__tests__/webhookService.test.ts
+++ b/backend/src/__tests__/webhookService.test.ts
@@ -16,6 +16,7 @@ jest.unstable_mockModule("../db/connection.js", () => ({
 const { WebhookService, getRetryDelayMs } = await import(
   "../services/webhookService.js"
 );
+const { default: logger } = await import("../utils/logger.js");
 
 describe("WebhookService", () => {
   const originalFetch = global.fetch;
@@ -23,6 +24,7 @@ describe("WebhookService", () => {
   afterEach(() => {
     jest.clearAllMocks();
     global.fetch = originalFetch;
+    delete process.env.WEBHOOK_MAX_PAYLOAD_BYTES;
   });
 
   it("returns the expected retry delays", () => {
@@ -93,5 +95,110 @@ describe("WebhookService", () => {
     );
 
     nowSpy.mockRestore();
+  });
+
+  it("truncates oversized webhook payloads before delivery", async () => {
+    process.env.WEBHOOK_MAX_PAYLOAD_BYTES = "200";
+
+    const fetchMock: any = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+    }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const warnSpy = jest
+      .spyOn(logger, "warn")
+      .mockImplementation(() => logger as typeof logger);
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, callback_url: "https://consumer.example", secret: null }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const service = new WebhookService();
+    await service.dispatch({
+      eventId: "evt-oversized",
+      eventType: "LoanApproved",
+      loanId: 42,
+      borrower: "GBORROWER123",
+      ledger: 100,
+      ledgerClosedAt: new Date("2025-01-01T00:00:00.000Z"),
+      txHash: "tx-oversized",
+      contractId: "contract-123",
+      topics: ["LoanApproved", "42"],
+      value: "x".repeat(1_024),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const deliveredBody = String(fetchMock.mock.calls[0]?.[1]?.body);
+    const deliveredPayload = JSON.parse(deliveredBody) as Record<string, unknown>;
+    expect(deliveredPayload.truncated).toBe(true);
+    expect(deliveredPayload.reason).toBe("payload_too_large");
+    expect(deliveredPayload.eventId).toBe("evt-oversized");
+    expect(deliveredPayload.maxPayloadBytes).toBe(200);
+    expect(Number(deliveredPayload.originalPayloadBytes)).toBeGreaterThan(200);
+    expect(deliveredPayload.value).toBeUndefined();
+
+    const insertParams = mockQuery.mock.calls[1]?.[1] as unknown[];
+    expect(JSON.parse(String(insertParams[5]))).toEqual(deliveredPayload);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Webhook payload exceeds size limit, sending summary payload",
+      expect.objectContaining({
+        eventId: "evt-oversized",
+        eventType: "LoanApproved",
+        maxPayloadBytes: 200,
+      }),
+    );
+  });
+
+  it("logs when a webhook payload approaches the configured size limit", async () => {
+    process.env.WEBHOOK_MAX_PAYLOAD_BYTES = "512";
+
+    const fetchMock: any = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+    }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const warnSpy = jest
+      .spyOn(logger, "warn")
+      .mockImplementation(() => logger as typeof logger);
+
+    const event = {
+      eventId: "evt-near-limit",
+      eventType: "LoanApproved" as const,
+      loanId: 42,
+      borrower: "GBORROWER123",
+      ledger: 100,
+      ledgerClosedAt: new Date("2025-01-01T00:00:00.000Z"),
+      txHash: "tx-near-limit",
+      contractId: "contract-123",
+      topics: ["LoanApproved", "42"],
+      value: "",
+    };
+
+    while (Buffer.byteLength(JSON.stringify(event)) < 460) {
+      event.value += "x";
+    }
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, callback_url: "https://consumer.example", secret: null }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const service = new WebhookService();
+    await service.dispatch(event);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Webhook payload is near size limit",
+      expect.objectContaining({
+        eventId: "evt-near-limit",
+        eventType: "LoanApproved",
+        maxPayloadBytes: 512,
+      }),
+    );
   });
 });

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -60,6 +60,11 @@ interface RegisterWebhookInput {
   secret?: string;
 }
 
+interface PreparedWebhookPayload {
+  body: string;
+  payload: Record<string, unknown>;
+}
+
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -67,6 +72,128 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 function getWebhookRequestTimeoutMs(): number {
   return parsePositiveInt(process.env.WEBHOOK_REQUEST_TIMEOUT_MS, 30 * 1000);
+}
+
+function getWebhookMaxPayloadBytes(): number {
+  return parsePositiveInt(process.env.WEBHOOK_MAX_PAYLOAD_BYTES, 64 * 1024);
+}
+
+function summarizeOversizedPayload(
+  payload: Record<string, unknown>,
+  originalPayloadBytes: number,
+  maxPayloadBytes: number,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    truncated: true,
+    reason: "payload_too_large",
+    originalPayloadBytes,
+    maxPayloadBytes,
+  };
+
+  const passthroughKeys = [
+    "eventId",
+    "eventType",
+    "loanId",
+    "borrower",
+    "ledger",
+  ] as const;
+
+  for (const key of passthroughKeys) {
+    const value = payload[key];
+    if (value !== undefined) {
+      summary[key] = value;
+    }
+  }
+
+  if (Array.isArray(payload.topics)) {
+    summary.topicsCount = payload.topics.length;
+  }
+
+  return summary;
+}
+
+function summarizeOversizedPayloadMinimal(
+  payload: Record<string, unknown>,
+  originalPayloadBytes: number,
+  maxPayloadBytes: number,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    truncated: true,
+    reason: "payload_too_large",
+    originalPayloadBytes,
+    maxPayloadBytes,
+  };
+
+  if (typeof payload.eventId === "string") {
+    summary.eventId = payload.eventId;
+  }
+  if (typeof payload.eventType === "string") {
+    summary.eventType = payload.eventType;
+  }
+
+  return summary;
+}
+
+function prepareWebhookPayload(
+  payload: Record<string, unknown>,
+): PreparedWebhookPayload {
+  const body = JSON.stringify(payload);
+  const payloadBytes = Buffer.byteLength(body);
+  const maxPayloadBytes = getWebhookMaxPayloadBytes();
+  const eventId =
+    typeof payload.eventId === "string" ? payload.eventId : undefined;
+  const eventType =
+    typeof payload.eventType === "string" ? payload.eventType : undefined;
+
+  if (payloadBytes > maxPayloadBytes) {
+    let summarizedPayload = summarizeOversizedPayload(
+      payload,
+      payloadBytes,
+      maxPayloadBytes,
+    );
+    let summarizedBody = JSON.stringify(summarizedPayload);
+
+    if (Buffer.byteLength(summarizedBody) > maxPayloadBytes) {
+      summarizedPayload = summarizeOversizedPayloadMinimal(
+        payload,
+        payloadBytes,
+        maxPayloadBytes,
+      );
+      summarizedBody = JSON.stringify(summarizedPayload);
+    }
+
+    if (Buffer.byteLength(summarizedBody) > maxPayloadBytes) {
+      throw new Error(
+        `Webhook summary payload exceeds configured limit of ${maxPayloadBytes} bytes`,
+      );
+    }
+
+    logger.warn("Webhook payload exceeds size limit, sending summary payload", {
+      eventId,
+      eventType,
+      payloadBytes,
+      maxPayloadBytes,
+    });
+
+    return {
+      body: summarizedBody,
+      payload: summarizedPayload,
+    };
+  }
+
+  if (payloadBytes >= Math.floor(maxPayloadBytes * 0.9)) {
+    logger.warn("Webhook payload is near size limit", {
+      eventId,
+      eventType,
+      payloadBytes,
+      maxPayloadBytes,
+    });
+  }
+
+  return {
+    body,
+    payload,
+  };
 }
 
 async function postWebhook(
@@ -183,7 +310,8 @@ export class WebhookService {
     payload: Record<string, unknown>,
     attemptCount: number,
   ): Promise<void> {
-    const body = JSON.stringify(payload);
+    const preparedPayload = prepareWebhookPayload(payload);
+    const body = preparedPayload.body;
 
     const signature = secret
       ? crypto.createHmac("sha256", secret).update(body).digest("hex")
@@ -384,6 +512,9 @@ export class WebhookService {
     });
 
     try {
+      const preparedPayload = prepareWebhookPayload(
+        event as unknown as Record<string, unknown>,
+      );
       const webhooksResult = await query(
         `SELECT id, callback_url, secret
          FROM webhook_subscriptions
@@ -399,7 +530,7 @@ export class WebhookService {
             String((hook as { callback_url: string }).callback_url),
             ((hook as { secret?: string | null }).secret ?? undefined) ||
               undefined,
-            event,
+            preparedPayload,
           ),
         ),
       );
@@ -416,9 +547,9 @@ export class WebhookService {
     subscriptionId: number,
     callbackUrl: string,
     secret: string | undefined,
-    payload: IndexedLoanEvent,
+    payload: PreparedWebhookPayload,
   ): Promise<void> {
-    const body = JSON.stringify(payload);
+    const body = payload.body;
 
     const signature = secret
       ? crypto.createHmac("sha256", secret).update(body).digest("hex")
@@ -445,8 +576,8 @@ export class WebhookService {
           VALUES ($1, $2, $3, 1, $4, $5, $6::jsonb, NULL)`,
           [
             subscriptionId,
-            payload.eventId,
-            payload.eventType,
+            payload.payload.eventId,
+            payload.payload.eventType,
             response.status,
             new Date(),
             body,
@@ -469,8 +600,8 @@ export class WebhookService {
           VALUES ($1, $2, $3, 1, $4, $5, $6::jsonb, $7)`,
           [
             subscriptionId,
-            payload.eventId,
-            payload.eventType,
+            payload.payload.eventId,
+            payload.payload.eventType,
             response.status,
             `Webhook returned status ${response.status}`,
             body,
@@ -481,7 +612,7 @@ export class WebhookService {
         logger.warn("Webhook delivery failed, scheduled retry", {
           subscriptionId,
           callbackUrl,
-          eventId: payload.eventId,
+          eventId: payload.payload.eventId,
           statusCode: response.status,
           nextRetryAt,
         });
@@ -502,8 +633,8 @@ export class WebhookService {
         VALUES ($1, $2, $3, 1, $4, $5::jsonb, $6)`,
         [
           subscriptionId,
-          payload.eventId,
-          payload.eventType,
+          payload.payload.eventId,
+          payload.payload.eventType,
           error instanceof Error ? error.message : "Unknown webhook error",
           body,
           nextRetryAt,
@@ -513,7 +644,7 @@ export class WebhookService {
       logger.error("Failed to send webhook, scheduled retry", {
         subscriptionId,
         callbackUrl,
-        eventId: payload.eventId,
+        eventId: payload.payload.eventId,
         error,
         nextRetryAt,
       });

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -19,6 +19,7 @@ pub enum PoolError {
     InsufficientLiquidity = 7,
     InvalidMaxPoolSize = 9,
     NoProposedAdmin = 10,
+    CooldownTooLong = 11,
 }
 
 /// Storage keys.
@@ -77,6 +78,7 @@ impl LendingPool {
     const PERSISTENT_TTL_BUMP: u32 = 518400;
     const CURRENT_VERSION: u32 = 3;
     const DEFAULT_WITHDRAWAL_COOLDOWN: u32 = 1_440;
+    const MAX_WITHDRAWAL_COOLDOWN_LEDGERS: u32 = 17_280 * 30;
 
     // ── TTL helpers ───────────────────────────────────────────────────────
 
@@ -348,8 +350,11 @@ impl LendingPool {
         Ok(())
     }
 
-    pub fn set_withdrawal_cooldown(env: Env, ledgers: u32) {
+    pub fn set_withdrawal_cooldown(env: Env, ledgers: u32) -> Result<(), PoolError> {
         Self::admin(&env).require_auth();
+        if ledgers > Self::MAX_WITHDRAWAL_COOLDOWN_LEDGERS {
+            return Err(PoolError::CooldownTooLong);
+        }
 
         let old_cooldown = Self::get_withdrawal_cooldown(env.clone());
 
@@ -359,6 +364,7 @@ impl LendingPool {
         Self::bump_instance_ttl(&env);
 
         withdrawal_cooldown_updated(&env, old_cooldown, ledgers);
+        Ok(())
     }
 
     pub fn get_max_pool_size(env: Env, token: Address) -> i128 {

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -239,6 +239,21 @@ fn test_withdraw_succeeds_after_cooldown() {
 }
 
 #[test]
+fn test_set_withdrawal_cooldown_rejects_values_above_maximum() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+
+    let result = pool_client.try_set_withdrawal_cooldown(&(17_280 * 30 + 1));
+    assert_eq!(result, Err(Ok(crate::PoolError::CooldownTooLong)));
+    assert_eq!(pool_client.get_withdrawal_cooldown(), 1_440);
+}
+
+#[test]
 fn test_emergency_withdraw_bypasses_pause_and_cooldown() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -130,3 +130,22 @@ pub fn collateral_liquidated(env: &Env, loan_id: u32, amount: i128) {
     let topics = (Symbol::new(env, "CollateralLiquidated"), loan_id);
     env.events().publish(topics, amount);
 }
+
+pub fn loan_liquidated(
+    env: &Env,
+    loan_id: u32,
+    borrower: Address,
+    liquidator: Address,
+    debt_repaid: i128,
+    liquidator_bonus: i128,
+    borrower_refund: i128,
+) {
+    let topics = (
+        Symbol::new(env, "LoanLiquidated"),
+        loan_id,
+        borrower,
+        liquidator,
+    );
+    env.events()
+        .publish(topics, (debt_repaid, liquidator_bonus, borrower_refund));
+}

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -55,6 +55,7 @@ pub enum LoanError {
     NftPaused = 20,
     InvalidConfiguration = 21,
     SeizedBorrower = 22,
+    LoanNotLiquidatable = 23,
 }
 
 #[contracttype]
@@ -64,6 +65,7 @@ pub enum LoanStatus {
     Approved,
     Repaid,
     Defaulted,
+    Liquidated,
     Cancelled,
     Rejected,
 }
@@ -118,6 +120,8 @@ pub enum DataKey {
     DefaultWindowLedgers,
     RateOracle,
     ProposedAdmin,
+    LiquidationThresholdBps,
+    LiquidationBonusBps,
 }
 
 #[contract]
@@ -131,13 +135,17 @@ impl LoanManager {
     const PERSISTENT_TTL_BUMP: u32 = 518400;
     const DEFAULT_INTEREST_RATE_BPS: u32 = 1200;
     const DEFAULT_TERM_LEDGERS: u32 = 17280;
-    const CURRENT_VERSION: u32 = 3;
+    const CURRENT_VERSION: u32 = 4;
     const DEFAULT_LATE_FEE_RATE_BPS: u32 = 500;
     const MAX_LATE_FEE_CAP_BPS: u32 = 2500;
     const DEFAULT_MAX_LOAN_AMOUNT: i128 = 50_000;
     const DEFAULT_MAX_LOANS_PER_BORROWER: u32 = 3;
     const DEFAULT_GRACE_PERIOD_LEDGERS: u32 = 4_320;
     const DEFAULT_DEFAULT_WINDOW_LEDGERS: u32 = Self::DEFAULT_TERM_LEDGERS;
+    const DEFAULT_LIQUIDATION_THRESHOLD_BPS: u32 = 15_000;
+    const DEFAULT_LIQUIDATION_BONUS_BPS: u32 = 500;
+    const MIN_COLLATERAL_RATIO_BPS: i128 = 10_000;
+    const MAX_RATIO_BPS: u32 = 10_000;
     const LATE_REPAYMENT_SCORE_PENALTY: i32 = 10;
     const DEFAULT_SCORE_PENALTY_POINTS: u32 = 50;
     const DEFAULT_MIN_REPAYMENT_AMOUNT: i128 = 100;
@@ -328,6 +336,65 @@ impl LoanManager {
             .instance()
             .get(&DataKey::LateFeeRateBps)
             .unwrap_or(Self::DEFAULT_LATE_FEE_RATE_BPS)
+            .min(Self::MAX_LATE_FEE_CAP_BPS)
+    }
+
+    fn liquidation_threshold_bps(env: &Env) -> u32 {
+        Self::bump_instance_ttl(env);
+        env.storage()
+            .instance()
+            .get(&DataKey::LiquidationThresholdBps)
+            .unwrap_or(Self::DEFAULT_LIQUIDATION_THRESHOLD_BPS)
+    }
+
+    fn liquidation_bonus_bps(env: &Env) -> u32 {
+        Self::bump_instance_ttl(env);
+        env.storage()
+            .instance()
+            .get(&DataKey::LiquidationBonusBps)
+            .unwrap_or(Self::DEFAULT_LIQUIDATION_BONUS_BPS)
+    }
+
+    fn validate_late_fee_rate(rate_bps: u32) -> Result<(), LoanError> {
+        if rate_bps > Self::MAX_LATE_FEE_CAP_BPS {
+            return Err(LoanError::InvalidRate);
+        }
+        Ok(())
+    }
+
+    fn validate_liquidation_threshold(ratio_bps: u32) -> Result<(), LoanError> {
+        if (ratio_bps as i128) < Self::MIN_COLLATERAL_RATIO_BPS {
+            return Err(LoanError::InvalidConfiguration);
+        }
+        Ok(())
+    }
+
+    fn validate_liquidation_bonus_bps(bonus_bps: u32) -> Result<(), LoanError> {
+        if bonus_bps > Self::MAX_RATIO_BPS {
+            return Err(LoanError::InvalidConfiguration);
+        }
+        Ok(())
+    }
+
+    fn is_collateral_ratio_below_threshold(
+        collateral_amount: i128,
+        total_debt: i128,
+        threshold_bps: u32,
+    ) -> bool {
+        if total_debt <= 0 {
+            return false;
+        }
+
+        if collateral_amount <= 0 {
+            return true;
+        }
+
+        collateral_amount
+            .checked_mul(Self::MAX_RATIO_BPS as i128)
+            .expect("collateral ratio overflow")
+            < total_debt
+                .checked_mul(threshold_bps as i128)
+                .expect("collateral ratio overflow")
     }
 
     fn grace_period_ledgers(env: &Env) -> u32 {
@@ -559,6 +626,36 @@ impl LoanManager {
         (principal_payment, interest_payment, late_fee_payment)
     }
 
+    fn apply_debt_recovery(loan: &mut Loan, amount: i128) {
+        if amount <= 0 {
+            return;
+        }
+
+        let (principal_payment, interest_payment, late_fee_payment) =
+            Self::proportional_repayment_split(loan, amount);
+
+        loan.interest_paid = loan
+            .interest_paid
+            .checked_add(interest_payment)
+            .expect("interest paid overflow");
+        loan.accrued_interest = loan
+            .accrued_interest
+            .checked_sub(interest_payment)
+            .expect("interest underflow");
+        loan.late_fee_paid = loan
+            .late_fee_paid
+            .checked_add(late_fee_payment)
+            .expect("late fee paid overflow");
+        loan.accrued_late_fee = loan
+            .accrued_late_fee
+            .checked_sub(late_fee_payment)
+            .expect("late fee underflow");
+        loan.principal_paid = loan
+            .principal_paid
+            .checked_add(principal_payment)
+            .expect("principal paid overflow");
+    }
+
     fn collateral_amount(env: &Env, loan_id: u32) -> i128 {
         let loan_key = DataKey::Loan(loan_id);
         if let Some(loan) = env.storage().persistent().get::<DataKey, Loan>(&loan_key) {
@@ -645,6 +742,9 @@ impl LoanManager {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(LoanError::AlreadyInitialized);
         }
+        Self::validate_late_fee_rate(Self::DEFAULT_LATE_FEE_RATE_BPS)?;
+        Self::validate_liquidation_threshold(Self::DEFAULT_LIQUIDATION_THRESHOLD_BPS)?;
+        Self::validate_liquidation_bonus_bps(Self::DEFAULT_LIQUIDATION_BONUS_BPS)?;
         env.storage()
             .instance()
             .set(&DataKey::NftContract, &nft_contract);
@@ -681,6 +781,14 @@ impl LoanManager {
             &DataKey::DefaultWindowLedgers,
             &Self::DEFAULT_DEFAULT_WINDOW_LEDGERS,
         );
+        env.storage().instance().set(
+            &DataKey::LiquidationThresholdBps,
+            &Self::DEFAULT_LIQUIDATION_THRESHOLD_BPS,
+        );
+        env.storage().instance().set(
+            &DataKey::LiquidationBonusBps,
+            &Self::DEFAULT_LIQUIDATION_BONUS_BPS,
+        );
         Self::bump_instance_ttl(&env);
         Ok(())
     }
@@ -712,6 +820,28 @@ impl LoanManager {
                 .instance()
                 .set(&DataKey::LateFeeRateBps, &Self::DEFAULT_LATE_FEE_RATE_BPS);
         }
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::LiquidationThresholdBps)
+        {
+            env.storage().instance().set(
+                &DataKey::LiquidationThresholdBps,
+                &Self::DEFAULT_LIQUIDATION_THRESHOLD_BPS,
+            );
+        }
+        if !env.storage().instance().has(&DataKey::LiquidationBonusBps) {
+            env.storage().instance().set(
+                &DataKey::LiquidationBonusBps,
+                &Self::DEFAULT_LIQUIDATION_BONUS_BPS,
+            );
+        }
+
+        let late_fee_rate = Self::late_fee_rate_bps(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::LateFeeRateBps, &late_fee_rate);
+
         env.storage()
             .instance()
             .set(&DataKey::Version, &Self::CURRENT_VERSION);
@@ -856,6 +986,7 @@ impl LoanManager {
             .instance()
             .get(&DataKey::Token)
             .expect("token not set");
+        let term_ledgers = Self::read_default_term(&env);
 
         // Cross-contract READ for liquidity check — still in the CHECKS phase.
         let pool_client = PoolClient::new(&env, &lending_pool);
@@ -870,7 +1001,8 @@ impl LoanManager {
         let transfer_amount = loan.amount;
 
         loan.status = LoanStatus::Approved;
-        loan.due_date = env.ledger().sequence() + loan.term_ledgers;
+        loan.term_ledgers = term_ledgers;
+        loan.due_date = env.ledger().sequence() + term_ledgers;
         loan.last_interest_ledger = env.ledger().sequence();
         loan.last_late_fee_ledger = loan
             .due_date
@@ -1026,10 +1158,10 @@ impl LoanManager {
         env.storage().persistent().set(&loan_key, &loan);
         Self::bump_persistent_ttl(&env, &loan_key);
 
-        // If loan is fully repaid, emit terminal event and remove from storage
+        // If loan is fully repaid, emit the terminal event and keep the terminal
+        // state queryable for downstream consumers and tests.
         if completed {
             events::loan_repaid(&env, borrower.clone(), loan_id, amount);
-            // env.storage().persistent().remove(&loan_key);
         }
 
         if amount >= 100 {
@@ -1154,6 +1286,106 @@ impl LoanManager {
 
     pub fn get_collateral(env: Env, loan_id: u32) -> i128 {
         Self::collateral_amount(&env, loan_id)
+    }
+
+    pub fn liquidate(env: Env, liquidator: Address, loan_id: u32) -> Result<(), LoanError> {
+        use soroban_sdk::token::TokenClient;
+
+        liquidator.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let loan_key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&loan_key)
+            .ok_or(LoanError::LoanNotFound)?;
+        Self::bump_persistent_ttl(&env, &loan_key);
+
+        if loan.status != LoanStatus::Approved {
+            return Err(LoanError::LoanNotActive);
+        }
+
+        let total_debt = {
+            let (current_total_debt, _) = Self::current_total_debt(&env, &mut loan);
+            current_total_debt
+        };
+        let threshold_bps = Self::liquidation_threshold_bps(&env);
+        if !Self::is_collateral_ratio_below_threshold(
+            loan.collateral_amount,
+            total_debt,
+            threshold_bps,
+        ) {
+            return Err(LoanError::LoanNotLiquidatable);
+        }
+
+        let collateral_amount = loan.collateral_amount;
+        let configured_bonus = collateral_amount
+            .checked_mul(Self::liquidation_bonus_bps(&env) as i128)
+            .and_then(|value| value.checked_div(Self::MAX_RATIO_BPS as i128))
+            .expect("liquidation bonus overflow");
+
+        let (debt_repaid, liquidator_bonus, borrower_refund) = if collateral_amount >= total_debt {
+            let collateral_surplus = collateral_amount
+                .checked_sub(total_debt)
+                .expect("collateral surplus underflow");
+            let liquidator_bonus = configured_bonus.min(collateral_surplus);
+            let borrower_refund = collateral_surplus
+                .checked_sub(liquidator_bonus)
+                .expect("borrower refund underflow");
+            (total_debt, liquidator_bonus, borrower_refund)
+        } else {
+            (collateral_amount, 0, 0)
+        };
+
+        Self::apply_debt_recovery(&mut loan, debt_repaid);
+        loan.status = LoanStatus::Liquidated;
+        loan.collateral_amount = 0;
+        env.storage().persistent().set(&loan_key, &loan);
+        Self::bump_persistent_ttl(&env, &loan_key);
+        Self::decrement_borrower_loan_count(&env, &loan.borrower);
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("token not set");
+        let lending_pool: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::LendingPool)
+            .expect("lending pool not set");
+        let token_client = TokenClient::new(&env, &token);
+
+        if debt_repaid > 0 {
+            token_client.transfer(&env.current_contract_address(), &lending_pool, &debt_repaid);
+        }
+        if liquidator_bonus > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &liquidator,
+                &liquidator_bonus,
+            );
+        }
+        if borrower_refund > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &loan.borrower,
+                &borrower_refund,
+            );
+        }
+
+        events::loan_liquidated(
+            &env,
+            loan_id,
+            loan.borrower,
+            liquidator,
+            debt_repaid,
+            liquidator_bonus,
+            borrower_refund,
+        );
+
+        Ok(())
     }
 
     pub fn cancel_loan(env: Env, borrower: Address, loan_id: u32) -> Result<(), LoanError> {
@@ -1395,9 +1627,7 @@ impl LoanManager {
     }
 
     pub fn set_late_fee_rate(env: Env, rate_bps: u32) -> Result<(), LoanError> {
-        if rate_bps > 10_000 {
-            return Err(LoanError::InvalidRate);
-        }
+        Self::validate_late_fee_rate(rate_bps)?;
         let admin = Self::admin(&env);
         admin.require_auth();
 
@@ -1413,6 +1643,34 @@ impl LoanManager {
 
     pub fn get_late_fee_rate(env: Env) -> u32 {
         Self::late_fee_rate_bps(&env)
+    }
+
+    pub fn set_liquidation_threshold(env: Env, ratio_bps: u32) -> Result<(), LoanError> {
+        Self::validate_liquidation_threshold(ratio_bps)?;
+        Self::admin(&env).require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::LiquidationThresholdBps, &ratio_bps);
+        Self::bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    pub fn get_liquidation_threshold(env: Env) -> u32 {
+        Self::liquidation_threshold_bps(&env)
+    }
+
+    pub fn set_liquidation_bonus_bps(env: Env, bonus_bps: u32) -> Result<(), LoanError> {
+        Self::validate_liquidation_bonus_bps(bonus_bps)?;
+        Self::admin(&env).require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::LiquidationBonusBps, &bonus_bps);
+        Self::bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    pub fn get_liquidation_bonus_bps(env: Env) -> u32 {
+        Self::liquidation_bonus_bps(&env)
     }
 
     pub fn set_grace_period_ledgers(env: Env, ledgers: u32) -> Result<(), LoanError> {
@@ -1814,10 +2072,6 @@ impl LoanManager {
         nft_client.record_default(&loan.borrower, &Some(env.current_contract_address()));
 
         events::loan_defaulted(&env, loan_id, loan.borrower.clone());
-
-        // Remove loan from storage after emitting terminal event
-        // env.storage().persistent().remove(&loan_key);
-
         Ok(())
     }
 
@@ -1862,9 +2116,6 @@ impl LoanManager {
             nft_client.record_default(&loan.borrower, &Some(env.current_contract_address()));
 
             events::loan_defaulted(&env, loan_id, loan.borrower.clone());
-
-            // Remove loan from storage after emitting terminal event
-            // env.storage().persistent().remove(&loan_key);
         }
 
         Ok(())

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -84,7 +84,7 @@ fn test_loan_request_success() {
 
     let (manager, nft_client, _pool, _token, _token_admin) = setup_test(&env);
     let borrower = Address::generate(&env);
-    assert_eq!(manager.version(), 3);
+    assert_eq!(manager.version(), 4);
 
     // Give borrower a score high enough to pass (>= 500)
     let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
@@ -950,7 +950,7 @@ fn test_late_fee_is_capped_at_quarter_principal() {
     let stellar_token = StellarAssetClient::new(&env, &token_id);
     stellar_token.mint(&pool_client, &10_000);
 
-    manager.set_late_fee_rate(&10_000);
+    manager.set_late_fee_rate(&2_500);
     manager.set_grace_period_ledgers(&0);
     let loan_id = manager.request_loan(&borrower, &1000, &17280);
     manager.approve_loan(&loan_id);
@@ -960,6 +960,17 @@ fn test_late_fee_is_capped_at_quarter_principal() {
 
     let loan = manager.get_loan(&loan_id);
     assert_eq!(loan.accrued_late_fee, 250);
+}
+
+#[test]
+fn test_set_late_fee_rate_rejects_above_cap() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool_client, _token_id, _token_admin) = setup_test(&env);
+
+    let result = manager.try_set_late_fee_rate(&2_501);
+    assert_eq!(result, Err(Ok(LoanError::InvalidRate)));
 }
 
 #[test]
@@ -1084,6 +1095,80 @@ fn test_collateral_is_seized_on_batch_default() {
         token_client.balance(&pool_client),
         pool_balance_before + 300 + 500
     );
+}
+
+#[test]
+fn test_liquidate_under_threshold_transfers_bonus_and_refund() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(&borrower, &650, &history_hash, &None);
+
+    let token_client = TokenClient::new(&env, &token_id);
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &20_000);
+    stellar_token.mint(&borrower, &20_000);
+
+    manager.set_liquidation_threshold(&14_500);
+    manager.set_liquidation_bonus_bps(&1_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+    manager.deposit_collateral(&loan_id, &1_400);
+
+    let borrower_balance_before = token_client.balance(&borrower);
+    let liquidator_balance_before = token_client.balance(&liquidator);
+    let pool_balance_before = token_client.balance(&pool_client);
+
+    manager.liquidate(&liquidator, &loan_id);
+
+    let liquidated_loan = manager.get_loan(&loan_id);
+    assert_eq!(liquidated_loan.status, LoanStatus::Liquidated);
+    assert_eq!(manager.get_collateral(&loan_id), 0);
+    assert_eq!(manager.get_borrower_loan_count(&borrower), 0);
+    assert_eq!(
+        token_client.balance(&pool_client),
+        pool_balance_before + 1_000
+    );
+    assert_eq!(
+        token_client.balance(&liquidator),
+        liquidator_balance_before + 140
+    );
+    assert_eq!(
+        token_client.balance(&borrower),
+        borrower_balance_before + 260
+    );
+}
+
+#[test]
+fn test_liquidate_rejects_healthy_collateral_ratio() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(&borrower, &650, &history_hash, &None);
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &20_000);
+    stellar_token.mint(&borrower, &20_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+    manager.deposit_collateral(&loan_id, &1_600);
+
+    let result = manager.try_liquidate(&liquidator, &loan_id);
+    assert_eq!(result, Err(Ok(LoanError::LoanNotLiquidatable)));
+    assert_eq!(manager.get_loan(&loan_id).status, LoanStatus::Approved);
+    assert_eq!(manager.get_collateral(&loan_id), 1_600);
 }
 
 #[test]

--- a/contracts/loan_manager/test_snapshots/test/test_admin_transfer_via_propose_accept.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_admin_transfer_via_propose_accept.1.json
@@ -554,6 +554,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -634,7 +658,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_approve_already_approved_loan.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_approve_already_approved_loan.1.json
@@ -1069,6 +1069,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1149,7 +1173,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_approve_loan_fails_when_pool_has_insufficient_liquidity.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_approve_loan_fails_when_pool_has_insufficient_liquidity.1.json
@@ -901,6 +901,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -981,7 +1005,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_approve_loan_flow.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_approve_loan_flow.1.json
@@ -1071,6 +1071,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1151,7 +1175,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_approve_loan_insufficient_pool_liquidity.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_approve_loan_insufficient_pool_liquidity.1.json
@@ -958,6 +958,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1038,7 +1062,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_approve_nonexistent_loan.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_approve_nonexistent_loan.1.json
@@ -485,6 +485,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -565,7 +589,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_blocks_new_requests.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_blocks_new_requests.1.json
@@ -1466,6 +1466,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1546,7 +1570,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_enforced_and_released_on_repay.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_enforced_and_released_on_repay.1.json
@@ -1892,6 +1892,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1972,7 +1996,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_cancel_pending_loan.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_cancel_pending_loan.1.json
@@ -922,6 +922,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1002,7 +1026,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_cancel_pending_loan_returns_collateral.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_cancel_pending_loan_returns_collateral.1.json
@@ -984,6 +984,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1064,7 +1088,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_check_default_already_repaid.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_default_already_repaid.1.json
@@ -1261,6 +1261,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1341,7 +1365,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_check_default_not_past_due.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_default_not_past_due.1.json
@@ -1069,6 +1069,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1149,7 +1173,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_check_default_respects_default_window.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_default_respects_default_window.1.json
@@ -1122,6 +1122,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1202,7 +1226,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_check_default_success.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_default_success.1.json
@@ -1297,6 +1297,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1377,7 +1401,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_check_defaults_batch.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_defaults_batch.1.json
@@ -2707,6 +2707,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -2787,7 +2811,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_collateral_is_seized_on_batch_default.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_collateral_is_seized_on_batch_default.1.json
@@ -2217,6 +2217,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -2297,7 +2321,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_collateral_is_seized_on_default.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_collateral_is_seized_on_default.1.json
@@ -1407,6 +1407,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1487,7 +1511,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_configurable_interest_rate_and_default_term.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_configurable_interest_rate_and_default_term.1.json
@@ -1198,6 +1198,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1278,7 +1302,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_and_auto_release_on_full_repayment.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_and_auto_release_on_full_repayment.1.json
@@ -1316,6 +1316,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1396,7 +1420,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_rejects_non_active_loan.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_rejects_non_active_loan.1.json
@@ -900,6 +900,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -980,7 +1004,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_full_repayment_ignores_minimum_amount.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_full_repayment_ignores_minimum_amount.1.json
@@ -1317,6 +1317,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1412,7 +1436,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_get_borrower_loans.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_get_borrower_loans.1.json
@@ -1610,6 +1610,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1690,7 +1714,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_late_fee_is_capped_at_quarter_principal.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_late_fee_is_capped_at_quarter_principal.1.json
@@ -109,7 +109,7 @@
               "function_name": "set_late_fee_rate",
               "args": [
                 {
-                  "u32": 10000
+                  "u32": 2500
                 }
               ]
             }
@@ -1155,7 +1155,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 10000
+                          "u32": 2500
                         }
                       },
                       {
@@ -1168,6 +1168,30 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
                         }
                       },
                       {
@@ -1254,7 +1278,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_late_full_repayment_applies_score_penalty.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_late_full_repayment_applies_score_penalty.1.json
@@ -1265,6 +1265,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1345,7 +1369,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_legacy_zero_interest_config_falls_back_to_default.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_legacy_zero_interest_config_falls_back_to_default.1.json
@@ -972,6 +972,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1052,7 +1076,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_loan_request_failure_low_score.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_loan_request_failure_low_score.1.json
@@ -606,6 +606,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -686,7 +710,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_loan_request_success.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_loan_request_success.1.json
@@ -901,6 +901,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -981,7 +1005,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_minimum_repayment_amount_enforced.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_minimum_repayment_amount_enforced.1.json
@@ -1183,6 +1183,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1278,7 +1302,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_overdue_partial_repayment_still_reduces_principal.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_overdue_partial_repayment_still_reduces_principal.1.json
@@ -1366,6 +1366,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1446,7 +1470,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_overdue_repayment_charges_late_fee.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_overdue_repayment_charges_late_fee.1.json
@@ -1367,6 +1367,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1447,7 +1471,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_partial_repayment_tracks_split_balances.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_partial_repayment_tracks_split_balances.1.json
@@ -1316,6 +1316,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1396,7 +1420,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_query_functions.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_query_functions.1.json
@@ -962,6 +962,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1042,7 +1066,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_reject_pending_loan.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_reject_pending_loan.1.json
@@ -955,6 +955,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1035,7 +1059,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_reject_pending_loan_returns_collateral.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_reject_pending_loan_returns_collateral.1.json
@@ -1017,6 +1017,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1097,7 +1121,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_repayment_flow.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_repayment_flow.1.json
@@ -1353,6 +1353,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1433,7 +1457,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_request_loan_above_max_amount_fails.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_request_loan_above_max_amount_fails.1.json
@@ -661,6 +661,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -741,7 +765,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_request_loan_negative_amount.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_request_loan_negative_amount.1.json
@@ -606,6 +606,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -686,7 +710,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_set_admin_updates_admin_immediately.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_set_admin_updates_admin_immediately.1.json
@@ -552,6 +552,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -632,7 +656,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_set_interest_rate_zero_rejected.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_set_interest_rate_zero_rejected.1.json
@@ -485,6 +485,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -565,7 +589,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_small_loan_interest_accrual_precision.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_small_loan_interest_accrual_precision.1.json
@@ -1069,6 +1069,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1149,7 +1173,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/loan_manager/test_snapshots/test/test_small_repayment_does_not_change_score.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_small_repayment_does_not_change_score.1.json
@@ -1235,6 +1235,30 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "LiquidationBonusBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 500
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "LiquidationThresholdBps"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 15000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "LoanCounter"
                             }
                           ]
@@ -1330,7 +1354,7 @@
                           ]
                         },
                         "val": {
-                          "u32": 3
+                          "u32": 4
                         }
                       }
                     ]

--- a/contracts/multisig_governance/src/lib.rs
+++ b/contracts/multisig_governance/src/lib.rs
@@ -506,9 +506,6 @@ impl GovernanceContract {
 
         env.storage().instance().remove(&KEY_PENDING);
 
-        // Set cooldown timestamp to prevent immediate reproposal spam
-        env.storage().instance().set(&KEY_LAST_CANCELLED_AT, &now);
-
         env.events().publish(
             (symbol_short!("GovExp"), caller.clone()),
             ProposalExpiredEvent {

--- a/contracts/multisig_governance/test_snapshots/test/expire_proposal_works_after_ttl.1.json
+++ b/contracts/multisig_governance/test_snapshots/test/expire_proposal_works_after_ttl.1.json
@@ -104,14 +104,6 @@
                       },
                       {
                         "key": {
-                          "symbol": "CANCEL_AT"
-                        },
-                        "val": {
-                          "u64": 605801
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "COUNT"
                         },
                         "val": {

--- a/contracts/multisig_governance/test_snapshots/test/new_proposal_allowed_after_expiry.1.json
+++ b/contracts/multisig_governance/test_snapshots/test/new_proposal_allowed_after_expiry.1.json
@@ -136,14 +136,6 @@
                       },
                       {
                         "key": {
-                          "symbol": "CANCEL_AT"
-                        },
-                        "val": {
-                          "u64": 605801
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "COUNT"
                         },
                         "val": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -46,6 +46,7 @@
       "completed": "Completed",
       "repaid": "Repaid",
       "failed": "Failed",
+      "liquidated": "Liquidated",
       "defaulted": "Defaulted"
     },
     "pagination": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -46,6 +46,7 @@
       "completed": "Completado",
       "repaid": "Pagado",
       "failed": "Fallido",
+      "liquidated": "Liquidado",
       "defaulted": "Incumplido"
     },
     "pagination": {

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -46,6 +46,7 @@
       "completed": "Nakumpleto",
       "repaid": "Binayaran",
       "failed": "Nabigo",
+      "liquidated": "Liquidated",
       "defaulted": "Di-nakamit"
     },
     "pagination": {

--- a/frontend/src/app/[locale]/activity/page.tsx
+++ b/frontend/src/app/[locale]/activity/page.tsx
@@ -13,11 +13,25 @@ type FilterType = "all" | "loan" | "remittance";
 
 interface ActivityItem {
   id: string;
-  type: "Loan Request" | "Loan Active" | "Loan Repaid" | "Loan Defaulted" | "Remittance";
+  type:
+    | "Loan Request"
+    | "Loan Active"
+    | "Loan Repaid"
+    | "Loan Defaulted"
+    | "Loan Liquidated"
+    | "Remittance";
   description: string;
   amount: string;
   timestamp: string;
-  status: "pending" | "active" | "completed" | "repaid" | "failed" | "defaulted" | "processing";
+  status:
+    | "pending"
+    | "active"
+    | "completed"
+    | "repaid"
+    | "failed"
+    | "defaulted"
+    | "liquidated"
+    | "processing";
   txHash?: string;
 }
 
@@ -44,11 +58,13 @@ export default function ActivityPage() {
       type:
         loan.status === "repaid"
           ? "Loan Repaid"
-          : loan.status === "defaulted"
-            ? "Loan Defaulted"
-            : loan.status === "active"
-              ? "Loan Active"
-              : "Loan Request",
+          : loan.status === "liquidated"
+            ? "Loan Liquidated"
+            : loan.status === "defaulted"
+              ? "Loan Defaulted"
+              : loan.status === "active"
+                ? "Loan Active"
+                : "Loan Request",
       description: `Loan #${loan.id} — ${loan.currency}`,
       amount: `${loan.status === "repaid" ? "+" : "-"}${formatCurrency(loan.amount)}`,
       timestamp: new Date(loan.createdAt).toISOString(),
@@ -170,7 +186,9 @@ export default function ActivityPage() {
                       className={`h-10 w-10 rounded-full flex items-center justify-center flex-shrink-0 ${
                         item.status === "completed" || item.status === "repaid"
                           ? "bg-green-50 dark:bg-green-500/10"
-                          : item.status === "failed" || item.status === "defaulted"
+                          : item.status === "failed" ||
+                              item.status === "defaulted" ||
+                              item.status === "liquidated"
                             ? "bg-red-50 dark:bg-red-500/10"
                             : "bg-indigo-50 dark:bg-indigo-500/10"
                       }`}
@@ -179,7 +197,9 @@ export default function ActivityPage() {
                       {item.amount.startsWith("+") ? (
                         <ArrowDownLeft
                           className={`h-5 w-5 ${
-                            item.status === "failed" || item.status === "defaulted"
+                            item.status === "failed" ||
+                            item.status === "defaulted" ||
+                            item.status === "liquidated"
                               ? "text-red-600 dark:text-red-400"
                               : "text-green-600 dark:text-green-400"
                           }`}
@@ -305,6 +325,7 @@ function getStatusTone(status: string): "success" | "warning" | "danger" | "info
       return "warning";
     case "failed":
     case "defaulted":
+    case "liquidated":
       return "danger";
     case "active":
       return "info";

--- a/frontend/src/app/[locale]/loans/[loanId]/LoanDetailsPageClient.tsx
+++ b/frontend/src/app/[locale]/loans/[loanId]/LoanDetailsPageClient.tsx
@@ -253,15 +253,17 @@ export function LoanDetailsPageClient() {
               <p className="mt-3 text-sm leading-6 text-indigo-700/80 dark:text-indigo-200">
                 Make a repayment before the next due date to keep your score trending upward.
               </p>
-              {loan.status !== "repaid" && (
-                <Link
-                  href={`/repay/${loanId}`}
-                  className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
-                >
-                  Make Payment
-                  <ChevronRight className="h-4 w-4" />
-                </Link>
-              )}
+              {loan.status !== "repaid" &&
+                loan.status !== "defaulted" &&
+                loan.status !== "liquidated" && (
+                  <Link
+                    href={`/repay/${loanId}`}
+                    className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500"
+                  >
+                    Make Payment
+                    <ChevronRight className="h-4 w-4" />
+                  </Link>
+                )}
 
               {latestTxHash && (
                 <div className="mt-3">
@@ -279,11 +281,13 @@ export function LoanDetailsPageClient() {
               Collateral status
             </h2>
             <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-              {loan.status === "defaulted"
-                ? "Collateral has been seized."
-                : loan.status === "repaid"
-                  ? "Collateral released — loan fully repaid."
-                  : "Collateral is held in escrow for the duration of this loan."}
+              {loan.status === "liquidated"
+                ? "Collateral was liquidated after the position fell below the collateral threshold."
+                : loan.status === "defaulted"
+                  ? "Collateral has been seized."
+                  : loan.status === "repaid"
+                    ? "Collateral released — loan fully repaid."
+                    : "Collateral is held in escrow for the duration of this loan."}
             </p>
           </div>
         </aside>

--- a/frontend/src/app/components/borrower/LoanCard.tsx
+++ b/frontend/src/app/components/borrower/LoanCard.tsx
@@ -23,20 +23,24 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
   const daysUntil = getDaysUntilDeadline(loan.nextPaymentDeadline);
   const isOverdue = daysUntil < 0;
   const isUrgent = daysUntil >= 0 && daysUntil <= 7;
+  const isLiquidated = loan.status === "liquidated";
   const isDefaulted = loan.status === "defaulted";
+  const isTerminalDistressed = isDefaulted || isLiquidated;
 
   // ── Badge ──────────────────────────────────────────────────────────────────
   const badge =
     variant === "detailed"
       ? {
-          label: isDefaulted
-            ? "Defaulted"
-            : isOverdue
-              ? "Overdue"
-              : isUrgent
-                ? "Due Soon"
-                : "On Track",
-          className: isDefaulted
+          label: isLiquidated
+            ? "Liquidated"
+            : isDefaulted
+              ? "Defaulted"
+              : isOverdue
+                ? "Overdue"
+                : isUrgent
+                  ? "Due Soon"
+                  : "On Track",
+          className: isTerminalDistressed
             ? "bg-red-900 text-white"
             : isOverdue
               ? "bg-red-100 text-red-800"
@@ -47,32 +51,34 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
       : null;
 
   // ── Deadline colours ───────────────────────────────────────────────────────
-  const deadlineBg = isDefaulted
+  const deadlineBg = isTerminalDistressed
     ? "bg-red-900/20"
     : isOverdue
       ? "bg-red-50"
       : isUrgent
         ? "bg-yellow-50"
         : "bg-gray-50";
-  const deadlineTextColor = isDefaulted
+  const deadlineTextColor = isTerminalDistressed
     ? "text-red-900"
     : isOverdue
       ? "text-red-600"
       : isUrgent
         ? "text-yellow-600"
         : "text-gray-900";
-  const deadlineSubColor = isDefaulted
+  const deadlineSubColor = isTerminalDistressed
     ? "text-red-700"
     : isOverdue
       ? "text-red-600"
       : isUrgent
         ? "text-yellow-600"
         : "text-gray-600";
-  const deadlineLabel = isDefaulted
-    ? "Contact support to recover"
-    : isOverdue
-      ? `${Math.abs(daysUntil)} days overdue`
-      : `${daysUntil} days remaining`;
+  const deadlineLabel = isLiquidated
+    ? "Collateral was liquidated"
+    : isDefaulted
+      ? "Contact support to recover"
+      : isOverdue
+        ? `${Math.abs(daysUntil)} days overdue`
+        : `${daysUntil} days remaining`;
 
   // ── Progress (detailed only) ───────────────────────────────────────────────
   const totalForProgress = loan.principal + loan.accruedInterest;
@@ -154,7 +160,7 @@ export function LoanCard({ loan, variant = "compact" }: LoanCardProps) {
 
       {/* Actions */}
       <div className="flex gap-3">
-        {isDefaulted ? (
+        {isTerminalDistressed ? (
           <>
             <Button
               onClick={() => router.push(`/loans/${loan.id}`)}

--- a/frontend/src/app/components/ui/LoanStatusBadge.tsx
+++ b/frontend/src/app/components/ui/LoanStatusBadge.tsx
@@ -1,6 +1,6 @@
 import { StatusIndicator } from "./StatusIndicator";
 
-type LoanStatus = "active" | "pending" | "repaid" | "defaulted";
+type LoanStatus = "active" | "pending" | "repaid" | "defaulted" | "liquidated";
 
 const STATUS_CONFIG: Record<
   LoanStatus,
@@ -9,6 +9,7 @@ const STATUS_CONFIG: Record<
   active: { label: "Active", tone: "success" },
   repaid: { label: "Repaid", tone: "info" },
   defaulted: { label: "Defaulted", tone: "danger" },
+  liquidated: { label: "Liquidated", tone: "danger" },
   pending: { label: "Pending", tone: "warning" },
 };
 

--- a/frontend/src/app/components/ui/RepaymentProgress.tsx
+++ b/frontend/src/app/components/ui/RepaymentProgress.tsx
@@ -5,7 +5,7 @@ import { LoanStatusBadge } from "./LoanStatusBadge";
 interface RepaymentProgressProps {
   totalRepaid: number;
   totalOwed: number;
-  status: "active" | "repaid" | "defaulted" | "pending";
+  status: "active" | "repaid" | "defaulted" | "pending" | "liquidated";
 }
 
 function formatCurrency(value: number) {

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -24,26 +24,21 @@ export class NetworkUnavailableError extends Error {
   name = "NetworkUnavailableError";
 }
 
-// NEXT_PUBLIC_API_URL is required in production.
-// In development it falls back to localhost — but never silently in production.
+const DEFAULT_API_URL = "http://localhost:3001";
+
+// Keep builds and prerendering safe even when CI/deploy env vars are absent.
+// Runtime environments should still override this with NEXT_PUBLIC_API_URL.
 function resolveApiUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL;
 
-  if (!url) {
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        "[remitlend] NEXT_PUBLIC_API_URL is required in production but was not set. " +
-          "Add it to your deployment environment variables.",
-      );
-    }
-    console.warn(
-      "[remitlend] NEXT_PUBLIC_API_URL is not set. " +
-        "Falling back to http://localhost:3001 (development only).",
-    );
-    return "http://localhost:3001";
+  if (url) {
+    return url;
   }
 
-  return url;
+  console.warn(
+    "[remitlend] NEXT_PUBLIC_API_URL is not set. " + `Falling back to ${DEFAULT_API_URL}.`,
+  );
+  return DEFAULT_API_URL;
 }
 
 let cachedApiUrl: string | null = null;
@@ -152,13 +147,15 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+export type LoanStatus = "pending" | "active" | "repaid" | "defaulted" | "liquidated";
+
 export interface Loan {
   id: string;
   amount: number;
   currency: string;
   interestRate: number;
   termDays: number;
-  status: "pending" | "active" | "repaid" | "defaulted";
+  status: LoanStatus;
   borrowerId: string;
   createdAt: string;
 }
@@ -220,7 +217,7 @@ export interface BorrowerLoan {
   totalOwed: number;
   totalRepaid: number;
   nextPaymentDeadline: string;
-  status: "active" | "pending" | "repaid" | "defaulted";
+  status: LoanStatus;
   borrower: string;
   approvedAt?: string;
 }
@@ -239,7 +236,7 @@ export interface LoanDetails {
   totalRepaid: number;
   totalOwed: number;
   interestRate: number;
-  status: "active" | "repaid" | "defaulted" | "pending";
+  status: LoanStatus;
   requestedAt?: string;
   approvedAt?: string;
   events: LoanEvent[];


### PR DESCRIPTION
Closes #356
Closes #633
Closes #636
Closes #645

Summary
- add loan liquidation flow and configuration
- enforce late fee and withdrawal cooldown caps
- add webhook payload size safeguards and tests
- update related frontend and CI-blocking type/build issues

Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -- --test-threads=1
- cargo tarpaulin --out Xml
- backend: npm run typecheck
- backend: npm test
- frontend: npm run lint
- frontend: npm run build