### PR TITLE
docs: add SECURITY.md disclosure policy and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,7 @@ We welcome contributions from developers of all skill levels! Please see our [CO
 ## 📄 License
 
 This project is licensed under the ISC License. See the `LICENSE` file for details..
+
+## 🔒 Security
+
+Please refer to our [Security Policy](SECURITY.md) for information on supported versions, out-of-scope targets, and how to responsibly disclose a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, the following versions are actively maintained and receive security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| Latest Tag | :white_check_mark: |
+| Older Versions | :x: |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in RemitLend's contracts, backend, or frontend, please report it privately. **Do not create a public GitHub issue.**
+
+### Contact Information
+Please send your vulnerability reports directly to the maintainers or via our secure communication channels. If no direct security email is listed, you can reach out as a fallback via the contributor Telegram: [https://t.me/+DOylgFv1jyJlNzM0](https://t.me/+DOylgFv1jyJlNzM0) and request a secure channel for disclosure.
+
+### Scope
+
+**In-Scope:**
+* Soroban Smart Contracts (`/contracts`)
+* Backend API / Services (`/backend`)
+* Frontend Client (`/frontend`)
+
+**Out-of-Scope:**
+* Third-party services, APIs, and dependencies.
+* Issues requiring physical access to a user's device.
+* Denial of Service (DoS) attacks.
+* Phishing or social engineering.
+
+### Disclosure Policy and SLA
+* We will acknowledge receipt of your vulnerability report within **5 business days**.
+* We ask for a **90-day responsible disclosure window** before any public disclosure is made by researchers.
+* We will keep you updated on the progress of the fix and remediation.
+
+### Bounties
+At this time, we do not run a formal, paid bug bounty program. However, high-impact vulnerability reports may be recognized and rewarded on a discretionary basis, depending on the severity of the bug and the quality of the report.
+
+_Note: GPG Key encryption for reports is currently unsupported but may be added in the future._


### PR DESCRIPTION
Fixes #908.

### Changes
- Adds a canonical `SECURITY.md` at the repo root to establish a responsible disclosure window (90-day), contact fallback, supported versions (`main`), and scope definitions for researchers.
- Links to `SECURITY.md` from the `README.md` Security section to satisfy GitHub platform security policy gaps.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora