### PR TITLE
Add SSE fallback, amount precision guards, lending pool tests, and CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: backend
+      - name: Lint
+        run: npm run lint
+        working-directory: backend
+      - name: Build
+        run: npm run build
+        working-directory: backend
       - name: Type check
         run: npm run typecheck
         working-directory: backend

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -501,6 +501,81 @@ fn test_full_loan_cycle_with_interest() {
     assert_eq!(token_client.balance(&pool_id), 0);
 }
 
+#[test]
+fn test_pool_stats_reflect_funds_allocated_and_returned() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let provider = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &5_000);
+
+    pool_client.deposit(&provider, &token_id, &5_000);
+
+    let initial_stats = pool_client.get_pool_stats(&token_id);
+    assert_eq!(initial_stats.total_deposits, 5_000);
+    assert_eq!(initial_stats.pool_token_balance, 5_000);
+    assert_eq!(initial_stats.utilization_bps, 0);
+
+    token_client.transfer(&pool_id, &borrower, &2_000);
+    let allocated_stats = pool_client.get_pool_stats(&token_id);
+    assert_eq!(allocated_stats.pool_token_balance, 3_000);
+    assert_eq!(allocated_stats.total_deposits, 5_000);
+    assert_eq!(allocated_stats.utilization_bps, 4_000);
+
+    stellar_asset_client.mint(&borrower, &200);
+    token_client.transfer(&borrower, &pool_id, &2_200);
+
+    let returned_stats = pool_client.get_pool_stats(&token_id);
+    assert_eq!(returned_stats.pool_token_balance, 5_200);
+    assert_eq!(returned_stats.total_deposits, 5_000);
+    assert_eq!(returned_stats.utilization_bps, 0);
+}
+
+#[test]
+fn test_many_depositors_receive_proportional_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let depositors = [
+        (Address::generate(&env), 1_000_i128),
+        (Address::generate(&env), 2_000_i128),
+        (Address::generate(&env), 3_000_i128),
+    ];
+
+    for (provider, amount) in &depositors {
+        stellar_asset_client.mint(provider, amount);
+        pool_client.deposit(provider, &token_id, amount);
+    }
+
+    stellar_asset_client.mint(&pool_id, &600);
+
+    for (provider, shares) in &depositors {
+        pool_client.withdraw(provider, &token_id, shares);
+    }
+
+    assert_eq!(token_client.balance(&depositors[0].0), 1_100);
+    assert_eq!(token_client.balance(&depositors[1].0), 2_200);
+    assert_eq!(token_client.balance(&depositors[2].0), 3_300);
+    assert_eq!(token_client.balance(&pool_id), 0);
+}
+
 // ── Admin transfer ────────────────────────────────────────────────────────────
 
 #[test]

--- a/frontend/src/app/[locale]/lend/LendPageClient.tsx
+++ b/frontend/src/app/[locale]/lend/LendPageClient.tsx
@@ -32,6 +32,12 @@ import { selectWalletAddress, useWalletStore } from "../../stores/useWalletStore
 import { useSSE } from "../../hooks/useSSE";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { Tooltip } from "../../components/ui/Tooltip";
+import {
+  buildAmountHelperText,
+  getPrecisionError,
+  parseAmount,
+  sanitizeAmountInput,
+} from "../../utils/amount";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
@@ -61,17 +67,23 @@ export function LendPageClient() {
         invalidatePoolStats();
       }
     },
+    onFallbackPoll: () => invalidatePoolStats(),
   });
 
+  const depositPrecisionError = getPrecisionError(depositAmount, "USDC");
+  const withdrawPrecisionError = getPrecisionError(withdrawAmount, "USDC");
+  const depositHelper = buildAmountHelperText(depositAmount, "USDC");
+  const withdrawHelper = buildAmountHelperText(withdrawAmount, "USDC");
+
   const handleDeposit = async () => {
-    const amount = parseFloat(depositAmount);
-    if (!address || isNaN(amount) || amount <= 0) return;
+    const amount = parseAmount(depositAmount);
+    if (!address || Number.isNaN(amount) || amount <= 0 || depositPrecisionError) return;
     await depositOp.executeDeposit({ amount, depositorAddress: address });
   };
 
   const handleWithdraw = async () => {
-    const amount = parseFloat(withdrawAmount);
-    if (!address || isNaN(amount) || amount <= 0) return;
+    const amount = parseAmount(withdrawAmount);
+    if (!address || Number.isNaN(amount) || amount <= 0 || withdrawPrecisionError) return;
     await withdrawalOp.executeWithdrawal({ amount, depositorAddress: address });
   };
 
