### PR TITLE
docs: fix Swagger path from /api-docs to /docs and add API Reference to README

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,7 +263,7 @@ The backend serves as a bridge between the frontend and blockchain, handling off
 - `GET /api/health` - Health check
 - `GET /api/score/:userId` - Get user credit score
 - `POST /api/score/simulate` - Simulate remittance history
-- `GET /api-docs` - Swagger documentation
+- `GET /docs` - Swagger documentation
 
 **Middleware**:
 - `errorHandler` - Centralized error handling

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ The repository is organized as a monorepo containing three core packages:
 *For a detailed look at how these components interact, see our [Architecture Diagram](ARCHITECTURE.md).*
 *New contributor? Start with the in-repo wiki: [docs/wiki/README.md](docs/wiki/README.md).*
 
+### API Reference
+
+The backend exposes an interactive Swagger UI for exploring and testing API endpoints. Start the backend server (see [Quick Start](#quick-start-with-docker-recommended) or [Manual Setup](#manual-setup)), then open:
+
+- **Swagger UI**: [http://localhost:3001/docs](http://localhost:3001/docs)
+- **OpenAPI JSON**: [http://localhost:3001/docs.json](http://localhost:3001/docs.json)
+
+Both endpoints are gated to non-production environments (`NODE_ENV !== "production"`).
+
 ## 🛠 Tech Stack
 
 - **Blockchain**: [Stellar](https://stellar.org) (Soroban Smart Contracts)
@@ -79,7 +88,7 @@ The repository is organized as a monorepo containing three core packages:
 4. **Access the application:**
    - Frontend: [http://localhost:3000](http://localhost:3000)
    - Backend API: [http://localhost:3001](http://localhost:3001)
-   - API Documentation: [http://localhost:3001/api-docs](http://localhost:3001/api-docs)
+   - API Documentation: [http://localhost:3001/docs](http://localhost:3001/docs)
 
 ### Manual Setup
 


### PR DESCRIPTION
close #956 
## Summary

Fixes stale Swagger reference paths in documentation and adds an API Reference section to the README.

## Changes

- **ARCHITECTURE.md**: Fixed \GET /api-docs\ → \GET /docs\ (line 266) to match the actual mount path in \mountSwaggerDocs\
- **README.md**: Fixed \http://localhost:3001/api-docs\ → \http://localhost:3001/docs\ in the Quick Start section
- **README.md**: Added a new **API Reference** subsection under Project Structure linking to the interactive Swagger UI (\/docs\) and OpenAPI JSON (\/docs.json\), noting the environment gate

Closes #859