### PR TITLE
Add recent transactions drawer and governance console

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,6 +23,7 @@ import authRoutes from "./routes/authRoutes.js";
 import notificationsRoutes from "./routes/notificationsRoutes.js";
 import eventRoutes from "./routes/eventRoutes.js";
 import remittanceRoutes from "./routes/remittanceRoutes.js";
+import transactionRoutes from "./routes/transactionRoutes.js";
 import { globalRateLimiter } from "./middleware/rateLimiter.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
@@ -168,6 +169,7 @@ app.use("/api/auth", authRoutes);
 app.use("/api/notifications", notificationsRoutes);
 app.use("/api/events", eventRoutes);
 app.use("/api/remittances", remittanceRoutes);
+app.use("/api/transactions", transactionRoutes);
 
 // Versioned API routes (v1 - current)
 app.use("/api/v1", simulationRoutes);
@@ -177,6 +179,7 @@ app.use("/api/v1/indexer", indexerRoutes);
 app.use("/api/v1/admin", adminRoutes);
 app.use("/api/v1/auth", authRoutes);
 app.use("/api/v1/remittances", remittanceRoutes);
+app.use("/api/v1/transactions", transactionRoutes);
 
 // ── Diagnostic / Test Routes ─────────────────────────────────────
 // Only exposed in test environment to verify centralized error handling.

--- a/backend/src/controllers/adminGovernanceController.ts
+++ b/backend/src/controllers/adminGovernanceController.ts
@@ -1,0 +1,79 @@
+import type { Request, Response } from "express";
+import { query } from "../db/connection.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+type GovernanceRow = {
+  proposal_id?: string;
+  proposed_admin?: string;
+  approval_count?: number | string;
+  threshold?: number | string;
+  executable_at?: string | Date | null;
+  expires_at?: string | Date | null;
+  signer_address?: string | null;
+  approved?: boolean | null;
+};
+
+function parseSignersFromEnv() {
+  return (process.env.GOVERNANCE_SIGNERS ?? "")
+    .split(",")
+    .map((address) => address.trim())
+    .filter(Boolean)
+    .map((address) => ({ address, approved: false }));
+}
+
+export const getPendingGovernance = asyncHandler(
+  async (_req: Request, res: Response) => {
+    const currentAdmin = process.env.GOVERNANCE_CURRENT_ADMIN ?? process.env.ADMIN_PUBLIC_KEY ?? null;
+    const targetContract = process.env.MULTISIG_GOVERNANCE_CONTRACT_ID ?? null;
+    const threshold = Number.parseInt(process.env.GOVERNANCE_THRESHOLD ?? "0", 10) || 0;
+
+    try {
+      const result = await query<GovernanceRow>(
+        `SELECT
+           proposal_id,
+           proposed_admin,
+           approval_count,
+           threshold,
+           executable_at,
+           expires_at,
+           signer_address,
+           approved
+         FROM multisig_governance_pending
+         ORDER BY proposal_id DESC`,
+      );
+
+      if (result.rows.length > 0) {
+        const first = result.rows[0];
+        res.json({
+          currentAdmin,
+          targetContract,
+          pendingProposal: {
+            id: first.proposal_id,
+            proposedAdmin: first.proposed_admin,
+            approvalCount: Number(first.approval_count ?? 0),
+            threshold: Number(first.threshold ?? threshold),
+            executableAt: first.executable_at,
+            expiresAt: first.expires_at,
+            signers: result.rows
+              .filter((row) => row.signer_address)
+              .map((row) => ({
+                address: row.signer_address,
+                approved: Boolean(row.approved),
+              })),
+          },
+        });
+        return;
+      }
+    } catch {
+      // The contract-facing index table is optional in early deployments.
+    }
+
+    res.json({
+      currentAdmin,
+      targetContract,
+      pendingProposal: null,
+      signers: parseSignersFromEnv(),
+      threshold,
+    });
+  },
+);

