### PR TITLE
Validate LoanManager min score bounds

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -165,6 +165,7 @@ impl LoanManager {
     const MIN_RATE_BPS: u32 = 1; // Minimum 0.01% interest rate
     /// Default maximum interest rate (configurable via set_rate_bounds). #631
     const MAX_RATE_BPS: u32 = 100_000; // Maximum 1000% interest rate
+    const MAX_CREDIT_SCORE: u32 = 850;
     const MAX_PENALTY_MULTIPLIER: i128 = 2; // Total debt cannot exceed 2x original principal
 
     fn bump_instance_ttl(env: &Env) {
@@ -1935,7 +1936,11 @@ impl LoanManager {
         Self::default_window_ledgers(&env)
     }
 
-    pub fn set_min_score(env: Env, min_score: u32) {
+    pub fn set_min_score(env: Env, min_score: u32) -> Result<(), LoanError> {
+        if min_score == 0 || min_score > Self::MAX_CREDIT_SCORE {
+            return Err(LoanError::InvalidConfiguration);
+        }
+
         Self::admin(&env).require_auth();
 
         let old_score: u32 = env
@@ -1946,6 +1951,7 @@ impl LoanManager {
         env.storage().instance().set(&DataKey::MinScore, &min_score);
         Self::bump_instance_ttl(&env);
         events::min_score_updated(&env, old_score, min_score);
+        Ok(())
     }
 
     pub fn set_max_loan_amount(env: Env, amount: i128) -> Result<(), LoanError> {

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -630,6 +630,46 @@ fn test_set_interest_rate_zero_rejected() {
 }
 
 #[test]
+fn test_set_min_score_updates_value() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _token_admin) = setup_test(&env);
+
+    manager.set_min_score(&700);
+
+    assert_eq!(manager.get_min_score(), 700);
+}
+
+#[test]
+fn test_set_min_score_accepts_max_score_boundary() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _token_admin) = setup_test(&env);
+
+    manager.set_min_score(&850);
+
+    assert_eq!(manager.get_min_score(), 850);
+}
+
+#[test]
+fn test_set_min_score_rejects_out_of_bounds_values() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _token_admin) = setup_test(&env);
+
+    let above_max = manager.try_set_min_score(&851);
+    assert_eq!(above_max, Err(Ok(LoanError::InvalidConfiguration)));
+    assert_eq!(manager.get_min_score(), 500);
+
+    let zero = manager.try_set_min_score(&0);
+    assert_eq!(zero, Err(Ok(LoanError::InvalidConfiguration)));
+    assert_eq!(manager.get_min_score(), 500);
+}
+
+#[test]
 fn test_legacy_zero_interest_config_falls_back_to_default() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
## Summary

Refs #941.

This hardens `LoanManager::set_min_score` so the admin setter follows the same `Result<(), LoanError>` pattern as the other guarded configuration setters and rejects unsafe score bounds.

## Approach

- Added a local `MAX_CREDIT_SCORE` ceiling of `850`, matching the RemittanceNFT score cap referenced by the issue.
- Changed `set_min_score` to return `Result<(), LoanError>`.
- Rejects `0` and values above `850` with `LoanError::InvalidConfiguration` before writing storage.
- Keeps the existing successful update path, including `min_score_updated`, unchanged after validation succeeds.
- Added focused tests for a normal update, boundary value `850`, and rejected out-of-bounds values.

## Security

- Prevents a misconfigured or compromised admin flow from setting `min_score > 850`, which would make all borrowers fail the score gate.
- Prevents `min_score = 0`, which would effectively disable the score gate.
- Does not alter loan balances, repayments, pool transfers, collateral logic, or borrower state.
- Failed updates do not write the new config value.

## Verification

- `docker run --rm -v "C:\\Users\\ADMIN\\.openclaw\\github-jobs\\remitlend:/work" -w /work/contracts rust:1.95 bash -lc "/usr/local/cargo/bin/cargo test -p loan_manager set_min_score"`
- `git diff --check`
