### PR TITLE
Add pause/yield contract stats plus NFT viewer and notifications inboxfeat: add contract pause stats and frontend NFT notifications views

### DIFF
--- a/backend/src/controllers/scoreController.ts
+++ b/backend/src/controllers/scoreController.ts
@@ -376,3 +376,30 @@ export const getOnChainScoreHistory = asyncHandler(
     res.json({ success: true, ...response });
   },
 );
+
+/**
+ * GET /api/score/:walletAddress/nft
+ *
+ * Reads the user's RemittanceNFT metadata and adjacent counters from the
+ * RemittanceNFT contract. Returns `nft: null` when no NFT exists yet.
+ */
+export const getRemittanceNft = asyncHandler(
+  async (req: Request, res: Response) => {
+    const { walletAddress } = req.params as { walletAddress: string };
+
+    const cacheKey = `score:nft:${walletAddress}`;
+    const cached = await cacheService.get<Record<string, unknown>>(cacheKey);
+    if (cached) {
+      res.json({ success: true, walletAddress, nft: cached });
+      return;
+    }
+
+    const nft = await sorobanService.getRemittanceNftMetadata(walletAddress);
+
+    if (nft) {
+      await cacheService.set(cacheKey, nft, 60);
+    }
+
+    res.json({ success: true, walletAddress, nft });
+  },
+);

