### PR TITLE
feat(#879): persist LoanApprv events into audit_logs with admin attri…

### DIFF
--- a/backend/src/services/__tests__/eventIndexer.test.ts
+++ b/backend/src/services/__tests__/eventIndexer.test.ts
@@ -107,6 +107,39 @@ function makeRawAdminConfigEvent(
   };
 }
 
+/**
+ * Build a raw Soroban event that parses as LoanApprv.
+ * topic[0] = "LoanApprv" (event type symbol)
+ * topic[1] = admin address ("GADMIN123")
+ * value    = [loanId=42, borrower="GBORROWER123"]
+ */
+function makeRawLoanApprvEvent(id = "apprv-001"): Record<string, unknown> {
+  const makeSym = (name: string) => ({
+    sym: () => ({ toString: () => name }),
+    toXDR: (_enc: string) => `xdr:${name}`,
+  });
+
+  return {
+    id,
+    pagingToken: id,
+    topic: [
+      makeSym("LoanApprv"),
+      // admin address — _val makes scValToNative return a string
+      { _val: "GADMIN123", sym: () => { throw new Error("not a sym"); }, toXDR: () => "xdr:admin" },
+    ],
+    value: {
+      // scValToNative returns [42, "GBORROWER123"] for arrays
+      _val: [42, "GBORROWER123"],
+      sym: () => { throw new Error("not a sym"); },
+      toXDR: () => "xdr:apprv-val",
+    },
+    ledger: 200,
+    ledgerClosedAt: new Date().toISOString(),
+    txHash: "txhash-apprv-001",
+    contractId: { toString: () => "CONTRACT001" },
+  };
+}
+
 /** Run the withTransaction callback immediately using the provided mock client. */
 function stubWithTransaction(mockClient: MockClient): void {
   mockWithTransaction.mockImplementation(async (fn: TxCallback) =>
@@ -193,6 +226,7 @@ beforeAll(async () => {
       "RateOracleUpdated",
       "PoolPaused",
       "PoolUnpaused",
+      "LoanApprv",
     ],
   }));
 
