### PR TITLE
feat(#884): add X-Idempotent-Replayed header to idempotency middleware

### DIFF
--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -35,9 +35,13 @@ export const idempotencyMiddleware = async (
         method: req.method,
       });
 
+      // X-Idempotent-Replayed: true signals to the client that this response
+      // is a cached replay of a prior request, not a fresh execution.
+      // Clients can use this to de-duplicate toasts and avoid double-counting.
       res
         .status(cached.status)
         .set("X-Idempotency-Cache", "HIT")
+        .set("X-Idempotent-Replayed", "true")
         .json(cached.body);
       return;
     }
@@ -69,6 +73,10 @@ export const idempotencyMiddleware = async (
       }
       return originalSend.call(this, body);
     };
+
+    // X-Idempotent-Replayed: false on the first (fresh) execution so the
+    // client always receives the header and can branch on its value.
+    res.set("X-Idempotent-Replayed", "false");
 
     // Store the response in cache once the request is finished
     res.on("finish", async () => {

--- a/backend/src/tests/idempotency.test.ts
+++ b/backend/src/tests/idempotency.test.ts
@@ -64,6 +64,31 @@ describe("Idempotency Middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("sets X-Idempotent-Replayed: true on a cache hit (replayed response)", async () => {
+    const key = "replay-key";
+    const cachedResponse = { status: 200, body: { id: 99 } };
+    asMock(req.header).mockReturnValue(key);
+    (cacheService.get as jest.Mock<() => Promise<any>>).mockResolvedValue(
+      cachedResponse,
+    );
+
+    await idempotencyMiddleware(req as Request, res as Response, next);
+
+    expect(res.set).toHaveBeenCalledWith("X-Idempotent-Replayed", "true");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("sets X-Idempotent-Replayed: false on a fresh (cache miss) execution", async () => {
+    const key = "fresh-key";
+    asMock(req.header).mockReturnValue(key);
+    (cacheService.get as jest.Mock<() => Promise<any>>).mockResolvedValue(null);
+
+    await idempotencyMiddleware(req as Request, res as Response, next);
+
+    expect(res.set).toHaveBeenCalledWith("X-Idempotent-Replayed", "false");
+    expect(next).toHaveBeenCalled();
+  });
+
   it("should proceed and intercept response on cache miss", async () => {
     const key = "new-key";
     asMock(req.header).mockReturnValue(key);

--- a/docs/wiki/api-idempotency.md
+++ b/docs/wiki/api-idempotency.md
@@ -1,0 +1,50 @@
+# API Idempotency
+
+Write endpoints that mutate state (e.g. `/api/loans/:loanId/repay/build`)
+support the `Idempotency-Key` request header. Sending the same key twice
+within the 24-hour cache window returns an identical response without
+re-executing side effects.
+
+## Request header
+
+```
+Idempotency-Key: <client-generated-uuid>
+```
+
+Use a fresh UUID per logical operation. Re-use the same UUID only when
+retrying after a network failure.
+
+## Response headers
+
+| Header | Values | Meaning |
+|---|---|---|
+| `X-Idempotency-Cache` | `HIT` | Response was served from the idempotency cache |
+| `X-Idempotent-Replayed` | `true` / `false` | `true` = cached replay; `false` = fresh execution |
+
+`X-Idempotent-Replayed` is always present on requests that include an
+`Idempotency-Key`, regardless of whether the key was seen before. This
+lets the frontend branch without checking two separate headers:
+
+```ts
+const replayed = response.headers.get("X-Idempotent-Replayed") === "true";
+if (!replayed) {
+  showSuccessToast("Repayment submitted");   // first execution
+} else {
+  // duplicate submission — silently ignore or show a softer message
+}
+```
+
+## Cached status codes
+
+Only `2xx` and `4xx` responses are cached. `5xx` responses are never
+cached so that clients can safely retry transient server errors.
+
+## TTL
+
+The idempotency cache entry expires after **24 hours**.
+
+## Out of scope
+
+- Changing the cache backend or TTL (tracked separately).
+- Replaying side effects — the cache stores and replays the HTTP
+  response only; the underlying transaction is not re-executed.


### PR DESCRIPTION
- Cache hit  → X-Idempotent-Replayed: true  (alongside existing X-Idempotency-Cache: HIT)
- Fresh exec → X-Idempotent-Replayed: false (set before next() so header is present in every response that carries an Idempotency-Key)
- Lets the frontend de-duplicate toasts and avoid double-counting without consulting two separate headers
- Add two new unit tests asserting both header values
- Add docs/wiki/api-idempotency.md documenting both response headers, TTL, cached status-code policy, and a TS usage example
closes #884