--- a/backend/src/routes/scoreRoutes.ts
+++ b/backend/src/routes/scoreRoutes.ts
@@ -4,9 +4,11 @@ import {
   updateScore,
   getScoreBreakdown,
   getOnChainScoreHistory,
+  getRemittanceNft,
 } from "../controllers/scoreController.js";
 import { validate } from "../middleware/validation.js";
 import {
+  getRemittanceNftSchema,
   getScoreHistorySchema,
   getScoreSchema,
   updateScoreSchema,
@@ -100,6 +102,15 @@ router.get(
   requireWalletParamMatchesJwt("walletAddress"),
   validate(getScoreHistorySchema),
   getOnChainScoreHistory,
+);
+
+router.get(
+  "/:walletAddress/nft",
+  requireJwtAuth,
+  requireScopes("read:score"),
+  requireWalletParamMatchesJwt("walletAddress"),
+  validate(getRemittanceNftSchema),
+  getRemittanceNft,
 );
 
 /**

--- a/backend/src/schemas/scoreSchemas.ts
+++ b/backend/src/schemas/scoreSchemas.ts
@@ -14,6 +14,13 @@ export const getScoreHistorySchema = z.object({
   }),
 });
 
+// Schema for GET /score/:walletAddress/nft
+export const getRemittanceNftSchema = z.object({
+  params: z.object({
+    walletAddress: z.string().min(1).max(100),
+  }),
+});
+
 // Schema for POST /score/update
 export const updateScoreSchema = z.object({
   body: z.object({
@@ -31,4 +38,5 @@ export const updateScoreSchema = z.object({
 // TypeScript types
 export type GetScoreInput = z.infer<typeof getScoreSchema>;
 export type GetScoreHistoryInput = z.infer<typeof getScoreHistorySchema>;
+export type GetRemittanceNftInput = z.infer<typeof getRemittanceNftSchema>;
 export type UpdateScoreInput = z.infer<typeof updateScoreSchema>;

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -871,6 +871,96 @@ class SorobanService {
     return entries;
   }
 
+  private stringifyBytes(value: unknown): string {
+    if (typeof value === "string") return value;
+    if (value instanceof Uint8Array) {
+      return Array.from(value)
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+    }
+    if (Array.isArray(value) && value.every((item) => typeof item === "number")) {
+      return value.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+    if (value && typeof value === "object" && "toString" in value) {
+      return String(value);
+    }
+    return "";
+  }
+
+  private async simulateRemittanceNftRead(
+    functionName: string,
+    userPublicKey: string,
+    extraArgs: ReturnType<typeof nativeToScVal>[] = [],
+  ): Promise<unknown> {
+    const server = this.getRpcServer();
+    const contractId = this.getRemittanceNftContractId();
+    const passphrase = this.getNetworkPassphrase();
+    const source = this.getScoreReadSourceKeypair();
+
+    const account = await server.getAccount(source.publicKey());
+    const userScVal = nativeToScVal(Address.fromString(userPublicKey), {
+      type: "address",
+    });
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: passphrase,
+    })
+      .addOperation(
+        Operation.invokeContractFunction({
+          contract: contractId,
+          function: functionName,
+          args: [userScVal, ...extraArgs],
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    const simulation = await server.simulateTransaction(tx);
+    if ("error" in simulation) {
+      throw AppError.internal(
+        `Failed to simulate ${functionName} for ${userPublicKey}: ${String(simulation.error ?? "")}`,
+      );
+    }
+
+    return simulation.result?.retval ? scValToNative(simulation.result.retval) : null;
+  }
+
+  async getRemittanceNftMetadata(userPublicKey: string): Promise<{
+    score: number;
+    historyHash: string;
+    metadataUri: string;
+    defaultCount: number;
+    transferCooldownRemaining: number;
+    lastUpdateLedger: number;
+  } | null> {
+    const nativeMetadata = (await this.simulateRemittanceNftRead(
+      "get_metadata",
+      userPublicKey,
+    )) as Record<string, unknown> | null;
+
+    if (!nativeMetadata) {
+      return null;
+    }
+
+    const [defaultCountNative, cooldownNative, history] = await Promise.all([
+      this.simulateRemittanceNftRead("get_default_count", userPublicKey),
+      this.simulateRemittanceNftRead("get_transfer_cooldown_remaining", userPublicKey),
+      this.getOnChainScoreHistory(userPublicKey).catch(() => []),
+    ]);
+
+    const latestHistoryEntry = history[history.length - 1];
+
+    return {
+      score: Number(nativeMetadata.score ?? 0),
+      historyHash: this.stringifyBytes(nativeMetadata.history_hash),
+      metadataUri: String(nativeMetadata.metadata_uri ?? ""),
+      defaultCount: Number(defaultCountNative ?? 0),
+      transferCooldownRemaining: Number(cooldownNative ?? 0),
+      lastUpdateLedger: Number(latestHistoryEntry?.timestamp ?? 0),
+    };
+  }
+
   /**
    * Ping the Stellar RPC server to verify connectivity.
    * Calls getLatestLedger() with a 5-second timeout.

--- a/contracts/lending_pool/src/events.rs
+++ b/contracts/lending_pool/src/events.rs
@@ -1,3 +1,4 @@
+use crate::DataKey;
 use soroban_sdk::{Address, Env, Symbol};
 
 pub fn deposit(env: &Env, provider: Address, token: Address, amount: i128, shares_minted: i128) {
@@ -10,8 +11,20 @@ pub fn withdraw(env: &Env, provider: Address, token: Address, amount: i128, shar
     env.events().publish(topics, (amount, shares_burned));
 }
 
-#[allow(dead_code)]
 pub fn yield_distributed(env: &Env, token: Address, amount: i128) {
+    if amount > 0 {
+        let total = env
+            .storage()
+            .instance()
+            .get::<_, i128>(&DataKey::TotalYieldDistributed(token.clone()))
+            .unwrap_or(0)
+            .checked_add(amount)
+            .expect("total yield distributed overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalYieldDistributed(token.clone()), &total);
+    }
+
     let topics = (Symbol::new(env, "YieldDistributed"), token);
     env.events().publish(topics, amount);
 }

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -50,6 +50,8 @@ pub enum DataKey {
     TotalDeposits(Address),
     /// token → number of active depositors
     DepositorCount(Address),
+    /// token → cumulative yield explicitly distributed to the pool
+    TotalYieldDistributed(Address),
     ProposedAdmin,
     Version,
 }
@@ -61,6 +63,7 @@ pub struct PoolStats {
     pub total_shares: i128,
     pub pool_token_balance: i128,
     pub depositor_count: u32,
+    pub total_yield_distributed: i128,
     /// Fraction of tracked principal currently out on loan, in basis points.
     /// Only positive when active loans have reduced pool_balance below
     /// total_deposits.
@@ -149,6 +152,14 @@ impl LendingPool {
         env.storage()
             .instance()
             .get(&DataKey::DepositorCount(token.clone()))
+            .unwrap_or(0)
+    }
+
+    fn total_yield_distributed(env: &Env, token: &Address) -> i128 {
+        Self::bump_instance_ttl(env);
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalYieldDistributed(token.clone()))
             .unwrap_or(0)
     }
 
@@ -389,6 +400,14 @@ impl LendingPool {
         Self::total_shares(&env, &token)
     }
 
+    pub fn get_depositor_count(env: Env, token: Address) -> u32 {
+        Self::read_depositor_count(&env, &token)
+    }
+
+    pub fn get_total_yield_distributed(env: Env, token: Address) -> i128 {
+        Self::total_yield_distributed(&env, &token)
+    }
+
     pub fn get_withdrawal_cooldown(env: Env) -> u32 {
         Self::withdrawal_cooldown(&env)
     }
@@ -596,6 +615,7 @@ impl LendingPool {
             total_shares,
             pool_token_balance,
             depositor_count: Self::read_depositor_count(&env, &token),
+            total_yield_distributed: Self::total_yield_distributed(&env, &token),
             utilization_bps,
         }
     }

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{LendingPool, LendingPoolClient};
+use crate::{events, LendingPool, LendingPoolClient};
 use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient;
@@ -349,6 +349,29 @@ fn test_share_price_increases_when_interest_arrives() {
     // Provider still holds 1000 shares; pool now has 1100 tokens.
     assert_eq!(pool_client.get_shares(&provider, &token_id), 1_000);
     assert_eq!(pool_client.get_deposit(&provider, &token_id), 1_100);
+}
+
+#[test]
+fn test_yield_distributed_event_updates_total_yield_distributed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _stellar_asset_client, _token_client) = create_token_contract(&env, &admin);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+
+    assert_eq!(pool_client.get_total_yield_distributed(&token_id), 0);
+
+    events::yield_distributed(&env, token_id.clone(), 100);
+    events::yield_distributed(&env, token_id.clone(), 50);
+
+    assert_eq!(pool_client.get_total_yield_distributed(&token_id), 150);
+    assert_eq!(
+        pool_client.get_pool_stats(&token_id).total_yield_distributed,
+        150
+    );
 }
 
 #[test]
@@ -836,7 +859,10 @@ fn test_pool_stats() {
     assert_eq!(stats.total_deposits, 0);
     assert_eq!(stats.total_shares, 0);
     assert_eq!(stats.depositor_count, 0);
+    assert_eq!(stats.total_yield_distributed, 0);
     assert_eq!(stats.utilization_bps, 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 0);
+    assert_eq!(pool_client.get_total_yield_distributed(&token_id), 0);
 
     // After first deposit.
     pool_client.deposit(&provider1, &token_id, &2000);
@@ -844,7 +870,9 @@ fn test_pool_stats() {
     assert_eq!(stats.total_deposits, 2000);
     assert_eq!(stats.total_shares, 2000);
     assert_eq!(stats.depositor_count, 1);
+    assert_eq!(stats.total_yield_distributed, 0);
     assert_eq!(stats.utilization_bps, 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 1);
 
     // After second deposit.
     pool_client.deposit(&provider2, &token_id, &2000);
@@ -852,6 +880,8 @@ fn test_pool_stats() {
     assert_eq!(stats.total_deposits, 4000);
     assert_eq!(stats.total_shares, 4000);
     assert_eq!(stats.depositor_count, 2);
+    assert_eq!(stats.total_yield_distributed, 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 2);
 
     // Simulate a loan (1000 tokens leave pool).
     let token_client = TokenClient::new(&env, &token_id);
@@ -859,6 +889,7 @@ fn test_pool_stats() {
     let stats = pool_client.get_pool_stats(&token_id);
     assert_eq!(stats.total_deposits, 4000);
     assert_eq!(stats.pool_token_balance, 3000);
+    assert_eq!(stats.total_yield_distributed, 0);
     assert_eq!(stats.utilization_bps, 2500); // 1000 / 4000 = 25 %
 
     // Return borrowed tokens before withdrawals so providers get full value.
@@ -870,6 +901,8 @@ fn test_pool_stats() {
     assert_eq!(stats.total_deposits, 2000);
     assert_eq!(stats.total_shares, 2000);
     assert_eq!(stats.depositor_count, 1);
+    assert_eq!(stats.total_yield_distributed, 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 1);
 
     // provider2 redeems 2000 shares → 2000 assets.
     pool_client.withdraw(&provider2, &token_id, &2000);
@@ -877,6 +910,9 @@ fn test_pool_stats() {
     assert_eq!(stats.total_deposits, 0);
     assert_eq!(stats.total_shares, 0);
     assert_eq!(stats.depositor_count, 0);
+    assert_eq!(stats.total_yield_distributed, 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 0);
+    assert_eq!(pool_client.get_total_yield_distributed(&token_id), 0);
 }
 
 // ── Additional coverage tests ─────────────────────────────────────────────────

--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -66,14 +66,14 @@ pub fn min_score_updated(env: &Env, old_score: u32, new_score: u32) {
         .publish((symbol_short!("MinScore"),), (old_score, new_score));
 }
 
-pub fn paused(env: &Env) {
+pub fn paused(env: &Env, paused_at_ledger: u32) {
     let topics = (Symbol::new(env, "Paused"),);
-    env.events().publish(topics, ());
+    env.events().publish(topics, paused_at_ledger);
 }
 
-pub fn unpaused(env: &Env) {
+pub fn unpaused(env: &Env, unpaused_at_ledger: u32) {
     let topics = (Symbol::new(env, "Unpaused"),);
-    env.events().publish(topics, ());
+    env.events().publish(topics, unpaused_at_ledger);
 }
 
 // pub fn min_score_updated(env: &Env, old_score: u32, new_score: u32) {

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -113,6 +113,7 @@ pub enum DataKey {
     BorrowerLoanCount(Address),
     BorrowerLoans(Address),
     Paused,
+    PausedAtLedger,
     InterestRateBps,
     DefaultTermLedgers,
     Version,
@@ -2268,20 +2269,26 @@ impl LoanManager {
 
     pub fn pause(env: Env) {
         Self::admin(&env).require_auth();
+        let paused_at_ledger = env.ledger().sequence();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::PausedAtLedger, &paused_at_ledger);
         Self::bump_instance_ttl(&env);
-        events::paused(&env);
+        events::paused(&env, paused_at_ledger);
         env.events()
-            .publish((Symbol::new(&env, "ContractPaused"),), ());
+            .publish((Symbol::new(&env, "ContractPaused"),), paused_at_ledger);
     }
 
     pub fn unpause(env: Env) {
         Self::admin(&env).require_auth();
+        let unpaused_at_ledger = env.ledger().sequence();
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().remove(&DataKey::PausedAtLedger);
         Self::bump_instance_ttl(&env);
-        events::unpaused(&env);
+        events::unpaused(&env, unpaused_at_ledger);
         env.events()
-            .publish((Symbol::new(&env, "ContractUnpaused"),), ());
+            .publish((Symbol::new(&env, "ContractUnpaused"),), unpaused_at_ledger);
     }
 
     pub fn is_paused(env: Env) -> bool {
@@ -2290,6 +2297,14 @@ impl LoanManager {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    pub fn get_paused_at_ledger(env: Env) -> u32 {
+        Self::bump_instance_ttl(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::PausedAtLedger)
+            .unwrap_or(0)
     }
 
     pub fn check_default(env: Env, loan_id: u32) -> Result<(), LoanError> {

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -439,6 +439,41 @@ fn test_paused_blocks_new_loans_and_repayments_but_allows_collateral_release() {
 }
 
 #[test]
+fn test_pause_tracks_paused_at_ledger_and_clears_on_unpause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _admin) = setup_test(&env);
+
+    assert_eq!(manager.get_paused_at_ledger(), 0);
+
+    env.ledger().set_sequence_number(123);
+    manager.pause();
+    assert!(manager.is_paused());
+    assert_eq!(manager.get_paused_at_ledger(), 123);
+
+    let events = env.events().all();
+    let contract_paused_event = events.get(events.len() - 1).unwrap();
+    let paused_at_ledger = u32::try_from_val(&env, &contract_paused_event.2).unwrap();
+    assert_eq!(paused_at_ledger, 123);
+
+    env.ledger().set_sequence_number(456);
+    manager.unpause();
+    assert!(!manager.is_paused());
+    assert_eq!(manager.get_paused_at_ledger(), 0);
+
+    let events = env.events().all();
+    let contract_unpaused_event = events.get(events.len() - 1).unwrap();
+    let unpaused_at_ledger = u32::try_from_val(&env, &contract_unpaused_event.2).unwrap();
+    assert_eq!(unpaused_at_ledger, 456);
+
+    env.ledger().set_sequence_number(789);
+    manager.pause();
+    assert!(manager.is_paused());
+    assert_eq!(manager.get_paused_at_ledger(), 789);
+}
+
+#[test]
 fn test_cancel_pending_loan_returns_collateral() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();

--- a/frontend/e2e/notifications-inbox.spec.ts
+++ b/frontend/e2e/notifications-inbox.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const MOCK_ADDRESS = "GCJPBXSE6WCQDCEYZW6C3YVZCSSCHC4AE72L5KWKCYL2CLLL7NH5VSCI";
+
+test.beforeEach(async ({ page }: { page: Page }) => {
+  await page.addInitScript((address: string) => {
+    window.localStorage.setItem(
+      "remitlend-wallet",
+      JSON.stringify({
+        state: {
+          status: "connected",
+          address,
+          network: { chainId: 2, name: "TESTNET", isSupported: true },
+          balances: [],
+          shouldAutoReconnect: true,
+        },
+        version: 0,
+      }),
+    );
+    window.localStorage.setItem(
+      "remitlend-user",
+      JSON.stringify({
+        state: {
+          user: { id: address, walletAddress: address, email: "alice@example.com", kycVerified: true },
+          authToken: "test-token",
+          isAuthenticated: true,
+        },
+        version: 0,
+      }),
+    );
+  }, MOCK_ADDRESS);
+
+  await page.route(/\/(api\/)?notifications\?/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          unreadCount: 2,
+          notifications: [
+            {
+              id: 1,
+              userId: MOCK_ADDRESS,
+              type: "repayment_due",
+              title: "Repayment due soon",
+              message: "Your next repayment is due tomorrow.",
+              loanId: 7,
+              read: false,
+              createdAt: "2026-05-27T10:00:00.000Z",
+            },
+            {
+              id: 2,
+              userId: MOCK_ADDRESS,
+              type: "score_changed",
+              title: "Score increased",
+              message: "Your credit score moved up after a remittance.",
+              read: false,
+              createdAt: "2026-05-27T09:00:00.000Z",
+            },
+            {
+              id: 3,
+              userId: MOCK_ADDRESS,
+              type: "loan_approved",
+              title: "Loan approved",
+              message: "Your loan request was approved.",
+              read: true,
+              createdAt: "2026-05-26T09:00:00.000Z",
+            },
+          ],
+        },
+      }),
+    });
+  });
+
+  await page.route(/\/(api\/)?notifications\/mark-read$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+});
+
+test("opens notifications inbox from dropdown view all and applies filters", async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  await page.goto("/en");
+
+  await page.getByRole("button", { name: /Notifications/i }).click();
+  await page.getByRole("button", { name: /View all notifications/i }).click();
+
+  await expect(page).toHaveURL(/\/en\/notifications/);
+  await expect(page.getByRole("heading", { name: "Notifications" })).toBeVisible();
+  await expect(page.getByText("Repayment due soon")).toBeVisible();
+
+  await page.getByRole("button", { name: "Score changed" }).click();
+  await expect(page).toHaveURL(/type=score_changed/);
+  await expect(page.getByText("Score increased")).toBeVisible();
+  await expect(page.getByText("Repayment due soon")).toBeHidden();
+
+  await page.getByLabel("Unread only").check();
+  await expect(page).toHaveURL(/unread=true/);
+});

--- a/frontend/e2e/remittance-nft-viewer.spec.ts
+++ b/frontend/e2e/remittance-nft-viewer.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const MOCK_ADDRESS = "GCJPBXSE6WCQDCEYZW6C3YVZCSSCHC4AE72L5KWKCYL2CLLL7NH5VSCI";
+
+test.beforeEach(async ({ page }: { page: Page }) => {
+  await page.addInitScript((address: string) => {
+    window.localStorage.setItem(
+      "remitlend-wallet",
+      JSON.stringify({
+        state: {
+          status: "connected",
+          address,
+          network: { chainId: 2, name: "TESTNET", isSupported: true },
+          balances: [],
+          shouldAutoReconnect: true,
+        },
+        version: 0,
+      }),
+    );
+    window.localStorage.setItem(
+      "remitlend-user",
+      JSON.stringify({
+        state: {
+          user: { id: address, walletAddress: address, email: "alice@example.com", kycVerified: true },
+          authToken: "test-token",
+          isAuthenticated: true,
+        },
+        version: 0,
+      }),
+    );
+  }, MOCK_ADDRESS);
+});
+
+test("shows Remittance NFT metadata on the kingdom page", async ({ page }: { page: Page }) => {
+  await page.route(/\/(api\/)?score\/[^/]+\/nft$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        walletAddress: MOCK_ADDRESS,
+        nft: {
+          score: 742,
+          historyHash: "abcdef123456",
+          metadataUri: "https://example.com/remittance-nft.json",
+          defaultCount: 1,
+          transferCooldownRemaining: 1440,
+          lastUpdateLedger: 987654,
+        },
+      }),
+    });
+  });
+
+  await page.goto("/en/kingdom");
+
+  await expect(page.getByRole("heading", { name: "Remittance NFT" })).toBeVisible();
+  await expect(page.getByText("742")).toBeVisible();
+  await expect(page.getByText("1,440 ledgers")).toBeVisible();
+  await expect(page.getByRole("link", { name: /example.com\/remittance-nft.json/i })).toHaveAttribute(
+    "target",
+    "_blank",
+  );
+});
+
+test("shows empty NFT state with remittance CTA", async ({ page }: { page: Page }) => {
+  await page.route(/\/(api\/)?score\/[^/]+\/nft$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, walletAddress: MOCK_ADDRESS, nft: null }),
+    });
+  });
+
+  await page.goto("/en/kingdom");
+
+  await expect(page.getByText("No Remittance NFT yet")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Send first remittance" })).toHaveAttribute(
+    "href",
+    "/en/send-remittance",
+  );
+});

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -61,6 +61,7 @@
     "repay": "Repay",
     "dashboard": "Dashboard",
     "activity": "Activity",
+    "notifications": "Notifications",
     "adminDisputes": "Disputes"
   },
   "Loans": {
@@ -108,7 +109,56 @@
     "unlockedCount": "{unlocked} / {total}",
     "progress": "Progress",
     "unlocked": "Unlocked {date}",
-    "repaymentProgress": "Repayment Progress"
+    "repaymentProgress": "Repayment Progress",
+    "nft": {
+      "eyebrow": "Credit Asset",
+      "title": "Remittance NFT",
+      "description": "View the on-chain credit asset built from your remittance and repayment history.",
+      "connectTitle": "Connect your wallet",
+      "connectDescription": "Your Remittance NFT appears here once your wallet is connected.",
+      "error": "Unable to load your Remittance NFT right now.",
+      "emptyTitle": "No Remittance NFT yet",
+      "emptyDescription": "Send your first remittance to start building an on-chain credit asset.",
+      "emptyAction": "Send first remittance",
+      "score": "Score",
+      "historyHash": "History hash",
+      "defaultCount": "Default count",
+      "cooldownRemaining": "Transfer cooldown remaining",
+      "lastUpdateLedger": "Last update ledger",
+      "metadataUri": "Metadata URI",
+      "ledgers": "{count} ledgers",
+      "notAvailable": "Not available"
+    }
+  },
+  "Notifications": {
+    "eyebrow": "Inbox",
+    "title": "Notifications",
+    "description": "Review repayment reminders, score changes, loan updates, and alerts from one place.",
+    "viewAll": "View all notifications",
+    "unread": "Unread",
+    "markRead": "Mark read",
+    "markAllVisibleRead": "Mark unread as read",
+    "filters": {
+      "title": "Filters",
+      "unreadOnly": "Unread only"
+    },
+    "types": {
+      "all": "All",
+      "loan_approved": "Loan approved",
+      "repayment_due": "Repayment due",
+      "repayment_confirmed": "Repayment confirmed",
+      "loan_defaulted": "Loan defaulted",
+      "score_changed": "Score changed"
+    },
+    "empty": {
+      "title": "No notifications found",
+      "description": "New alerts and reminders will appear here.",
+      "action": "Back to dashboard"
+    },
+    "error": "Unable to load notifications. Please try again.",
+    "pagination": {
+      "summary": "Showing {count} of {total} notifications on page {page}"
+    }
   },
   "LoanCard": {
     "totalOwed": "Total Owed",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -61,6 +61,7 @@
     "repay": "Repagar",
     "dashboard": "Tablero",
     "activity": "Actividad",
+    "notifications": "Notificaciones",
     "adminDisputes": "Disputas"
   },
   "Loans": {
@@ -108,7 +109,56 @@
     "unlockedCount": "{unlocked} / {total}",
     "progress": "Progreso",
     "unlocked": "Desbloqueado {date}",
-    "repaymentProgress": "Progreso de reembolso"
+    "repaymentProgress": "Progreso de reembolso",
+    "nft": {
+      "eyebrow": "Activo crediticio",
+      "title": "Remittance NFT",
+      "description": "Consulta el activo crediticio en cadena creado a partir de tus remesas e historial de pagos.",
+      "connectTitle": "Conecta tu billetera",
+      "connectDescription": "Tu Remittance NFT aparecerá aquí cuando conectes tu billetera.",
+      "error": "No se pudo cargar tu Remittance NFT en este momento.",
+      "emptyTitle": "Aún no tienes Remittance NFT",
+      "emptyDescription": "Envía tu primera remesa para empezar a construir un activo crediticio en cadena.",
+      "emptyAction": "Enviar primera remesa",
+      "score": "Puntaje",
+      "historyHash": "Hash del historial",
+      "defaultCount": "Incumplimientos",
+      "cooldownRemaining": "Enfriamiento de transferencia restante",
+      "lastUpdateLedger": "Último ledger actualizado",
+      "metadataUri": "URI de metadatos",
+      "ledgers": "{count} ledgers",
+      "notAvailable": "No disponible"
+    }
+  },
+  "Notifications": {
+    "eyebrow": "Bandeja",
+    "title": "Notificaciones",
+    "description": "Revisa recordatorios de pago, cambios de puntaje, actualizaciones de préstamos y alertas en un solo lugar.",
+    "viewAll": "Ver todas las notificaciones",
+    "unread": "No leída",
+    "markRead": "Marcar leída",
+    "markAllVisibleRead": "Marcar no leídas como leídas",
+    "filters": {
+      "title": "Filtros",
+      "unreadOnly": "Solo no leídas"
+    },
+    "types": {
+      "all": "Todas",
+      "loan_approved": "Préstamo aprobado",
+      "repayment_due": "Pago pendiente",
+      "repayment_confirmed": "Pago confirmado",
+      "loan_defaulted": "Préstamo en incumplimiento",
+      "score_changed": "Puntaje cambiado"
+    },
+    "empty": {
+      "title": "No se encontraron notificaciones",
+      "description": "Las nuevas alertas y recordatorios aparecerán aquí.",
+      "action": "Volver al panel"
+    },
+    "error": "No se pudieron cargar las notificaciones. Inténtalo de nuevo.",
+    "pagination": {
+      "summary": "Mostrando {count} de {total} notificaciones en la página {page}"
+    }
   },
   "LoanCard": {
     "totalOwed": "Total adeudado",

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -61,6 +61,7 @@
     "repay": "Bayaran",
     "dashboard": "Dashboard",
     "activity": "Aktibidad",
+    "notifications": "Mga Notification",
     "adminDisputes": "Mga Dispute"
   },
   "Loans": {
@@ -108,7 +109,56 @@
     "unlockedCount": "{unlocked} / {total}",
     "progress": "Pag-unlad",
     "unlocked": "I-unlock {date}",
-    "repaymentProgress": "Pag-unlad ng Pagbabayad"
+    "repaymentProgress": "Pag-unlad ng Pagbabayad",
+    "nft": {
+      "eyebrow": "Credit Asset",
+      "title": "Remittance NFT",
+      "description": "Tingnan ang on-chain credit asset na nabuo mula sa iyong remittance at repayment history.",
+      "connectTitle": "Ikonekta ang wallet",
+      "connectDescription": "Lalabas dito ang iyong Remittance NFT kapag nakakonekta na ang wallet mo.",
+      "error": "Hindi ma-load ang iyong Remittance NFT ngayon.",
+      "emptyTitle": "Wala pang Remittance NFT",
+      "emptyDescription": "Ipadala ang unang remittance para simulan ang paggawa ng on-chain credit asset.",
+      "emptyAction": "Send first remittance",
+      "score": "Score",
+      "historyHash": "History hash",
+      "defaultCount": "Default count",
+      "cooldownRemaining": "Natitirang transfer cooldown",
+      "lastUpdateLedger": "Huling update ledger",
+      "metadataUri": "Metadata URI",
+      "ledgers": "{count} ledgers",
+      "notAvailable": "Hindi available"
+    }
+  },
+  "Notifications": {
+    "eyebrow": "Inbox",
+    "title": "Mga Notification",
+    "description": "Suriin ang repayment reminders, score changes, loan updates, at alerts sa iisang lugar.",
+    "viewAll": "Tingnan lahat ng notifications",
+    "unread": "Unread",
+    "markRead": "Markahan read",
+    "markAllVisibleRead": "Markahan ang unread bilang read",
+    "filters": {
+      "title": "Mga Filter",
+      "unreadOnly": "Unread lang"
+    },
+    "types": {
+      "all": "Lahat",
+      "loan_approved": "Naaprubahang loan",
+      "repayment_due": "Due na repayment",
+      "repayment_confirmed": "Nakumpirmang repayment",
+      "loan_defaulted": "Defaulted na loan",
+      "score_changed": "Nagbago ang score"
+    },
+    "empty": {
+      "title": "Walang notification",
+      "description": "Lalabas dito ang mga bagong alert at reminder.",
+      "action": "Bumalik sa dashboard"
+    },
+    "error": "Hindi ma-load ang notifications. Subukan ulit.",
+    "pagination": {
+      "summary": "Ipinapakita ang {count} sa {total} notification sa page {page}"
+    }
   },
   "LoanCard": {
     "totalOwed": "Kabuuang Utang",

--- a/frontend/src/app/[locale]/kingdom/page.tsx
+++ b/frontend/src/app/[locale]/kingdom/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Crown } from "lucide-react";
+import Link from "next/link";
+import { ArrowUpRight, BadgeCheck, Crown, FileText, SendHorizontal, TimerReset } from "lucide-react";
 import dynamic from "next/dynamic";
 import { Suspense } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useGamificationStore } from "../../stores/useGamificationStore";
+import { selectWalletAddress, selectIsWalletConnected, useWalletStore } from "../../stores/useWalletStore";
+import { useRemittanceNft } from "../../hooks/useApi";
 import { Card } from "../../components/ui/Card";
 import { SkeletonCard } from "../../components/ui/Skeleton";
 import { AchievementsSkeleton } from "../../components/skeletons/AchievementsSkeleton";
@@ -33,8 +36,15 @@ const GamificationSettings = dynamic(
 
 export default function KingdomPage() {
   const t = useTranslations("Kingdom");
+  const locale = useLocale();
   const level = useGamificationStore((state) => state.level);
   const kingdomTitle = useGamificationStore((state) => state.kingdomTitle);
+  const address = useWalletStore(selectWalletAddress);
+  const isConnected = useWalletStore(selectIsWalletConnected);
+  const { data: nft, isLoading: isNftLoading, isError: isNftError } = useRemittanceNft(
+    address ?? undefined,
+    { enabled: isConnected && Boolean(address) },
+  );
 
   return (
     <main className="min-h-screen p-8 lg:p-12 max-w-7xl mx-auto space-y-8">
@@ -68,6 +78,121 @@ export default function KingdomPage() {
       <Suspense fallback={<KingdomProgressSkeleton />}>
         <KingdomProgressWidget />
       </Suspense>
+
+      <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm shadow-zinc-200/40 dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600 dark:text-indigo-400">
+              {t("nft.eyebrow")}
+            </p>
+            <h2 className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+              {t("nft.title")}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
+              {t("nft.description")}
+            </p>
+          </div>
+          <div className="rounded-xl bg-zinc-100 p-3 text-indigo-600 dark:bg-zinc-900 dark:text-indigo-300">
+            <BadgeCheck className="h-6 w-6" />
+          </div>
+        </div>
+
+        {!isConnected ? (
+          <div className="rounded-xl border border-dashed border-zinc-300 p-6 text-center dark:border-zinc-700">
+            <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              {t("nft.connectTitle")}
+            </p>
+            <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+              {t("nft.connectDescription")}
+            </p>
+          </div>
+        ) : isNftLoading ? (
+          <SkeletonCard />
+        ) : isNftError ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+            {t("nft.error")}
+          </div>
+        ) : !nft ? (
+          <div className="flex flex-col items-center gap-4 rounded-xl border border-dashed border-zinc-300 p-8 text-center dark:border-zinc-700">
+            <div className="rounded-xl bg-zinc-100 p-3 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
+              <FileText className="h-7 w-7" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                {t("nft.emptyTitle")}
+              </h3>
+              <p className="mt-2 max-w-md text-sm text-zinc-500 dark:text-zinc-400">
+                {t("nft.emptyDescription")}
+              </p>
+            </div>
+            <Link
+              href={`/${locale}/send-remittance`}
+              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700"
+            >
+              <SendHorizontal className="h-4 w-4" />
+              {t("nft.emptyAction")}
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
+            <div className="rounded-xl border border-zinc-200 p-5 dark:border-zinc-800">
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("nft.score")}</p>
+              <p className="mt-2 text-5xl font-bold text-zinc-900 dark:text-zinc-50">
+                {nft.score}
+              </p>
+              <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+                {t("nft.historyHash")}
+              </p>
+              <p className="mt-1 break-all rounded-lg bg-zinc-50 p-3 font-mono text-xs text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                {nft.historyHash || t("nft.notAvailable")}
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                { label: t("nft.defaultCount"), value: nft.defaultCount, icon: BadgeCheck },
+                {
+                  label: t("nft.cooldownRemaining"),
+                  value: t("nft.ledgers", { count: nft.transferCooldownRemaining }),
+                  icon: TimerReset,
+                },
+                {
+                  label: t("nft.lastUpdateLedger"),
+                  value: nft.lastUpdateLedger || t("nft.notAvailable"),
+                  icon: FileText,
+                },
+              ].map((item) => (
+                <article
+                  key={item.label}
+                  className="rounded-xl border border-zinc-200 p-4 dark:border-zinc-800"
+                >
+                  <item.icon className="mb-3 h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+                  <p className="text-sm text-zinc-500 dark:text-zinc-400">{item.label}</p>
+                  <p className="mt-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                    {item.value}
+                  </p>
+                </article>
+              ))}
+              <a
+                href={nft.metadataUri || undefined}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-xl border border-zinc-200 p-4 transition hover:border-indigo-300 hover:bg-indigo-50/60 dark:border-zinc-800 dark:hover:border-indigo-700 dark:hover:bg-indigo-950/20 sm:col-span-2"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("nft.metadataUri")}</p>
+                    <p className="mt-1 truncate font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+                      {nft.metadataUri || t("nft.notAvailable")}
+                    </p>
+                  </div>
+                  <ArrowUpRight className="h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400" />
+                </div>
+              </a>
+            </div>
+          </div>
+        )}
+      </section>
 
       {/* Achievements */}
       <Suspense fallback={<AchievementsSkeleton />}>