@@ -404,6 +438,47 @@ describe("EventIndexer – transaction atomicity via ingestRawEvents", () => {
 
     // withTransaction is the entry point instead
     expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("LoanApprv: inserts audit_logs row with actor=admin, action=loan_approved", async () => {
+    const auditInsertCalls: unknown[][] = [];
+
+    const mockClient: MockClient = {
+      query: jest.fn<any>().mockImplementation(async (sql: string, params: unknown[]) => {
+        if (sql.includes("INSERT INTO loan_events")) {
+          return { rowCount: 1, rows: [{ event_id: "apprv-001" }] };
+        }
+        if (sql.includes("INSERT INTO audit_logs")) {
+          auditInsertCalls.push(params);
+          return { rowCount: 1, rows: [] };
+        }
+        return { rowCount: 0, rows: [] };
+      }),
+    };
+    stubWithTransaction(mockClient);
+
+    const result = await makeIndexer().ingestRawEvents([makeRawLoanApprvEvent()]);
+
+    // Event must be counted as inserted
+    expect(result.insertedCount).toBe(1);
+
+    // Exactly one audit_logs INSERT must have been made
+    expect(auditInsertCalls).toHaveLength(1);
+
+    const [actor, action, target, payload] = auditInsertCalls[0] as [string, string, string, string];
+
+    // actor = admin address from topic[1]
+    expect(actor).toBe("GADMIN123");
+    // action = 'loan_approved'
+    expect(action).toBe("loan_approved");
+    // target = 'loan:<loanId>'
+    expect(target).toBe("loan:42");
+
+    // payload JSON must contain loanId, borrower, txHash
+    const parsed = JSON.parse(payload);
+    expect(parsed.loanId).toBe(42);
+    expect(parsed.borrower).toBe("GBORROWER123");
+    expect(parsed.txHash).toBe("txhash-apprv-001");
   });
 
   it("persists admin config events into audit_logs", async () => {

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -66,6 +66,12 @@ interface ContractEvent extends IndexedLoanEvent {
   amount?: string;
   loanId?: number;
   address?: string;
+  /**
+   * Admin address captured from the LoanApprv event topic[1].
+   * Used to record the approving admin in audit_logs (actor field).
+   * Only populated for LoanApprv events.
+   */
+  adminAddress?: string;
   ledger: number;
   ledgerClosedAt: Date;
   txHash: string;
@@ -534,6 +540,35 @@ export class EventIndexer {
             );
           }
 
+          /**
+           * LoanApprv audit row — records which admin approved a loan.
+           *
+           * audit_logs shape:
+           *   actor     — admin Stellar address (topic[1] of the LoanApprv event)
+           *   action    — 'loan_approved'
+           *   target    — 'loan:<loanId>'
+           *   payload   — { eventId, loanId, borrower, txHash }
+           *   ip_address — null (on-chain action, no HTTP request IP)
+           */
+          if (event.eventType === "LoanApprv") {
+            await client.query(
+              `INSERT INTO audit_logs (actor, action, target, payload, ip_address)
+               VALUES ($1, $2, $3, $4::jsonb, $5)`,
+              [
+                event.adminAddress ?? "SYSTEM",
+                "loan_approved",
+                `loan:${event.loanId ?? "unknown"}`,
+                JSON.stringify({
+                  eventId: event.eventId,
+                  loanId: event.loanId ?? null,
+                  borrower: event.address ?? null,
+                  txHash: event.txHash,
+                }),
+                null,
+              ],
+            );
+          }
+
           // Aggregate score deltas per borrower; a single bulk upsert at
           // the end of the transaction avoids N+1 score updates.
           if (event.eventType === "LoanRepaid") {
@@ -829,17 +864,29 @@ export class EventIndexer {
       }
     } else if (type === "LoanApprv") {
       // (type, admin), (loan_id, borrower)
+      // topic[1] = admin address who approved the loan
       const data = scValToNative(event.value);
       if (Array.isArray(data) && data.length >= 2) {
         loanId = Number(data[0]);
-        address = data[1].toString();
+        address = data[1].toString(); // borrower
       }
+      // adminAddress is decoded separately and attached below
     } else if (type === "LoanLiquidated") {
       // (type, loan_id, borrower, liquidator), (debt_repaid, liquidator_bonus, borrower_refund)
       if (!event.topic[1] || !event.topic[2]) return null;
       loanId = this.decodeLoanId(event.topic[1]);
       address = this.decodeAddress(event.topic[2]);
       amount = this.decodeTupleFirstNumericValue(event.value);
+    }
+
+    // Decode admin address for LoanApprv events (topic[1] = approving admin)
+    let adminAddress: string | undefined;
+    if (type === "LoanApprv" && event.topic[1]) {
+      try {
+        adminAddress = this.decodeAddress(event.topic[1]);
+      } catch {
+        // Admin address decode failed; audit row will fall back to "SYSTEM"
+      }
     }
 
     return {
@@ -856,6 +903,7 @@ export class EventIndexer {
       ...(interestRateBps !== undefined ? { interestRateBps } : {}),
       ...(termLedgers !== undefined ? { termLedgers } : {}),
       ...(address !== undefined ? { address } : {}),
+      ...(adminAddress !== undefined ? { adminAddress } : {}),
     };
   }
 


### PR DESCRIPTION
…bution

- Add adminAddress field to ContractEvent (decoded from topic[1])
- Insert audit_logs row on every new LoanApprv event with:
    actor     = admin Stellar address
    action    = 'loan_approved'
    target    = 'loan:<loanId>'
    payload   = { eventId, loanId, borrower, txHash }
    ip_address = null (on-chain action)
- Add unit test asserting actor, action, target, and payload shape
closes #879