### PR TITLE
feat: block SSRF hosts in webhook URLs; add robots.ts and sitemap.ts

### DIFF
--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -18,6 +18,36 @@ import {
 } from "../utils/pagination.js";
 import { parseCappedLimit } from "../utils/queryHelpers.js";
 import logger from "../utils/logger.js";
+
+/**
+ * Returns true if the hostname resolves to a private, loopback, or link-local
+ * address that should never receive outbound webhook deliveries (SSRF guard).
+ */
+function isPrivateHost(hostname: string): boolean {
+  // Strip IPv6 brackets
+  const host = hostname.replace(/^\[|\]$/g, "");
+
+  // Loopback
+  if (host === "localhost" || host === "::1") return true;
+  if (/^127\./.test(host)) return true;
+
+  // Link-local (169.254.x.x, fe80::)
+  if (/^169\.254\./.test(host)) return true;
+  if (/^fe80:/i.test(host)) return true;
+
+  // Private IPv4 ranges (RFC 1918)
+  if (/^10\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+
+  // AWS / GCP metadata endpoints
+  if (host === "169.254.169.254" || host === "metadata.google.internal") return true;
+
+  // Catch-all for unqualified single-label hostnames (e.g. "internal", "db")
+  if (!host.includes(".") && host !== "::1") return true;
+
+  return false;
+}
 import { getStellarRpcUrl } from "../config/stellar.js";
 
 const buildEventFilters = (
@@ -518,6 +548,13 @@ export const createWebhookSubscription = async (
       return res.status(400).json({
         success: false,
         message: "callbackUrl must use http or https",
+      });
+    }
+
+    if (isPrivateHost(parsedUrl.hostname)) {
+      return res.status(400).json({
+        success: false,
+        message: "callbackUrl must not target a private, loopback, or link-local address",
       });
     }
 

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/"],
+        disallow: [
+          "/api/",
+          "/[locale]/activity",
+          "/[locale]/admin",
+          "/[locale]/analytics",
+          "/[locale]/loans",
+          "/[locale]/notifications",
+          "/[locale]/remittances",
+          "/[locale]/repay",
+          "/[locale]/request-loan",
+          "/[locale]/send-remittance",
+          "/[locale]/settings",
+          "/[locale]/wallet",
+        ],
+      },
+    ],
+    sitemap: `${process.env.NEXT_PUBLIC_APP_URL ?? "https://remitlend.com"}/sitemap.xml`,
+  };
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://remitlend.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/lend`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/liquidations`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/kingdom`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+  ];
+}


### PR DESCRIPTION
Closes #993
Closes #994
Closes #995
Closes #1000

- **#994** (`indexerController.ts`): Adds `isPrivateHost()` guard before registering a webhook subscription. Blocks loopback (`127.x`, `localhost`, `::1`), link-local (`169.254.x`, `fe80:`), RFC 1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`), cloud metadata endpoints (`169.254.169.254`, `metadata.google.internal`), and unqualified single-label hostnames. Returns 400 with a clear message.

- **#1000** (`frontend/src/app/robots.ts`, `sitemap.ts`): Adds Next.js metadata route files. `robots.ts` allows crawling of public marketing pages and disallows all wallet-gated app routes and API paths. `sitemap.ts` lists public routes (home, lend, liquidations, kingdom) with appropriate priorities and change frequencies.