--- a/frontend/src/app/[locale]/notifications/error.tsx
+++ b/frontend/src/app/[locale]/notifications/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteErrorView } from "../../components/global_ui/RouteErrorView";
+
+export default function NotificationsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteErrorView error={error} reset={reset} scope="notifications page" />;
+}

--- a/frontend/src/app/[locale]/notifications/page.tsx
+++ b/frontend/src/app/[locale]/notifications/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  AlertTriangle,
+  Bell,
+  Check,
+  CheckCheck,
+  Clock,
+  Filter,
+  TrendingUp,
+} from "lucide-react";
+import {
+  useMarkNotificationsRead,
+  useNotifications,
+  type AppNotification,
+  type NotificationType,
+} from "../../hooks/useApi";
+import { PaginationControls } from "../../components/ui/PaginationControls";
+import { EmptyState } from "../../components/ui/EmptyState";
+
+const PAGE_SIZE = 10;
+
+const NOTIFICATION_TYPES: Array<NotificationType | "all"> = [
+  "all",
+  "loan_approved",
+  "repayment_due",
+  "repayment_confirmed",
+  "loan_defaulted",
+  "score_changed",
+];
+
+function notificationIcon(type: NotificationType) {
+  switch (type) {
+    case "loan_approved":
+      return Check;
+    case "repayment_confirmed":
+      return CheckCheck;
+    case "repayment_due":
+      return Clock;
+    case "loan_defaulted":
+      return AlertTriangle;
+    case "score_changed":
+      return TrendingUp;
+    default:
+      return Bell;
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function parseType(value: string | null): NotificationType | "all" {
+  return NOTIFICATION_TYPES.includes(value as NotificationType) ? (value as NotificationType) : "all";
+}
+
+function NotificationRow({
+  notification,
+  onMarkRead,
+  unreadLabel,
+  markReadLabel,
+}: {
+  notification: AppNotification;
+  onMarkRead: (id: number) => void;
+  unreadLabel: string;
+  markReadLabel: string;
+}) {
+  const Icon = notificationIcon(notification.type);
+
+  return (
+    <article
+      className={`rounded-xl border p-4 transition ${
+        notification.read
+          ? "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+          : "border-indigo-200 bg-indigo-50/50 dark:border-indigo-900 dark:bg-indigo-950/20"
+      }`}
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-100 text-indigo-600 dark:bg-zinc-900 dark:text-indigo-300">
+            <Icon className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-semibold text-zinc-900 dark:text-zinc-50">
+                {notification.title}
+              </h2>
+              {!notification.read && (
+                <span className="rounded-full bg-indigo-600 px-2 py-0.5 text-xs font-semibold text-white">
+                  {unreadLabel}
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">{notification.message}</p>
+            <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+              {formatDate(notification.createdAt)}
+            </p>
+          </div>
+        </div>
+        {!notification.read && (
+          <button
+            onClick={() => onMarkRead(notification.id)}
+            className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-700 transition hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-900"
+          >
+            <Check className="h-4 w-4" />
+            {markReadLabel}
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function NotificationsPage() {
+  const t = useTranslations("Notifications");
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const markRead = useMarkNotificationsRead();
+
+  const activeType = parseType(searchParams.get("type"));
+  const unreadOnly = searchParams.get("unread") === "true";
+  const currentPage = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+
+  const { data, isLoading, isError } = useNotifications({
+    limit: 100,
+    type: activeType,
+    unread: unreadOnly,
+  });
+
+  const notifications = data?.notifications ?? [];
+  const filteredNotifications = useMemo(() => {
+    return notifications.filter((notification) => {
+      const matchesType = activeType === "all" || notification.type === activeType;
+      const matchesUnread = !unreadOnly || !notification.read;
+      return matchesType && matchesUnread;
+    });
+  }, [activeType, notifications, unreadOnly]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredNotifications.length / PAGE_SIZE));
+  const page = Math.min(currentPage, totalPages);
+  const visibleNotifications = filteredNotifications.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const updateParams = (updates: Record<string, string | null>) => {
+    const next = new URLSearchParams(searchParams.toString());
+    Object.entries(updates).forEach(([key, value]) => {
+      if (!value) next.delete(key);
+      else next.set(key, value);
+    });
+    router.push(`${pathname}?${next.toString()}`);
+  };
+
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl space-y-6 p-8 lg:p-12">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600 dark:text-indigo-400">
+            {t("eyebrow")}
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-zinc-900 dark:text-zinc-50">
+            {t("title")}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
+            {t("description")}
+          </p>
+        </div>
+        {data?.unreadCount ? (
+          <button
+            onClick={() =>
+              markRead.mutate(notifications.filter((notification) => !notification.read).map((notification) => notification.id))
+            }
+            disabled={markRead.isPending}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:opacity-60"
+          >
+            <CheckCheck className="h-4 w-4" />
+            {t("markAllVisibleRead")}
+          </button>
+        ) : null}
+      </header>
+
+      <section className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
+        <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+          <Filter className="h-4 w-4" />
+          {t("filters.title")}
+        </div>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap gap-2">
+            {NOTIFICATION_TYPES.map((type) => (
+              <button
+                key={type}
+                onClick={() => updateParams({ type: type === "all" ? null : type, page: "1" })}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                  activeType === type
+                    ? "bg-indigo-600 text-white"
+                    : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                }`}
+              >
+                {
+                  {
+                    all: t("types.all"),
+                    loan_approved: t("types.loan_approved"),
+                    repayment_due: t("types.repayment_due"),
+                    repayment_confirmed: t("types.repayment_confirmed"),
+                    loan_defaulted: t("types.loan_defaulted"),
+                    score_changed: t("types.score_changed"),
+                  }[type]
+                }
+              </button>
+            ))}
+          </div>
+          <label className="inline-flex w-fit items-center gap-2 rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:text-zinc-300">
+            <input
+              type="checkbox"
+              checked={unreadOnly}
+              onChange={(event) =>
+                updateParams({ unread: event.target.checked ? "true" : null, page: "1" })
+              }
+              className="h-4 w-4 rounded border-zinc-300 text-indigo-600"
+            />
+            {t("filters.unreadOnly")}
+          </label>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((item) => (
+              <div
+                key={item}
+                className="h-28 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900"
+              />
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+            {t("error")}
+          </div>
+        ) : visibleNotifications.length === 0 ? (
+          <EmptyState
+            icon={Bell}
+            title={t("empty.title")}
+            description={t("empty.description")}
+            actionLabel={t("empty.action")}
+            actionHref={`/${locale}`}
+          />
+        ) : (
+          <>
+            <div className="space-y-3">
+              {visibleNotifications.map((notification) => (
+                <NotificationRow
+                  key={notification.id}
+                  notification={notification}
+                  onMarkRead={(id) => markRead.mutate([id])}
+                  unreadLabel={t("unread")}
+                  markReadLabel={t("markRead")}
+                />
+              ))}
+            </div>
+            <PaginationControls
+              currentPage={page}
+              totalPages={totalPages}
+              hasPrevious={page > 1}
+              hasNext={page < totalPages}
+              onPageChange={(nextPage) => updateParams({ page: String(nextPage) })}
+              onPrevious={() => updateParams({ page: String(Math.max(1, page - 1)) })}
+              onNext={() => updateParams({ page: String(Math.min(totalPages, page + 1)) })}
+              summary={t("pagination.summary", {
+                count: visibleNotifications.length,
+                total: filteredNotifications.length,
+                page,
+              })}
+            />
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/components/global_ui/NotificationDropdown.tsx
+++ b/frontend/src/app/components/global_ui/NotificationDropdown.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import { Bell, Check, CheckCheck, AlertTriangle, TrendingUp, Clock, X } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -164,6 +165,8 @@ function NotificationItem({
 
 export function NotificationDropdown() {
   const router = useRouter();
+  const locale = useLocale();
+  const t = useTranslations("Notifications");
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -330,12 +333,12 @@ export function NotificationDropdown() {
               <div className="border-t border-zinc-100 px-4 py-2 dark:border-zinc-800">
                 <button
                   onClick={() => {
-                    router.push("/loans");
+                    router.push(`/${locale}/notifications`);
                     setOpen(false);
                   }}
                   className="w-full text-center text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 py-1 transition-colors"
                 >
-                  View all loans →
+                  {t("viewAll")}
                 </button>
               </div>
             )}

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
   },
   notifications: {
     all: () => ["notifications"] as const,
+    list: (params: Record<string, unknown>) => ["notifications", params] as const,
   },
   adminDisputes: {
     all: () => ["admin", "disputes"] as const,
@@ -173,6 +174,21 @@ export interface CreditScoreResponse {
   userId: string;
   score: number;
   band: string;
+}
+
+export interface RemittanceNftMetadata {
+  score: number;
+  historyHash: string;
+  metadataUri: string;
+  defaultCount: number;
+  transferCooldownRemaining: number;
+  lastUpdateLedger: number;
+}
+
+interface RemittanceNftResponse {
+  success: boolean;
+  walletAddress: string;
+  nft: RemittanceNftMetadata | null;
 }
 
 export interface LoanConfig {
@@ -828,6 +844,21 @@ export function useCreditScoreHistory(
   });
 }
 
+export function useRemittanceNft(
+  walletAddress: string | undefined,
+  options?: Omit<UseQueryOptions<RemittanceNftMetadata | null>, "queryKey" | "queryFn">,
+) {
+  return useQuery<RemittanceNftMetadata | null>({
+    queryKey: ["remittanceNft", walletAddress],
+    queryFn: async () => {
+      const response = await apiFetch<RemittanceNftResponse>(`/score/${walletAddress}/nft`);
+      return response.nft;
+    },
+    enabled: !!walletAddress,
+    ...options,
+  });
+}
+
 /**
  * Fetches the current credit score for the authenticated borrower.
  */
@@ -1087,18 +1118,32 @@ interface NotificationsResponse {
   unreadCount: number;
 }
 
+export interface NotificationsQueryParams {
+  limit?: number;
+  unread?: boolean;
+  type?: NotificationType | "all";
+  page?: number;
+}
+
 /**
  * Fetches the authenticated user's notifications.
  * Polls every 60s as a fallback alongside the SSE stream.
  */
 export function useNotifications(
+  params: NotificationsQueryParams = {},
   options?: Omit<UseQueryOptions<NotificationsResponse>, "queryKey" | "queryFn">,
 ) {
   return useQuery<NotificationsResponse>({
-    queryKey: queryKeys.notifications.all(),
+    queryKey: queryKeys.notifications.list(params),
     queryFn: async () => {
+      const searchParams = new URLSearchParams();
+      searchParams.set("limit", String(params.limit ?? 50));
+      if (params.unread !== undefined) searchParams.set("unread", String(params.unread));
+      if (params.type && params.type !== "all") searchParams.set("type", params.type);
+      if (params.page) searchParams.set("page", String(params.page));
+
       const res = await apiFetch<{ success: boolean; data: NotificationsResponse }>(
-        "/notifications?limit=50",
+        `/notifications?${searchParams.toString()}`,
       );
       return res.data;
     },


### PR DESCRIPTION
closes #878 - Tracks LoanManager paused_at_ledger on pause, clears it on unpause, and exposes get_paused_at_ledger.
Updates pause and unpause events to emit the relevant ledger for indexers.

closes #876 - Exposes LendingPool depositor_count and total_yield_distributed through getters and pool stats.
Adds bookkeeping for yield_distributed and updates pool stats coverage.

closes #893 - Adds a Remittance NFT viewer on the kingdom page with score, metadata URI, defaults, cooldown, and last update ledger.
Adds a thin score NFT API wrapper, i18n strings, and Playwright coverage for populated and empty NFT states.

closes #892 - Adds a localized notifications inbox page with unread/type filters, URL search params, pagination, and standard states.
Updates the dropdown View all action to open the inbox and adds Playwright coverage for the flow.