--- a/backend/src/controllers/adminGovernanceController.ts
+++ b/backend/src/controllers/adminGovernanceController.ts
@@ -28,7 +28,7 @@ export const getPendingGovernance = asyncHandler(
     const threshold = Number.parseInt(process.env.GOVERNANCE_THRESHOLD ?? "0", 10) || 0;
 
     try {
-      const result = await query<GovernanceRow>(
+      const result = await query(
         `SELECT
            proposal_id,
            proposed_admin,
@@ -43,7 +43,7 @@ export const getPendingGovernance = asyncHandler(
       );
 
       if (result.rows.length > 0) {
-        const first = result.rows[0];
+        const first = result.rows[0] as GovernanceRow;
         res.json({
           currentAdmin,
           targetContract,
@@ -55,8 +55,8 @@ export const getPendingGovernance = asyncHandler(
             executableAt: first.executable_at,
             expiresAt: first.expires_at,
             signers: result.rows
-              .filter((row) => row.signer_address)
-              .map((row) => ({
+              .filter((row: GovernanceRow) => row.signer_address)
+              .map((row: GovernanceRow) => ({
                 address: row.signer_address,
                 approved: Boolean(row.approved),
               })),

--- a/backend/src/controllers/transactionController.ts
+++ b/backend/src/controllers/transactionController.ts
@@ -1,0 +1,76 @@
+import type { Request, Response } from "express";
+import { query } from "../db/connection.js";
+import { AppError } from "../errors/AppError.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function parseLimit(value: unknown): number {
+  if (typeof value !== "string") return DEFAULT_LIMIT;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function parseCursor(value: unknown): number | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export const listMyTransactions = asyncHandler(
+  async (req: Request, res: Response) => {
+    const publicKey = req.user?.publicKey;
+    if (!publicKey) {
+      throw AppError.unauthorized("Authentication required");
+    }
+
+    const limit = parseLimit(req.query.limit);
+    const cursor = parseCursor(req.query.cursor);
+    const params: Array<string | number> = [publicKey, limit + 1];
+    const cursorClause = cursor ? "AND id < $3" : "";
+    if (cursor) params.push(cursor);
+
+    const result = await query(
+      `SELECT
+         id,
+         tx_hash,
+         status,
+         submitted_at,
+         submitted_by,
+         transaction_type,
+         result_xdr
+       FROM transaction_submissions
+       WHERE submitted_by = $1
+       ${cursorClause}
+       ORDER BY id DESC
+       LIMIT $2`,
+      params,
+    );
+
+    const rows = result.rows.slice(0, limit);
+    const hasNext = result.rows.length > limit;
+    const nextCursor = hasNext ? String(rows[rows.length - 1]?.id) : null;
+
+    res.json({
+      success: true,
+      data: rows.map((row) => ({
+        id: row.id,
+        txHash: row.tx_hash,
+        status: row.status,
+        submittedAt: row.submitted_at,
+        submittedBy: row.submitted_by,
+        transactionType: row.transaction_type,
+        resultXdr: row.result_xdr,
+      })),
+      page_info: {
+        limit,
+        count: rows.length,
+        next_cursor: nextCursor,
+        has_previous: cursor !== null,
+        has_next: hasNext,
+      },
+    });
+  },
+);

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -22,6 +22,7 @@ import {
   getLoanDispute,
   rejectLoanDispute,
 } from "../controllers/adminDisputeController.js";
+import { getPendingGovernance } from "../controllers/adminGovernanceController.js";
 import { query } from "../db/connection.js";
 
 const router = Router();
@@ -106,6 +107,13 @@ router.post(
   requireJwtAuth,
   requireRoles("admin"),
   rejectLoanDispute,
+);
+
+router.get(
+  "/governance/pending",
+  requireJwtAuth,
+  requireRoles("admin"),
+  getPendingGovernance,
 );
 
 const checkDefaultsBodySchema = z.object({

--- a/backend/src/routes/transactionRoutes.ts
+++ b/backend/src/routes/transactionRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { listMyTransactions } from "../controllers/transactionController.js";
+import { requireJwtAuth } from "../middleware/jwtAuth.js";
+
+const router = Router();
+
+router.get("/me", requireJwtAuth, listMyTransactions);
+
+export default router;

--- a/frontend/e2e/admin-governance.spec.ts
+++ b/frontend/e2e/admin-governance.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+test("admin can view pending governance proposal", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "remitlend-user",
+      JSON.stringify({
+        state: {
+          authToken: "mock-admin-token",
+          isAuthenticated: true,
+          user: {
+            id: "admin",
+            email: "admin@example.com",
+            walletAddress: "GADMIN",
+            role: "admin",
+            kycVerified: true,
+          },
+        },
+        version: 0,
+      }),
+    );
+  });
+
+  await page.route("**/api/v1/admin/governance/pending", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        currentAdmin: "GADMINCURRENT",
+        targetContract: "CCONTRACT",
+        pendingProposal: {
+          id: "proposal-1",
+          proposedAdmin: "GNEWADMIN",
+          approvalCount: 1,
+          threshold: 2,
+          executableAt: new Date(Date.now() + 60_000).toISOString(),
+          expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+          signers: [
+            { address: "GSIGNER1", approved: true },
+            { address: "GSIGNER2", approved: false },
+          ],
+        },
+      }),
+    });
+  });
+
+  await page.goto("/en/admin/governance");
+  await expect(page.getByRole("heading", { name: /governance console/i })).toBeVisible();
+  await expect(page.getByText("proposal-1")).toBeVisible();
+  await expect(page.getByText("1/2")).toBeVisible();
+});

--- a/frontend/e2e/recent-transactions.spec.ts
+++ b/frontend/e2e/recent-transactions.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test("opens recent transactions drawer with copied hashes", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "remitlend-user",
+      JSON.stringify({
+        state: {
+          authToken: "mock-token",
+          isAuthenticated: true,
+          user: {
+            id: "u1",
+            email: "borrower@example.com",
+            walletAddress: "GBORROWER",
+            kycVerified: true,
+          },
+        },
+        version: 0,
+      }),
+    );
+  });
+
+  await page.route("**/api/v1/transactions/me**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: [
+          {
+            id: 9,
+            txHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            status: "SUCCESS",
+            submittedAt: new Date().toISOString(),
+            submittedBy: "GBORROWER",
+            transactionType: "loan",
+          },
+        ],
+        page_info: { limit: 20, count: 1, next_cursor: null, has_next: false },
+      }),
+    });
+  });
+
+  await page.goto("/en");
+  await page.getByRole("button", { name: /recent transactions/i }).click();
+  await expect(page.getByRole("dialog")).toContainText("Recent transactions");
+  await expect(page.getByText("SUCCESS")).toBeVisible();
+});

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -128,6 +128,31 @@
     "viewDetails": "View Details",
     "details": "Details"
   },
+  "RecentTransactions": {
+    "open": "Open recent transactions",
+    "close": "Close recent transactions",
+    "title": "Recent transactions",
+    "description": "Copy hashes and reopen Stellar Expert links.",
+    "loading": "Loading recent transactions...",
+    "empty": "No submitted transactions yet.",
+    "error": "Unable to load recent transactions."
+  },
+  "Governance": {
+    "title": "Governance console",
+    "description": "Read-only view of pending multisig admin-transfer proposals.",
+    "forbidden": "Admin access is required to view governance proposals.",
+    "loading": "Loading governance status...",
+    "error": "Unable to load governance status.",
+    "empty": "No pending governance proposal.",
+    "currentAdmin": "Current admin",
+    "targetContract": "Target contract",
+    "pendingProposal": "Pending proposal",
+    "approvals": "approvals",
+    "timeToExecutable": "Time to executable",
+    "expiresAt": "Expires at",
+    "approved": "Approved",
+    "pending": "Pending"
+  },
   "Settings": {
     "language": "Language",
     "selectLanguage": "Select Language"

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -128,6 +128,31 @@
     "viewDetails": "Ver detalles",
     "details": "Detalles"
   },
+  "RecentTransactions": {
+    "open": "Abrir transacciones recientes",
+    "close": "Cerrar transacciones recientes",
+    "title": "Transacciones recientes",
+    "description": "Copia hashes y abre enlaces de Stellar Expert.",
+    "loading": "Cargando transacciones recientes...",
+    "empty": "Aún no hay transacciones enviadas.",
+    "error": "No se pudieron cargar las transacciones recientes."
+  },
+  "Governance": {
+    "title": "Consola de gobernanza",
+    "description": "Vista de solo lectura de propuestas multisig pendientes.",
+    "forbidden": "Se requiere acceso de administrador para ver propuestas.",
+    "loading": "Cargando estado de gobernanza...",
+    "error": "No se pudo cargar el estado de gobernanza.",
+    "empty": "No hay propuesta de gobernanza pendiente.",
+    "currentAdmin": "Administrador actual",
+    "targetContract": "Contrato objetivo",
+    "pendingProposal": "Propuesta pendiente",
+    "approvals": "aprobaciones",
+    "timeToExecutable": "Tiempo para ejecutar",
+    "expiresAt": "Expira en",
+    "approved": "Aprobado",
+    "pending": "Pendiente"
+  },
   "Settings": {
     "language": "Idioma",
     "selectLanguage": "Seleccione el idioma"

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -128,6 +128,31 @@
     "viewDetails": "Tingnan ang Mga Detalye",
     "details": "Mga Detalye"
   },
+  "RecentTransactions": {
+    "open": "Buksan ang recent transactions",
+    "close": "Isara ang recent transactions",
+    "title": "Recent transactions",
+    "description": "Kopyahin ang hashes at buksan ang Stellar Expert links.",
+    "loading": "Naglo-load ng recent transactions...",
+    "empty": "Wala pang submitted transactions.",
+    "error": "Hindi ma-load ang recent transactions."
+  },
+  "Governance": {
+    "title": "Governance console",
+    "description": "Read-only view ng pending multisig admin-transfer proposals.",
+    "forbidden": "Kailangan ng admin access para makita ang governance proposals.",
+    "loading": "Naglo-load ng governance status...",
+    "error": "Hindi ma-load ang governance status.",
+    "empty": "Walang pending governance proposal.",
+    "currentAdmin": "Current admin",
+    "targetContract": "Target contract",
+    "pendingProposal": "Pending proposal",
+    "approvals": "approvals",
+    "timeToExecutable": "Time to executable",
+    "expiresAt": "Expires at",
+    "approved": "Approved",
+    "pending": "Pending"
+  },
   "Settings": {
     "language": "Wika",
     "selectLanguage": "Piliin ang Wika"

--- a/frontend/src/app/[locale]/admin/governance/page.tsx
+++ b/frontend/src/app/[locale]/admin/governance/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useAdminGovernancePending } from "../../../hooks/useApi";
+import { useUserStore } from "../../../stores/useUserStore";
+
+function shortAddress(value: string | null | undefined) {
+  if (!value) return "Not configured";
+  return value.length > 14 ? `${value.slice(0, 8)}...${value.slice(-6)}` : value;
+}
+
+function timeUntil(value: string | null | undefined) {
+  if (!value) return "Not scheduled";
+  const deltaMs = new Date(value).getTime() - Date.now();
+  if (!Number.isFinite(deltaMs)) return "Unknown";
+  if (deltaMs <= 0) return "Executable now";
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.ceil(minutes / 60)}h`;
+}
+
+export default function GovernancePage() {
+  const t = useTranslations("Governance");
+  const role = useUserStore((state) => state.user?.role);
+  const { data, isLoading, isError } = useAdminGovernancePending();
+
+  if (role && role !== "admin") {
+    return (
+      <main className="mx-auto max-w-5xl px-4 py-10">
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {t("forbidden")}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 px-4 py-10">
+      <div>
+        <h1 className="text-2xl font-semibold text-zinc-950 dark:text-zinc-50">{t("title")}</h1>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">{t("description")}</p>
+      </div>
+
+      {isLoading ? (
+        <section className="rounded-2xl border border-zinc-200 p-6 dark:border-zinc-800">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("loading")}</p>
+        </section>
+      ) : isError ? (
+        <section className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {t("error")}
+        </section>
+      ) : (
+        <>
+          <section className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-zinc-200 p-5 dark:border-zinc-800">
+              <p className="text-xs uppercase tracking-wide text-zinc-500">{t("currentAdmin")}</p>
+              <p className="mt-2 font-mono text-sm text-zinc-950 dark:text-zinc-50">
+                {shortAddress(data?.currentAdmin)}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-zinc-200 p-5 dark:border-zinc-800">
+              <p className="text-xs uppercase tracking-wide text-zinc-500">{t("targetContract")}</p>
+              <p className="mt-2 font-mono text-sm text-zinc-950 dark:text-zinc-50">
+                {shortAddress(data?.targetContract)}
+              </p>
+            </div>
+          </section>
+
+          {!data?.pendingProposal ? (
+            <section className="rounded-2xl border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+              {t("empty")}
+            </section>
+          ) : (
+            <section className="rounded-2xl border border-zinc-200 p-5 dark:border-zinc-800">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <p className="text-sm text-zinc-500">{t("pendingProposal")}</p>
+                  <h2 className="mt-1 text-lg font-semibold text-zinc-950 dark:text-zinc-50">
+                    {data.pendingProposal.id}
+                  </h2>
+                  <p className="mt-2 font-mono text-sm text-zinc-600 dark:text-zinc-300">
+                    {shortAddress(data.pendingProposal.proposedAdmin)}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-zinc-100 px-4 py-3 text-sm dark:bg-zinc-900">
+                  {data.pendingProposal.approvalCount}/{data.pendingProposal.threshold}{" "}
+                  {t("approvals")}
+                </div>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-zinc-500">
+                    {t("timeToExecutable")}
+                  </p>
+                  <p className="mt-1 text-sm text-zinc-950 dark:text-zinc-50">
+                    {timeUntil(data.pendingProposal.executableAt)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-zinc-500">{t("expiresAt")}</p>
+                  <p className="mt-1 text-sm text-zinc-950 dark:text-zinc-50">
+                    {data.pendingProposal.expiresAt ?? "Not configured"}
+                  </p>
+                </div>
+              </div>
+
+              <ul className="mt-6 divide-y divide-zinc-200 rounded-2xl border border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
+                {data.pendingProposal.signers.map((signer) => (
+                  <li key={signer.address} className="flex items-center justify-between px-4 py-3">
+                    <span className="font-mono text-sm">{shortAddress(signer.address)}</span>
+                    <span
+                      className={
+                        signer.approved
+                          ? "text-sm font-medium text-green-600"
+                          : "text-sm font-medium text-zinc-500"
+                      }
+                    >
+                      {signer.approved ? t("approved") : t("pending")}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/components/global_ui/Header.tsx
+++ b/frontend/src/app/components/global_ui/Header.tsx
@@ -13,6 +13,7 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { ThemeToggle } from "../ui/ThemeToggle";
 import { NotificationDropdown } from "./NotificationDropdown";
+import { RecentTransactionsDrawer } from "../transaction/RecentTransactionsDrawer";
 import { useWalletStore } from "../../stores/useWalletStore";
 import { useUserStore } from "../../stores/useUserStore";
 import { useGamificationStore } from "../../stores/useGamificationStore";
@@ -375,6 +376,8 @@ export function Header({ onMenuClick, className }: HeaderProps) {
         <div className="h-8 w-px bg-zinc-200 dark:bg-zinc-800 hidden sm:block" />
 
         <ThemeToggle />
+
+        <RecentTransactionsDrawer />
 
         <NotificationDropdown />
 

--- a/frontend/src/app/components/transaction/RecentTransactionsDrawer.tsx
+++ b/frontend/src/app/components/transaction/RecentTransactionsDrawer.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Clock3, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useMyTransactions } from "../../hooks/useApi";
+import { TxHashLink } from "../ui/TxHashLink";
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export function RecentTransactionsDrawer() {
+  const t = useTranslations("RecentTransactions");
+  const [open, setOpen] = useState(false);
+  const { data, isLoading, isError } = useMyTransactions({ limit: 20 });
+  const transactions = data?.items ?? [];
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={t("open")}
+        className="rounded-lg p-2 text-zinc-500 transition hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900"
+      >
+        <Clock3 className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+          <button
+            type="button"
+            aria-label={t("close")}
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setOpen(false)}
+          />
+          <aside className="absolute right-0 top-0 flex h-full w-full max-w-md flex-col border-l border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-950">
+            <div className="flex items-center justify-between border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+              <div>
+                <h2 className="text-base font-semibold text-zinc-950 dark:text-zinc-50">
+                  {t("title")}
+                </h2>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("description")}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label={t("close")}
+                className="rounded-lg p-2 text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900"
+              >
+                <X className="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-5">
+              {isLoading ? (
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("loading")}</p>
+              ) : isError ? (
+                <p className="text-sm text-red-600 dark:text-red-400">{t("error")}</p>
+              ) : transactions.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-zinc-300 p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+                  {t("empty")}
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {transactions.map((transaction) => (
+                    <li
+                      key={transaction.id}
+                      className="rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold capitalize text-zinc-950 dark:text-zinc-50">
+                            {transaction.transactionType}
+                          </p>
+                          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                            {formatDate(transaction.submittedAt)}
+                          </p>
+                        </div>
+                        <span className="rounded-full bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                          {transaction.status}
+                        </span>
+                      </div>
+                      <div className="mt-3">
+                        <TxHashLink txHash={transaction.txHash} />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/components/transaction/RecentTransactionsDrawer.tsx
+++ b/frontend/src/app/components/transaction/RecentTransactionsDrawer.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Clock3, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMyTransactions } from "../../hooks/useApi";
+import { useUserStore } from "../../stores/useUserStore";
 import { TxHashLink } from "../ui/TxHashLink";
 
 function formatDate(value: string) {
@@ -16,7 +17,8 @@ function formatDate(value: string) {
 export function RecentTransactionsDrawer() {
   const t = useTranslations("RecentTransactions");
   const [open, setOpen] = useState(false);
-  const { data, isLoading, isError } = useMyTransactions({ limit: 20 });
+  const authToken = useUserStore((state) => state.authToken);
+  const { data, isLoading, isError } = useMyTransactions({ limit: 20, enabled: open && Boolean(authToken) });
   const transactions = data?.items ?? [];
 
   return (

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -53,6 +53,12 @@ export const queryKeys = {
   notifications: {
     all: () => ["notifications"] as const,
   },
+  transactions: {
+    mine: (params: Record<string, unknown>) => ["transactions", "mine", params] as const,
+  },
+  governance: {
+    pending: () => ["admin", "governance", "pending"] as const,
+  },
   borrowerLoans: {
     byAddress: (address: string) => ["borrowerLoans", address] as const,
   },
@@ -253,6 +259,38 @@ export interface LoanStats {
   overdueCount: number;
 }
 
+export interface MyTransaction {
+  id: number;
+  txHash: string;
+  status: string;
+  submittedAt: string;
+  submittedBy: string | null;
+  transactionType: string;
+  resultXdr?: string | null;
+}
+
+export interface GovernanceSigner {
+  address: string;
+  approved: boolean;
+}
+
+export interface GovernancePendingProposal {
+  id: string;
+  targetContract: string;
+  proposedAdmin: string;
+  approvalCount: number;
+  threshold: number;
+  executableAt: string | null;
+  expiresAt: string | null;
+  signers: GovernanceSigner[];
+}
+
+export interface GovernancePendingResponse {
+  currentAdmin: string | null;
+  targetContract: string | null;
+  pendingProposal: GovernancePendingProposal | null;
+}
+
 export interface CursorPageInfo {
   limit: number;
   count: number;
@@ -334,6 +372,20 @@ async function fetchRemittancesPage(
 ): Promise<PaginatedListResult<Remittance>> {
   const response = await apiFetch<RawPaginatedResponse<Remittance[]>>(
     `/remittances${toQueryString({
+      limit: params.limit,
+      cursor: params.cursor,
+      status: params.status,
+    })}`,
+  );
+
+  return normalizePaginatedList(response);
+}
+
+async function fetchMyTransactionsPage(
+  params: CursorListParams = {},
+): Promise<PaginatedListResult<MyTransaction>> {
+  const response = await apiFetch<RawPaginatedResponse<MyTransaction[]>>(
+    `/transactions/me${toQueryString({
       limit: params.limit,
       cursor: params.cursor,
       status: params.status,
@@ -1216,5 +1268,20 @@ export async function submitLoanTransaction(signedTxXdr: string) {
   return apiFetch<{ txHash: string; status: string; resultXdr?: string }>("/loans/submit", {
     method: "POST",
     body: JSON.stringify({ signedTxXdr }),
+  });
+}
+
+export function useMyTransactions(params: CursorListParams = {}) {
+  return useQuery({
+    queryKey: queryKeys.transactions.mine(params),
+    queryFn: () => fetchMyTransactionsPage(params),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useAdminGovernancePending() {
+  return useQuery({
+    queryKey: queryKeys.governance.pending(),
+    queryFn: () => apiFetch<GovernancePendingResponse>("/admin/governance/pending"),
   });
 }

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -325,6 +325,7 @@ interface CursorListParams {
   limit?: number;
   cursor?: string | null;
   status?: string;
+  enabled?: boolean;
 }
 
 interface BorrowerLoansPageResponse {
@@ -1275,6 +1276,7 @@ export function useMyTransactions(params: CursorListParams = {}) {
   return useQuery({
     queryKey: queryKeys.transactions.mine(params),
     queryFn: () => fetchMyTransactionsPage(params),
+    enabled: params.enabled ?? true,
     placeholderData: keepPreviousData,
   });
 }

--- a/frontend/src/app/stores/useUserStore.ts
+++ b/frontend/src/app/stores/useUserStore.ts
@@ -23,6 +23,7 @@ export interface User {
   id: string;
   email: string;
   walletAddress?: string;
+  role?: "admin" | "borrower" | "lender";
   kycVerified: boolean;
   /** ISO 8601 timestamp of when the session was established */
   sessionStartedAt?: string;


### PR DESCRIPTION
Summary
- Add authenticated transaction submissions API and recent transactions drawer using existing transaction hash links.
- Add admin governance pending endpoint and read-only governance console page.
- Add i18n strings and Playwright specs for the new drawer and governance console.

Verification
- Ran `git diff --check`.
- Validated frontend message JSON files parse.
- Tests not run, per delegated workflow instruction to skip tests unless CI/CD or risk requires it.

Closes #894
Closes #895