@@ -150,14 +162,18 @@ export function LendPageClient() {
                 ? "bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-400"
                 : sseStatus === "connecting"
                   ? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
-                  : "bg-red-50 text-red-600 dark:bg-red-500/10 dark:text-red-400"
+                  : sseStatus === "polling"
+                    ? "bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300"
+                    : "bg-red-50 text-red-600 dark:bg-red-500/10 dark:text-red-400"
             }`}
             title={
               sseStatus === "connected"
                 ? "Live pool updates connected"
                 : sseStatus === "connecting"
                   ? "Connecting to live updates…"
-                  : "Live updates disconnected — retrying"
+                  : sseStatus === "polling"
+                    ? "Live updates dropped — polling while reconnecting"
+                    : "Live updates disconnected — retrying"
             }
           >
             {sseStatus === "connected" ? (
@@ -169,7 +185,9 @@ export function LendPageClient() {
               ? "Live"
               : sseStatus === "connecting"
                 ? "Connecting…"
-                : "Offline"}
+                : sseStatus === "polling"
+                  ? "Reconnecting…"
+                  : "Offline"}
           </div>
         )}
       </header>
@@ -291,16 +309,29 @@ export function LendPageClient() {
                   </label>
                   <input
                     id="deposit-amount"
-                    type="number"
+                    type="text"
+                    inputMode="decimal"
                     min="0"
-                    step="0.01"
+                    step="0.0000001"
                     value={depositAmount}
-                    onChange={(event) => setDepositAmount(event.target.value)}
-                    className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900"
+                    onChange={(event) => setDepositAmount(sanitizeAmountInput(event.target.value))}
+                    aria-invalid={depositPrecisionError ? true : undefined}
+                    className={`w-full rounded-xl border bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900 ${
+                      depositPrecisionError ? "border-red-500" : "border-zinc-200"
+                    }`}
                   />
+                  <p
+                    className={`text-xs ${
+                      depositPrecisionError
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-zinc-500 dark:text-zinc-400"
+                    }`}
+                  >
+                    {depositPrecisionError ?? depositHelper ?? "Up to 7 decimal places supported."}
+                  </p>
                   <button
                     type="submit"
-                    disabled={depositOp.isLoading}
+                    disabled={depositOp.isLoading || !!depositPrecisionError}
                     className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <ArrowUpRight className="h-4 w-4" />
@@ -324,16 +355,31 @@ export function LendPageClient() {
                   </label>
                   <input
                     id="withdraw-amount"
-                    type="number"
+                    type="text"
+                    inputMode="decimal"
                     min="0"
-                    step="0.01"
+                    step="0.0000001"
                     value={withdrawAmount}
-                    onChange={(event) => setWithdrawAmount(event.target.value)}
-                    className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900"
+                    onChange={(event) => setWithdrawAmount(sanitizeAmountInput(event.target.value))}
+                    aria-invalid={withdrawPrecisionError ? true : undefined}
+                    className={`w-full rounded-xl border bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900 ${
+                      withdrawPrecisionError ? "border-red-500" : "border-zinc-200"
+                    }`}
                   />
+                  <p
+                    className={`text-xs ${
+                      withdrawPrecisionError
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-zinc-500 dark:text-zinc-400"
+                    }`}
+                  >
+                    {withdrawPrecisionError ??
+                      withdrawHelper ??
+                      "Up to 7 decimal places supported."}
+                  </p>
                   <button
                     type="submit"
-                    disabled={withdrawalOp.isLoading}
+                    disabled={withdrawalOp.isLoading || !!withdrawPrecisionError}
                     className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
                   >
                     <ArrowDownLeft className="h-4 w-4" />

--- a/frontend/src/app/[locale]/repay/[loanId]/page.tsx
+++ b/frontend/src/app/[locale]/repay/[loanId]/page.tsx
@@ -22,6 +22,11 @@ import { useContractToast } from "../../../hooks/useContractToast";
 import { TransactionPreviewModal } from "../../../components/transaction/TransactionPreviewModal";
 import { useTransactionPreview } from "../../../hooks/useTransactionPreview";
 import { buildUnsignedRepaymentXdr } from "../../../utils/soroban";
+import {
+  buildAmountHelperText,
+  getPrecisionError,
+  sanitizeAmountInput,
+} from "../../../utils/amount";
 
 export default function RepayLoanPage() {
   const params = useParams<{ loanId: string }>();
@@ -44,6 +49,8 @@ export default function RepayLoanPage() {
   const [lastError, setLastError] = useState<TransactionErrorDetails | null>(null);
 
   const amountNumber = useMemo(() => Number(amount || "0"), [amount]);
+  const precisionError = getPrecisionError(amount, "USDC");
+  const helperText = buildAmountHelperText(amount, "USDC");
 
   const cancelFlow = () => {
     setTrackerState("cancelled");
@@ -57,6 +64,14 @@ export default function RepayLoanPage() {
     event.preventDefault();
     if (!isWalletConnected || !walletAddress) {
       toast.error("Wallet not connected", "Please connect your wallet first.");
+      return;
+    }
+    if (!amount || Number.isNaN(amountNumber) || amountNumber <= 0) {
+      toast.error("Invalid amount", "Enter a repayment amount greater than zero.");
+      return;
+    }
+    if (precisionError) {
+      toast.error("Invalid precision", precisionError);
       return;
     }
 
@@ -194,14 +209,29 @@ export default function RepayLoanPage() {
           </label>
           <input
             id="repayment-amount"
-            type="number"
+            type="text"
+            inputMode="decimal"
             value={amount}
-            onChange={(event) => setAmount(event.target.value)}
-            className="mt-2 w-full rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-zinc-900 outline-none transition focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50"
+            onChange={(event) => setAmount(sanitizeAmountInput(event.target.value))}
+            className={`mt-2 w-full rounded-2xl border bg-zinc-50 px-4 py-3 text-zinc-900 outline-none transition focus:border-indigo-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 ${
+              precisionError ? "border-red-500" : "border-zinc-200"
+            }`}
           />
+          <p
+            className={`mt-2 text-xs ${
+              precisionError ? "text-red-600 dark:text-red-400" : "text-zinc-500 dark:text-zinc-400"
+            }`}
+          >
+            {precisionError ?? helperText ?? "Up to 7 decimal places supported."}
+          </p>
         </div>
 
-        <Button type="submit" className="w-full" isLoading={isSubmitting}>
+        <Button
+          type="submit"
+          className="w-full"
+          isLoading={isSubmitting}
+          disabled={!!precisionError}
+        >
           Review & Repay
         </Button>
       </form>

--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -12,6 +12,12 @@ import { useGamificationStore } from "../../stores/useGamificationStore";
 import { useRepaymentOperation } from "../../hooks/useRepaymentOperation";
 import { OperationProgress } from "../ui/OperationProgress";
 import { useWalletStore, selectWalletAddress } from "../../stores/useWalletStore";
+import {
+  buildAmountHelperText,
+  getPrecisionError,
+  parseAmount,
+  sanitizeAmountInput,
+} from "../../utils/amount";
 
 interface LoanRepaymentFormProps {
   loanId: number;
@@ -40,17 +46,24 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
       setAmount("");
     },
   });
+  const precisionError = getPrecisionError(amount, "USDC");
+  const helperText = buildAmountHelperText(amount, "USDC");
 
   const handleAmountChange = (value: string) => {
-    setAmount(value);
+    setAmount(sanitizeAmountInput(value));
     setError(null);
   };
 
   const validateAmount = (): boolean => {
-    const numAmount = parseFloat(amount);
+    const numAmount = parseAmount(amount);
 
     if (!amount || isNaN(numAmount)) {
       setError("Please enter a valid amount");
+      return false;
+    }
+
+    if (precisionError) {
+      setError(precisionError);
       return false;
     }
 
@@ -75,7 +88,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
   const handleRepayClick = () => {
     if (!validateAmount()) return;
 
-    const numAmount = parseFloat(amount);
+    const numAmount = parseAmount(amount);
 
     const previewData = formatLoanRepayment({
       loanId,
@@ -92,7 +105,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
   };
 
   const handlePayFullAmount = () => {
-    setAmount(totalOwed.toString());
+    setAmount(totalOwed.toFixed(7).replace(/\.?0+$/, ""));
     setError(null);
   };
 
@@ -124,15 +137,16 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
           {/* Amount Input */}
           <div className="space-y-2">
             <Input
-              type="number"
+              type="text"
+              inputMode="decimal"
               label="Repayment Amount"
               placeholder="0.00"
               value={amount}
               onChange={(e) => handleAmountChange(e.target.value)}
-              error={error || undefined}
+              error={error || precisionError || undefined}
               leftIcon={<DollarSign className="h-4 w-4" />}
               required
-              helperText="Enter the amount you want to repay in USDC"
+              helperText={helperText ?? "Enter the amount you want to repay in USDC"}
             />
 
             <Button variant="ghost" size="sm" onClick={handlePayFullAmount} className="w-full">
@@ -161,7 +175,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
           <Button
             variant="primary"
             onClick={handleRepayClick}
-            disabled={!amount || !!error || repayment.isLoading}
+            disabled={!amount || !!error || !!precisionError || repayment.isLoading}
             className="w-full"
           >
             {repayment.isLoading ? "Processing..." : "Review Repayment"}

--- a/frontend/src/app/components/loan-wizard/StepAmountAsset.tsx
+++ b/frontend/src/app/components/loan-wizard/StepAmountAsset.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/Card";
 import type { LoanWizardData } from "./LoanApplicationWizard";
+import { buildAmountHelperText, getPrecisionError, sanitizeAmountInput } from "../../utils/amount";
 
 const TERM_OPTIONS = [
   { label: "30 days", days: 30 as const },
@@ -43,10 +44,16 @@ interface StepAmountAssetProps {
 export function StepAmountAsset({ data, onChange, onNext, error, onError }: StepAmountAssetProps) {
   const amountNumber = Number(data.amount || "0");
   const minAmount = 100;
+  const precisionError = getPrecisionError(data.amount, data.asset || "USDC");
+  const helperText = buildAmountHelperText(data.amount, data.asset || "USDC");
 
   const validate = (): boolean => {
     if (!data.amount || Number.isNaN(amountNumber) || amountNumber <= 0) {
       onError("Enter a valid loan amount.");
+      return false;
+    }
+    if (precisionError) {
+      onError(precisionError);
       return false;
     }
     if (data.maxAmount === 0) {
@@ -114,21 +121,25 @@ export function StepAmountAsset({ data, onChange, onNext, error, onError }: Step
             {/* Amount */}
             <Input
               label={`Amount (${data.asset})`}
-              type="number"
+              type="text"
+              inputMode="decimal"
               min={minAmount}
               max={data.maxAmount || undefined}
               value={data.amount}
               onChange={(e) => {
-                onChange({ amount: e.target.value });
+                onChange({ amount: sanitizeAmountInput(e.target.value) });
                 onError(null);
               }}
               placeholder="1000"
               required
               helperText={
-                data.maxAmount === 0
+                precisionError ||
+                helperText ||
+                (data.maxAmount === 0
                   ? "Not eligible"
-                  : `Eligible range: ${formatMoney(minAmount)} – ${formatMoney(data.maxAmount)}`
+                  : `Eligible range: ${formatMoney(minAmount)} – ${formatMoney(data.maxAmount)}`)
               }
+              error={precisionError || undefined}
             />
 
             {/* Term */}

--- a/frontend/src/app/components/remittance/RemittanceForm.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.tsx
@@ -11,6 +11,12 @@ import { isValidStellarAddress } from "../../utils/stellar";
 import { AlertCircle, Send, Loader } from "lucide-react";
 import { useCreateRemittance } from "../../hooks/useApi";
 import { toast } from "sonner";
+import {
+  buildAmountHelperText,
+  getPrecisionError,
+  parseAmount,
+  sanitizeAmountInput,
+} from "../../utils/amount";
 
 interface RemittanceFormProps {
   onSuccess?: () => void;
@@ -25,6 +31,8 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
 
   const txPreview = useTransactionPreview();
   const mutation = useCreateRemittance();
+  const precisionError = getPrecisionError(amount, token);
+  const helperText = buildAmountHelperText(amount, token);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -39,9 +47,11 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
     if (!amount) {
       newErrors.amount = "Amount is required";
     } else {
-      const numAmount = parseFloat(amount);
+      const numAmount = parseAmount(amount);
       if (isNaN(numAmount) || numAmount <= 0) {
         newErrors.amount = "Amount must be greater than 0";
+      } else if (precisionError) {
+        newErrors.amount = precisionError;
       }
     }
 
@@ -61,7 +71,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
   };
 
   const handleAmountChange = (value: string) => {
-    setAmount(value);
+    setAmount(sanitizeAmountInput(value));
     if (errors.amount) {
       setErrors({ ...errors, amount: "" });
     }
@@ -82,7 +92,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
       return;
     }
 
-    const numAmount = parseFloat(amount);
+    const numAmount = parseAmount(amount);
 
     const previewData = formatRemittanceSend({
       amount: numAmount,
@@ -177,23 +187,19 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
             <Input
               id="amount"
               label="Amount"
-              type="number"
+              type="text"
+              inputMode="decimal"
               placeholder="0.00"
               value={amount}
               onChange={(e) => handleAmountChange(e.target.value)}
               disabled={mutation.isPending}
               required
               min="0"
-              step="0.01"
+              step="0.0000001"
+              error={errors.amount || undefined}
+              helperText={helperText ?? "Up to 7 decimal places supported."}
               className={errors.amount ? "border-red-600" : ""}
             />
-
-            {errors.amount && (
-              <div className="mt-1 flex items-start gap-2 text-sm text-red-600">
-                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                <span>{errors.amount}</span>
-              </div>
-            )}
 
             <p className="text-[10px] text-zinc-500 dark:text-zinc-400 mt-2">
               <span className="text-red-600">*</span> Required field
@@ -245,7 +251,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
             <div className="flex gap-3 pt-4">
               <Button
                 onClick={handleReviewTransaction}
-                disabled={mutation.isPending || !recipientAddress || !amount}
+                disabled={mutation.isPending || !recipientAddress || !amount || !!precisionError}
                 className="flex-1"
               >
                 {mutation.isPending ? (

--- a/frontend/src/app/components/ui/Input.tsx
+++ b/frontend/src/app/components/ui/Input.tsx
@@ -12,7 +12,7 @@ function cn(...inputs: ClassValue[]) {
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
-  helperText?: string;
+  helperText?: React.ReactNode;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
 }

--- a/frontend/src/app/hooks/useSSE.ts
+++ b/frontend/src/app/hooks/useSSE.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useUserStore } from "../stores/useUserStore";
 
 export type SSEStatus = "connecting" | "connected" | "disconnected";
+export type RealtimeStatus = SSEStatus | "polling";
 
 interface UseSSEOptions<T> {
   /** Full URL of the SSE endpoint. Pass null/undefined to disable. */
@@ -14,6 +15,8 @@ interface UseSSEOptions<T> {
   onOpen?: () => void;
   /** Called when the connection closes with an error. */
   onError?: (error: Error) => void;
+  /** Invoked while the hook is in fallback polling mode. */
+  onFallbackPoll?: () => void | Promise<void>;
 }
 
 /**
@@ -25,12 +28,14 @@ export function useSSE<T = unknown>({
   onMessage,
   onOpen,
   onError,
-}: UseSSEOptions<T>): SSEStatus {
-  const [status, setStatus] = useState<SSEStatus>("connecting");
+  onFallbackPoll,
+}: UseSSEOptions<T>): RealtimeStatus {
+  const [status, setStatus] = useState<RealtimeStatus>("connecting");
   const token = useUserStore((s) => s.authToken);
   const retryDelay = useRef(1_000);
   const abortControllerRef = useRef<AbortController | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
@@ -38,6 +43,8 @@ export function useSSE<T = unknown>({
   onOpenRef.current = onOpen;
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
+  const onFallbackPollRef = useRef(onFallbackPoll);
+  onFallbackPollRef.current = onFallbackPoll;
 
   useEffect(() => {
     if (!url) {
@@ -47,9 +54,28 @@ export function useSSE<T = unknown>({
 
     let cancelled = false;
 
+    const stopPolling = () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+        pollingIntervalRef.current = null;
+      }
+    };
+
+    const startPolling = () => {
+      if (pollingIntervalRef.current || !onFallbackPollRef.current) {
+        return;
+      }
+
+      setStatus("polling");
+      void onFallbackPollRef.current();
+      pollingIntervalRef.current = setInterval(() => {
+        void onFallbackPollRef.current?.();
+      }, 10_000);
+    };
+
     async function connect() {
       if (cancelled) return;
-      
+
       // Clean up previous connection if any
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
@@ -61,7 +87,7 @@ export function useSSE<T = unknown>({
 
       try {
         const headers: Record<string, string> = {
-          "Accept": "text/event-stream",
+          Accept: "text/event-stream",
         };
 
         if (token) {
@@ -81,6 +107,7 @@ export function useSSE<T = unknown>({
           throw new Error("Response body is null");
         }
 
+        stopPolling();
         setStatus("connected");
         retryDelay.current = 1_000;
         onOpenRef.current?.();
@@ -117,11 +144,11 @@ export function useSSE<T = unknown>({
           return;
         }
 
-        setStatus("disconnected");
+        startPolling();
         onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
 
         if (!cancelled) {
-          const delay = Math.min(retryDelay.current, 30_000);
+          const delay = Math.min(retryDelay.current, 5_000);
           retryDelay.current = Math.min(delay * 2, 30_000);
           timeoutRef.current = setTimeout(connect, delay);
         }
@@ -138,6 +165,7 @@ export function useSSE<T = unknown>({
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
+      stopPolling();
     };
   }, [url, token]);
 

--- a/frontend/src/app/utils/amount.ts
+++ b/frontend/src/app/utils/amount.ts
@@ -1,0 +1,87 @@
+export const STROOP_DECIMALS = 7;
+export const STROOP_SCALE = 10 ** STROOP_DECIMALS;
+
+export function sanitizeAmountInput(value: string): string {
+  let sanitized = value.replace(/[^\d.]/g, "");
+  const firstDotIndex = sanitized.indexOf(".");
+  if (firstDotIndex !== -1) {
+    sanitized =
+      sanitized.slice(0, firstDotIndex + 1) + sanitized.slice(firstDotIndex + 1).replace(/\./g, "");
+  }
+  return sanitized;
+}
+
+export function countFractionDigits(value: string): number {
+  const [, fraction = ""] = value.split(".");
+  return fraction.length;
+}
+
+export function hasInvalidPrecision(value: string, decimals = STROOP_DECIMALS): boolean {
+  return countFractionDigits(value) > decimals;
+}
+
+export function parseAmount(value: string): number {
+  return Number.parseFloat(value);
+}
+
+export function formatTypedAmount(
+  value: string,
+  decimals = STROOP_DECIMALS,
+  locale = "en-US",
+): string | null {
+  const amount = parseAmount(value);
+  if (!value || Number.isNaN(amount)) {
+    return null;
+  }
+
+  return amount.toLocaleString(locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export function toStroops(value: string, decimals = STROOP_DECIMALS): bigint | null {
+  if (!value || hasInvalidPrecision(value, decimals)) {
+    return null;
+  }
+
+  const [whole = "0", fraction = ""] = value.split(".");
+  const normalizedFraction = fraction.padEnd(decimals, "0");
+
+  try {
+    return BigInt(whole || "0") * BigInt(STROOP_SCALE) + BigInt(normalizedFraction || "0");
+  } catch {
+    return null;
+  }
+}
+
+export function buildAmountHelperText(
+  value: string,
+  asset = "XLM",
+  decimals = STROOP_DECIMALS,
+  locale = "en-US",
+): string | null {
+  const formatted = formatTypedAmount(value, decimals, locale);
+  if (!formatted) {
+    return null;
+  }
+
+  const stroops = toStroops(value, decimals);
+  if (stroops === null) {
+    return `Formatted: ${formatted} ${asset}`;
+  }
+
+  return `Formatted: ${formatted} ${asset} • Stroops: ${stroops.toString()}`;
+}
+
+export function getPrecisionError(
+  value: string,
+  asset = "XLM",
+  decimals = STROOP_DECIMALS,
+): string | null {
+  if (!hasInvalidPrecision(value, decimals)) {
+    return null;
+  }
+
+  return `${asset} supports at most ${decimals} decimal places.`;
+}


### PR DESCRIPTION
## Summary
- add SSE polling fallback with reconnect status handling on the lend dashboard
- enforce 7-decimal precision across loan request, lend, remittance, and repayment amount inputs with stroop helper text
- expand lending pool tests for yield distribution and fund allocation stats
- harden the existing CI workflow with backend lint and build steps

## Verification
- cargo test -p lending_pool passed
- frontend build passed
- frontend lint still reports pre-existing formatting issues in e2e/borrower-loan-flow.spec.ts and src/app/hooks/useNotificationStream.ts
- backend lint and backend build still fail due pre-existing repo issues unrelated to this PR

Closes #734
Closes #735
Closes #737
Closes #739