### PR TITLE
feat(#880): sign webhook deliveries with HMAC-SHA256 X-RemitLend-Sign…

### DIFF
--- a/backend/src/__tests__/webhookService.test.ts
+++ b/backend/src/__tests__/webhookService.test.ts
@@ -211,28 +211,33 @@ describe("WebhookService", () => {
   });
 
   describe("HMAC signature", () => {
-    it("generates correct HMAC signature when secret is provided", async () => {
-      const fetchMock: any = jest.fn(async () => ({
-        ok: true,
-        status: 200,
-      }));
+    it("sets X-RemitLend-Signature with sha256= prefix for a known body+secret", async () => {
+      const secret = "test-secret-key";
+      const knownBody = JSON.stringify({ eventId: "evt-known", eventType: "LoanApproved" });
+
+      const crypto = await import("node:crypto");
+      const expectedHex = crypto
+        .createHmac("sha256", secret)
+        .update(knownBody)
+        .digest("hex");
+      const expectedHeader = `sha256=${expectedHex}`;
+
+      // Directly inspect the header value by spying on fetch
+      const fetchMock: any = jest.fn(async (_url: string, opts: RequestInit) => {
+        const hdrs = opts.headers as Record<string, string>;
+        expect(hdrs["x-remitlend-signature"]).toBe(expectedHeader);
+        return { ok: true, status: 200 };
+      });
       global.fetch = fetchMock as typeof fetch;
 
-      const secret = "test-secret-key";
       mockQuery
         .mockResolvedValueOnce({
-          rows: [
-            {
-              id: 1,
-              callback_url: "https://consumer.example",
-              secret,
-            },
-          ],
+          rows: [{ id: 1, callback_url: "https://consumer.example", secret }],
         })
         .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const service = new WebhookService();
-      const event = {
+      await service.dispatch({
         eventId: "evt-hmac-test",
         eventType: "LoanApproved" as const,
         loanId: 42,
@@ -243,24 +248,80 @@ describe("WebhookService", () => {
         contractId: "contract-123",
         topics: [],
         value: "value-xdr",
-      };
-
-      await service.dispatch(event);
+      });
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      const callArgs = fetchMock.mock.calls[0];
-      const headers = callArgs[1]?.headers;
-      const body = callArgs[1]?.body;
+    });
 
-      expect(headers["x-remitlend-signature"]).toBeDefined();
+    it("header value starts with 'sha256=' and matches HMAC-SHA256 of the request body", async () => {
+      const secret = "another-secret";
+      const fetchMock: any = jest.fn(async () => ({ ok: true, status: 200 }));
+      global.fetch = fetchMock as typeof fetch;
 
-      // Verify the signature is correct
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, callback_url: "https://hook.example", secret }],
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const service = new WebhookService();
+      await service.dispatch({
+        eventId: "evt-prefix-check",
+        eventType: "LoanRepaid" as const,
+        loanId: 7,
+        address: "GBORROWER456",
+        ledger: 200,
+        ledgerClosedAt: new Date("2025-06-01T00:00:00.000Z"),
+        txHash: "tx-prefix",
+        contractId: "contract-456",
+        topics: [],
+        value: "xdr-val",
+      });
+
+      const callOpts = fetchMock.mock.calls[0][1] as RequestInit;
+      const hdrs = callOpts.headers as Record<string, string>;
+      const sigHeader = hdrs["x-remitlend-signature"];
+
+      // Must start with the algorithm prefix
+      expect(sigHeader).toMatch(/^sha256=[a-f0-9]{64}$/);
+
+      // The hex part must equal HMAC-SHA256(secret, body)
       const crypto = await import("node:crypto");
-      const expectedSignature = crypto
+      const sentBody = callOpts.body as string;
+      const expectedHex = crypto
         .createHmac("sha256", secret)
-        .update(body)
+        .update(sentBody)
         .digest("hex");
-      expect(headers["x-remitlend-signature"]).toBe(expectedSignature);
+      expect(sigHeader).toBe(`sha256=${expectedHex}`);
+    });
+
+    it("omits X-RemitLend-Signature when no secret is configured", async () => {
+      const fetchMock: any = jest.fn(async () => ({ ok: true, status: 200 }));
+      global.fetch = fetchMock as typeof fetch;
+
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, callback_url: "https://nosecret.example", secret: null }],
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const service = new WebhookService();
+      await service.dispatch({
+        eventId: "evt-no-secret",
+        eventType: "LoanApproved" as const,
+        loanId: 1,
+        address: "GBORROWER789",
+        ledger: 300,
+        ledgerClosedAt: new Date("2025-01-01T00:00:00.000Z"),
+        txHash: "tx-nosecret",
+        contractId: "contract-789",
+        topics: [],
+        value: "xdr",
+      });
+
+      const callOpts = fetchMock.mock.calls[0][1] as RequestInit;
+      const hdrs = callOpts.headers as Record<string, string>;
+      expect(hdrs["x-remitlend-signature"]).toBeUndefined();
     });
   });
 

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -266,7 +266,10 @@ async function postWebhook(
       method: "POST",
       headers: {
         "content-type": "application/json",
-        ...(signature && { "x-remitlend-signature": signature }),
+        // X-RemitLend-Signature uses the GitHub/Stripe-style "sha256=<hex>"
+        // format so subscribers can verify payload integrity (see
+        // docs/wiki/webhook-signatures.md for the verification recipe).
+        ...(signature && { "x-remitlend-signature": `sha256=${signature}` }),
       },
       body,
       signal: controller.signal,

--- a/docs/wiki/webhook-signatures.md
+++ b/docs/wiki/webhook-signatures.md
@@ -1,0 +1,68 @@
+# Webhook Signature Verification
+
+Every outbound webhook delivery from RemitLend includes an
+`X-RemitLend-Signature` header that allows subscribers to verify the
+payload was not tampered with in transit.
+
+## Header format
+
+```
+X-RemitLend-Signature: sha256=<hex-encoded-hmac>
+```
+
+The value is `sha256=` followed by the lowercase hex-encoded
+HMAC-SHA256 digest of the **raw request body** using the subscriber
+secret that was supplied when the subscription was registered.
+
+## Verification recipe
+
+### Node.js
+
+```js
+import crypto from "node:crypto";
+
+function verifySignature(secret, rawBody, signatureHeader) {
+  const expected =
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+
+  // Use timingSafeEqual to prevent timing attacks
+  const a = Buffer.from(expected);
+  const b = Buffer.from(signatureHeader ?? "");
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+// Express example
+app.post("/webhook", express.raw({ type: "application/json" }), (req, res) => {
+  const sig = req.headers["x-remitlend-signature"];
+  if (!verifySignature(process.env.WEBHOOK_SECRET, req.body, sig)) {
+    return res.status(401).send("Invalid signature");
+  }
+  // process req.body …
+  res.sendStatus(200);
+});
+```
+
+### Python
+
+```python
+import hmac, hashlib
+
+def verify_signature(secret: str, raw_body: bytes, header: str) -> bool:
+    digest = "sha256=" + hmac.new(
+        secret.encode(), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(digest, header or "")
+```
+
+## Notes
+
+- The `Authorization: Bearer <secret>` header is also present for
+  backwards compatibility with existing subscribers that have not yet
+  adopted HMAC verification, but **`X-RemitLend-Signature` is the
+  authoritative integrity check**.
+- Always parse the raw body bytes *before* JSON-decoding; most
+  frameworks let you configure a raw-body parser for webhook routes.
+- Secrets can be rotated by deleting and re-creating the subscription
+  (secret rotation via the API is tracked in a separate issue).


### PR DESCRIPTION
…ature

- Prefix signature header value with 'sha256=' (GitHub/Stripe convention) so subscribers can verify payload integrity without parsing algorithms
- Keep existing bearer secret header for backward compatibility
- Add docs/wiki/webhook-signatures.md with Node.js + Python verification recipes and timingSafeEqual guidance
- Update HMAC test suite: assert 'sha256=<64-hex>' format, add tests for correct digest value against known body/secret, and no-secret path
- 
closes #880 