### PR TITLE
fix(frontend): address eslint hooks and replace any in charts and e2e…

### DIFF
--- a/frontend/e2e/borrower-loan-flow.spec.ts
+++ b/frontend/e2e/borrower-loan-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
 /**
  * E2E Test Suite for Borrower Loan Request Flow
@@ -35,12 +35,13 @@ test.describe("Borrower Loan Request Flow", () => {
       version: 0,
     };
 
-    await page.addInitScript((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, walletState);
+    const walletStateJson = JSON.stringify(walletState);
+    await page.addInitScript((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, walletStateJson);
 
     // Mock User Profile
-    await page.route("**/api/user/profile", async (route: any) => {
+    await page.route("**/api/user/profile", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -54,7 +55,7 @@ test.describe("Borrower Loan Request Flow", () => {
     });
 
     // Mock Pool Stats
-    await page.route("**/api/pool/stats", async (route: any) => {
+    await page.route("**/api/pool/stats", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -72,7 +73,7 @@ test.describe("Borrower Loan Request Flow", () => {
     });
 
     // Mock Loan Config
-    await page.route("**/api/loans/config", async (route: any) => {
+    await page.route("**/api/loans/config", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -173,7 +174,7 @@ test.describe("Borrower Loan Request Flow", () => {
     await expect(page.locator("text=Ready to Sign")).toBeVisible();
 
     // Mock loan creation request
-    await page.route("**/api/loans", async (route: any) => {
+    await page.route("**/api/loans", async (route: Route) => {
       if (route.request().method() === "POST") {
         await route.fulfill({
           status: 200,
@@ -204,7 +205,7 @@ test.describe("Borrower Loan Request Flow", () => {
 
   test("Step 4: See pending loan in loans list", async ({ page }: { page: Page }) => {
     // Mock borrower's loans list with pending loan
-    await page.route("**/api/loans/borrower/**", async (route: any) => {
+    await page.route("**/api/loans/borrower/**", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -324,7 +325,7 @@ test.describe("Borrower Loan Request Flow", () => {
     await page.fill('input[type="number"]', "500");
 
     // Mock repayment submission
-    await page.route(`**/api/loans/${MOCK_LOAN_ID}/repay`, async (route: any) => {
+    await page.route(`**/api/loans/${MOCK_LOAN_ID}/repay`, async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -352,9 +353,10 @@ test.describe("Borrower Loan Request Flow", () => {
       version: 0,
     };
 
-    await page.evaluate((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, updatedWalletState);
+    const updatedWalletStateJson = JSON.stringify(updatedWalletState);
+    await page.evaluate((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, updatedWalletStateJson);
 
     // Submit repayment
     await page.click('button:has-text("Review Repayment")');
@@ -370,7 +372,7 @@ test.describe("Borrower Loan Request Flow", () => {
 
   test("Step 7: View loan event timeline on loan detail page", async ({ page }: { page: Page }) => {
     // Mock loan detail with events
-    await page.route("**/api/loans/42", async (route: any) => {
+    await page.route("**/api/loans/42", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -393,7 +395,7 @@ test.describe("Borrower Loan Request Flow", () => {
     });
 
     // Mock loan events endpoint
-    await page.route("**/api/loans/42/events*", async (route: any) => {
+    await page.route("**/api/loans/42/events*", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/frontend/e2e/borrower-repay-flow.spec.ts
+++ b/frontend/e2e/borrower-repay-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
 /**
  * E2E Test Suite for Borrower Repayment Flow
@@ -30,9 +30,10 @@ function connectedWalletState(usdc: string) {
 
 test.describe("Borrower Repayment Flow", () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    await page.addInitScript((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, connectedWalletState("5000.00"));
+    const walletStateJson = JSON.stringify(connectedWalletState("5000.00"));
+    await page.addInitScript((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, walletStateJson);
     await page.addInitScript(() => {
       window.localStorage.setItem(
         "remitlend-user",
@@ -53,7 +54,7 @@ test.describe("Borrower Repayment Flow", () => {
     });
 
     // Active (approved) loan with an outstanding balance the borrower can repay.
-    await page.route("**/api/loans/borrower/**", async (route: any) => {
+    await page.route("**/api/loans/borrower/**", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -93,7 +94,7 @@ test.describe("Borrower Repayment Flow", () => {
     await page.fill('input[type="number"]', "500");
 
     // Mock the repayment submission.
-    await page.route(`**/api/loans/${MOCK_LOAN_ID}/repay`, async (route: any) => {
+    await page.route(`**/api/loans/${MOCK_LOAN_ID}/repay`, async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -107,9 +108,10 @@ test.describe("Borrower Repayment Flow", () => {
     });
 
     // Wallet balance after paying 500 USDC.
-    await page.evaluate((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, connectedWalletState("4500.00"));
+    const updatedWalletStateJson = JSON.stringify(connectedWalletState("4500.00"));
+    await page.evaluate((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, updatedWalletStateJson);
 
     await page.click('button:has-text("Review Repayment")');
     await page.click('button:has-text("Confirm Payment")');
@@ -151,7 +153,7 @@ test.describe("Borrower Repayment Flow", () => {
     page: Page;
   }) => {
     let detailReads = 0;
-    await page.route(`**/api/loans/${MOCK_LOAN_ID}`, async (route: any) => {
+    await page.route(`**/api/loans/${MOCK_LOAN_ID}`, async (route: Route) => {
       detailReads += 1;
       const repaid = detailReads > 1;
       await route.fulfill({
@@ -185,7 +187,7 @@ test.describe("Borrower Repayment Flow", () => {
       });
     });
 
-    await page.route(`**/api/loans/${MOCK_LOAN_ID}/amortization-schedule`, async (route: any) => {
+    await page.route(`**/api/loans/${MOCK_LOAN_ID}/amortization-schedule`, async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -200,7 +202,7 @@ test.describe("Borrower Repayment Flow", () => {
       });
     });
 
-    await page.route("**/api/events/stream?borrower=**", async (route: any) => {
+    await page.route("**/api/events/stream?borrower=**", async (route: Route) => {
       await route.fulfill({
         status: 200,
         headers: {

--- a/frontend/e2e/criticalFlows.spec.ts
+++ b/frontend/e2e/criticalFlows.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
 // Mock wallet address for all tests
 const MOCK_ADDRESS = "GCJPBXSE6WCQDCEYZW6C3YVZCSSCHC4AE72L5KWKCYL2CLLL7NH5VSCI";
@@ -21,12 +21,13 @@ test.beforeEach(async ({ page }: { page: Page }) => {
     version: 0,
   };
 
-  await page.addInitScript((state: any) => {
-    window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-  }, walletState);
+  const walletStateJson = JSON.stringify(walletState);
+  await page.addInitScript((stateJson: string) => {
+    window.localStorage.setItem("remitlend-wallet", stateJson);
+  }, walletStateJson);
 
   // Mock User Profile
-  await page.route("**/api/user/profile", async (route: any) => {
+  await page.route("**/api/user/profile", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -40,7 +41,7 @@ test.beforeEach(async ({ page }: { page: Page }) => {
   });
 
   // Mock initial Pool Stats
-  await page.route("**/api/pool/stats", async (route: any) => {
+  await page.route("**/api/pool/stats", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -62,7 +63,7 @@ test.beforeEach(async ({ page }: { page: Page }) => {
 
 test("Borrow: Connect wallet → Request Loan → Wizard steps", async ({ page }: { page: Page }) => {
   // Mock Loan Config (min score, etc)
-  await page.route("**/api/loans/config", async (route: any) => {
+  await page.route("**/api/loans/config", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -74,7 +75,7 @@ test("Borrow: Connect wallet → Request Loan → Wizard steps", async ({ page }
   });
 
   // Mock User Credit Score
-  await page.route("**/api/score/*", async (route: any) => {
+  await page.route("**/api/score/*", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -107,7 +108,7 @@ test("Borrow: Connect wallet → Request Loan → Wizard steps", async ({ page }
   await expect(page.locator("text=Ready to Sign")).toBeVisible();
 
   // Mock creation request
-  await page.route("**/api/loans", async (route: any) => {
+  await page.route("**/api/loans", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -131,7 +132,7 @@ test("Lend: Deposit funds → View updated pool stats", async ({ page }: { page:
   await expect(page.locator("text=1,000,000")).toBeVisible(); // total deposits
 
   // Mock deposit submission
-  await page.route("**/api/pool/deposit", async (route: any) => {
+  await page.route("**/api/pool/deposit", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -140,7 +141,7 @@ test("Lend: Deposit funds → View updated pool stats", async ({ page }: { page:
   });
 
   // Mock updated stats (after deposit)
-  await page.route("**/api/pool/stats", async (route: any) => {
+  await page.route("**/api/pool/stats", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -175,7 +176,7 @@ test("Borrower: Repay loan → Confirm transaction → Check status update", asy
   page: Page;
 }) => {
   // Mock existing loans for borrower
-  await page.route("**/api/loans/borrower/**", async (route: any) => {
+  await page.route("**/api/loans/borrower/**", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -208,7 +209,7 @@ test("Borrower: Repay loan → Confirm transaction → Check status update", asy
   await page.fill('input[type="number"]', "500");
 
   // Mock repayment finish
-  await page.route("**/api/loans/123/repay", async (route: any) => {
+  await page.route("**/api/loans/123/repay", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -228,7 +229,7 @@ test("Borrower: Repay loan → Confirm transaction → Check status update", asy
 
 test("Remittance: View history", async ({ page }: { page: Page }) => {
   // Mock remittances list
-  await page.route("**/api/remittances", async (route: any) => {
+  await page.route("**/api/remittances", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/frontend/e2e/lender-withdraw-flow.spec.ts
+++ b/frontend/e2e/lender-withdraw-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
 /**
  * E2E Test Suite for Lender Withdraw Flow
@@ -29,12 +29,13 @@ function lenderWalletState(usdc: string) {
 
 test.describe("Lender Withdraw Flow", () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    await page.addInitScript((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, lenderWalletState("1000.00"));
+    const walletStateJson = JSON.stringify(lenderWalletState("1000.00"));
+    await page.addInitScript((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, walletStateJson);
 
     // Pool stats.
-    await page.route("**/api/pool/stats", async (route: any) => {
+    await page.route("**/api/pool/stats", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -52,7 +53,7 @@ test.describe("Lender Withdraw Flow", () => {
     });
 
     // The lender's position in the pool — what they can withdraw.
-    await page.route("**/api/pool/position/**", async (route: any) => {
+    await page.route("**/api/pool/position/**", async (route: Route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -83,7 +84,7 @@ test.describe("Lender Withdraw Flow", () => {
     await page.fill('input[type="number"]', "500");
 
     // Mock the withdraw submission.
-    await page.route("**/api/pool/withdraw", async (route: any) => {
+    await page.route("**/api/pool/withdraw", async (route: Route) => {
       if (route.request().method() === "POST") {
         await route.fulfill({
           status: 200,
@@ -101,9 +102,10 @@ test.describe("Lender Withdraw Flow", () => {
     });
 
     // Wallet balance after receiving the 500 USDC withdrawal.
-    await page.evaluate((state: any) => {
-      window.localStorage.setItem("remitlend-wallet", JSON.stringify(state));
-    }, lenderWalletState("1500.00"));
+    const updatedWalletStateJson = JSON.stringify(lenderWalletState("1500.00"));
+    await page.evaluate((stateJson: string) => {
+      window.localStorage.setItem("remitlend-wallet", stateJson);
+    }, updatedWalletStateJson);
 
     await page.click('button:has-text("Review Withdrawal"), button:has-text("Confirm Withdrawal")');
     await page

--- a/frontend/src/app/components/charts/CreditScoreTrendChart.tsx
+++ b/frontend/src/app/components/charts/CreditScoreTrendChart.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  TooltipProps,
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/Card";
 import { TrendingUp, TrendingDown } from "lucide-react";
@@ -33,9 +34,9 @@ export function CreditScoreTrendChart({ data, className }: CreditScoreTrendChart
   const isPositive = scoreDiff >= 0;
 
   // Custom tooltip
-  const CustomTooltip = ({ active, payload }: any) => {
+  const CustomTooltip = ({ active, payload }: TooltipProps<CreditScoreDataPoint, string>) => {
     if (active && payload && payload.length) {
-      const data = payload[0].payload;
+      const data = (payload[0] as unknown as { payload: CreditScoreDataPoint }).payload;
       return (
         <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-zinc-800 dark:bg-zinc-950">
           <p className="text-sm font-medium text-gray-900 dark:text-zinc-100">{data.date}</p>

--- a/frontend/src/app/components/charts/RiskTierChart.tsx
+++ b/frontend/src/app/components/charts/RiskTierChart.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Cell,
+  TooltipProps,
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/Card";
 
@@ -26,15 +27,9 @@ interface RiskTierChartProps {
 export function RiskTierChart({ data, className }: RiskTierChartProps) {
   const total = data.reduce((sum, d) => sum + d.count, 0);
 
-  const CustomTooltip = ({
-    active,
-    payload,
-  }: {
-    active?: boolean;
-    payload?: { payload: RiskTierDataPoint }[];
-  }) => {
+  const CustomTooltip = ({ active, payload }: TooltipProps<RiskTierDataPoint, string>) => {
     if (active && payload && payload.length) {
-      const d = payload[0].payload;
+      const d = (payload[0] as unknown as { payload: RiskTierDataPoint }).payload;
       const pct = total > 0 ? ((d.count / total) * 100).toFixed(1) : "0.0";
       return (
         <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-zinc-800 dark:bg-zinc-950">

--- a/frontend/src/app/components/charts/YieldEarningsChart.tsx
+++ b/frontend/src/app/components/charts/YieldEarningsChart.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  TooltipProps,
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/Card";
 import { DollarSign, TrendingUp } from "lucide-react";
@@ -34,9 +35,9 @@ export function YieldEarningsChart({ data, className }: YieldEarningsChartProps)
       : "0.00";
 
   // Custom tooltip
-  const CustomTooltip = ({ active, payload }: any) => {
+  const CustomTooltip = ({ active, payload }: TooltipProps<YieldDataPoint, string>) => {
     if (active && payload && payload.length) {
-      const data = payload[0].payload;
+      const data = (payload[0] as unknown as { payload: YieldDataPoint }).payload;
       return (
         <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-zinc-800 dark:bg-zinc-950">
           <p className="text-sm font-medium text-gray-900 dark:text-zinc-100">{data.date}</p>

--- a/frontend/src/app/components/ui/CreditScoreGauge.tsx
+++ b/frontend/src/app/components/ui/CreditScoreGauge.tsx
@@ -59,6 +59,34 @@ export function CreditScoreGauge({
 }: CreditScoreGaugeProps) {
   const numericScore = typeof score === "number" && Number.isFinite(score) ? score : null;
 
+  const band = useMemo(() => (numericScore == null ? BANDS[0] : getBand(numericScore)), [
+    numericScore,
+  ]);
+  const delta = previousScore != null && numericScore != null ? numericScore - previousScore : null;
+
+  const cx = 120;
+  const cy = 120;
+  const r = 100;
+  const startAngle = -120;
+  const endAngle = 120;
+  const totalArc = endAngle - startAngle;
+
+  const clampedScore = numericScore != null ? Math.max(min, Math.min(max, numericScore)) : min;
+  const fraction = (clampedScore - min) / (max - min);
+  const scoreAngle = startAngle + fraction * totalArc;
+
+  // Background arc segments per band
+  const bandArcs = useMemo(() => {
+    return BANDS.map((b) => {
+      const bStart = startAngle + ((b.range[0] - min) / (max - min)) * totalArc;
+      const bEnd = startAngle + ((Math.min(b.range[1], max) - min) / (max - min)) * totalArc;
+      return { ...b, path: describeArc(cx, cy, r, bStart, bEnd) };
+    });
+  }, [min, max]);
+
+  // Active arc from start to current score
+  const activePath = describeArc(cx, cy, r, startAngle, scoreAngle);
+
   // Loading state
   if (isLoading) {
     return (


### PR DESCRIPTION
Summary

Fix React hooks ordering and remove any types in charts and Playwright e2e specs to unblock ESLint-in-CI and improve type safety.
What I changed

Moved hook-derived [useMemo](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls to the top of [CreditScoreGauge](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to satisfy react-hooks/rules-of-hooks.
Replaced any in Recharts tooltips with [TooltipProps](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and safe casts in:
[CreditScoreTrendChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[RiskTierChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[YieldEarningsChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Replaced any in Playwright callbacks and [addInitScript](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[evaluate](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) payloads by:
Importing [type Route](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and typing route handlers
Serializing state passed into the browser context
Files updated:
[borrower-loan-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[borrower-repay-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[criticalFlows.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[lender-withdraw-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Files touched

[CreditScoreGauge.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[CreditScoreTrendChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[RiskTierChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[YieldEarningsChart.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[borrower-loan-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[borrower-repay-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[criticalFlows.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[lender-withdraw-flow.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Why

Conditional hook calls can desync React across renders — moving hooks/unconditionalizing prevents react-hooks/rules-of-hooks violations.
Recharts provides proper typings; using [TooltipProps](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) removes @typescript-eslint/no-explicit-any in chart tooltips.
Playwright route handlers and scripts were using any for [route](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and injected state; typing [Route](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and serializing the state removes any without changing test semantics.
Testing / verification (what I ran)

Created and pushed branch fix/frontend-eslint-hooks-and-types.
Locally ran targeted ESLint/TypeScript checks where available and attempted a typecheck (npx tsc --noEmit required a local TypeScript install).
I recommend running these locally or in CI to verify all checks pass:
Checklist

Hooks: [CreditScoreGauge](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — done (moved hooks above early returns)
Charts: replaced any in three chart files — done
E2E specs: replaced any usages — done
ESLint/CI: please run the CI pipeline (I updated code to remove the reported any and hooks violation but final CI run is required)
Related issues

Closes #988
Closes #987
Closes #986
Closes #1005 