### PR TITLE
fix: repair red CI on main (backend tests + frontend amount conversion)

### DIFF
--- a/backend/src/services/__tests__/loanEndpoints.test.ts
+++ b/backend/src/services/__tests__/loanEndpoints.test.ts
@@ -1,50 +1,123 @@
-import { describe, it, expect } from "@jest/globals";
 import request from "supertest";
-import app from "../../app.js";
+import { jest } from "@jest/globals";
+import { Keypair } from "@stellar/stellar-sdk";
 
-const token = "test-token";
-const adminToken = "test-admin-token";
+type MockQueryResult = { rows: unknown[]; rowCount?: number };
 
-describe("POST /loans/:loanId/build-cancel", () => {
+const BORROWER = Keypair.random().publicKey();
+const ADMIN = Keypair.random().publicKey();
+
+// Configure auth before any module that reads these at import/sign time.
+process.env.JWT_SECRET = "test-jwt-secret-min-32-chars-long!!";
+process.env.ADMIN_WALLETS = ADMIN;
+
+// Loan fixtures keyed by the id used in the request path. PENDING satisfies
+// both the cancel (PENDING|OPEN) and reject (PENDING) guards.
+const loans: Record<string, { status: string; address: string }> = {
+  "loan-123": { status: "PENDING", address: BORROWER },
+  "completed-loan": { status: "COMPLETED", address: BORROWER },
+  "loan-1": { status: "PENDING", address: BORROWER },
+};
+
+const mockQuery: jest.MockedFunction<
+  (text: string, params?: unknown[]) => Promise<MockQueryResult>
+> = jest.fn(async (text: string, params?: unknown[]) => {
+  const loanId = params?.[0] as string | undefined;
+  const loan = loanId ? loans[loanId] : undefined;
+
+  // requireLoanOwner resolves the borrower from the unified loan_events view.
+  if (/from\s+loan_events/i.test(text)) {
+    return { rows: loan ? [{ address: loan.address }] : [] };
+  }
+  // Controllers load the loan row to check its status.
+  if (/from\s+loans\s+where\s+id/i.test(text)) {
+    return { rows: loan ? [{ id: loanId, status: loan.status }] : [] };
+  }
+  // audit_logs INSERT and anything else: no-op.
+  return { rows: [] };
+});
+
+jest.unstable_mockModule("../../db/connection.js", () => ({
+  default: { query: mockQuery },
+  query: mockQuery,
+  getClient: jest.fn(),
+  closePool: jest.fn(),
+  withTransaction: jest.fn(),
+}));
+
+// Keep Redis out of the test.
+jest.unstable_mockModule("../cacheService.js", () => ({
+  cacheService: {
+    get: jest.fn<() => Promise<null>>().mockResolvedValue(null),
+    set: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    delete: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    ping: jest.fn<() => Promise<string>>().mockResolvedValue("ok"),
+  },
+}));
+
+// Avoid real Stellar RPC; return a deterministic unsigned transaction.
+const mockBuildCancelLoanTx = jest
+  .fn<(borrower: string, loanId: string) => Promise<unknown>>()
+  .mockResolvedValue({
+    unsignedTxXdr: "AAAAcancel",
+    networkPassphrase: "Test",
+  });
+const mockBuildRejectLoanTx = jest
+  .fn<(admin: string, loanId: string, reason: string) => Promise<unknown>>()
+  .mockResolvedValue({
+    unsignedTxXdr: "AAAAreject",
+    networkPassphrase: "Test",
+  });
+
+jest.unstable_mockModule("../sorobanService.js", () => ({
+  sorobanService: {
+    buildCancelLoanTx: mockBuildCancelLoanTx,
+    buildRejectLoanTx: mockBuildRejectLoanTx,
+  },
+}));
+
+const { generateJwtToken } = await import("../authService.js");
+const { default: app } = await import("../../app.js");
+
+const borrowerAuth = `Bearer ${generateJwtToken(BORROWER)}`;
+const adminAuth = `Bearer ${generateJwtToken(ADMIN)}`;
+
+describe("POST /api/loans/:loanId/build-cancel", () => {
   it("should build cancel transaction", async () => {
     const response = await request(app)
-      .post("/loans/loan-123/build-cancel")
-      .set("Authorization", `Bearer ${token}`);
+      .post("/api/loans/loan-123/build-cancel")
+      .set("Authorization", borrowerAuth);
 
     expect(response.status).toBe(200);
-
     expect(response.body.transaction).toBeDefined();
   });
-});
 
-describe("POST /admin/loans/:loanId/build-reject", () => {
-  it("should build reject transaction", async () => {
+  it("should reject non-cancellable loans", async () => {
     const response = await request(app)
-      .post("/admin/loans/loan-123/build-reject")
-      .set("Authorization", `Bearer ${adminToken}`)
-      .send({
-        reason: "Insufficient collateral",
-      });
+      .post("/api/loans/completed-loan/build-cancel")
+      .set("Authorization", borrowerAuth);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
   });
 });
 
-it("should reject non-cancellable loans", async () => {
-  const response = await request(app)
-    .post("/loans/completed-loan/build-cancel")
-    .set("Authorization", `Bearer ${token}`);
+describe("POST /api/admin/loans/:loanId/build-reject", () => {
+  it("should build reject transaction", async () => {
+    const response = await request(app)
+      .post("/api/admin/loans/loan-123/build-reject")
+      .set("Authorization", adminAuth)
+      .send({ reason: "Insufficient collateral" });
 
-  expect(response.status).toBe(400);
-});
+    expect(response.status).toBe(200);
+    expect(response.body.transaction).toBeDefined();
+  });
 
-it("should fail if reason too short", async () => {
-  const response = await request(app)
-    .post("/admin/loans/loan-1/build-reject")
-    .set("Authorization", `Bearer ${adminToken}`)
-    .send({
-      reason: "bad",
-    });
+  it("should fail if reason too short", async () => {
+    const response = await request(app)
+      .post("/api/admin/loans/loan-1/build-reject")
+      .set("Authorization", adminAuth)
+      .send({ reason: "bad" });
 
-  expect(response.status).toBe(400);
+    expect(response.status).toBe(400);
+  });
 });

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -623,21 +623,23 @@ class NotificationService {
 
   private mapRow(row: Record<string, unknown>): Notification {
     const loanId = row.loan_id != null ? (row.loan_id as number) : undefined;
-    const actionUrl: string | null =
-      row.action_url != null ? (row.action_url as string) : null;
+    const actionUrl =
+      row.action_url != null ? (row.action_url as string) : undefined;
     const base = {
       id: row.id as number,
       userId: row.user_id as string,
       type: row.type as NotificationType,
       title: row.title as string,
       message: row.message as string,
-      actionUrl,
       read: row.read as boolean,
       status:
         (row.status as NotificationStatus) ?? (row.read ? "read" : "unread"),
       createdAt: new Date(row.created_at as string),
     };
-    return loanId !== undefined ? { ...base, loanId } : base;
+    // Keep optional fields omitted rather than null so the mapped shape is
+    // consistent (loanId is treated the same way).
+    const withLoan = loanId !== undefined ? { ...base, loanId } : base;
+    return actionUrl !== undefined ? { ...withLoan, actionUrl } : withLoan;
   }
 }
 

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -343,6 +343,12 @@ export class WebhookService {
           payload: Record<string, unknown>;
           attempt_count: number;
         };
+        // Defensive circuit breaker: the SQL filter above already excludes
+        // deliveries at the retry ceiling, but guard here too so a delivery
+        // at MAX_RETRY_ATTEMPTS is never re-sent even if it slips through.
+        if (delivery.attempt_count >= MAX_RETRY_ATTEMPTS) {
+          continue;
+        }
         await WebhookService.retryWebhookDelivery(
           delivery.id,
           delivery.subscription_id,

--- a/frontend/src/app/utils/amount.ts
+++ b/frontend/src/app/utils/amount.ts
@@ -61,7 +61,10 @@ export function toStroops(value: string, decimals = STROOP_DECIMALS): bigint | n
   const normalizedFraction = fraction.padEnd(decimals, "0");
 
   try {
-    return BigInt(whole || "0") * BigInt(STROOP_SCALE) + BigInt(normalizedFraction || "0");
+    // Scale by the requested precision, not the fixed 7-decimal stroop scale,
+    // so non-XLM assets (e.g. 2-decimal USDC) convert correctly.
+    const scale = BigInt(10) ** BigInt(decimals);
+    return BigInt(whole || "0") * scale + BigInt(normalizedFraction || "0");
   } catch {
     return null;
   }


### PR DESCRIPTION
## Why

`main` has been failing the **backend** and **frontend** CI jobs on every merge since May 29 (last green run was May 27). Contributors branching off `main` inherit a red pipeline. The contracts, env-docs, and supply-chain jobs are unaffected.

CI showed 6 failing backend tests and 1 failing frontend test. This PR fixes all of them.

## Fixes

1. **`webhookService.processRetries`** — add a defensive circuit-breaker guard so a delivery already at `MAX_RETRY_ATTEMPTS` is never re-sent even if it slips past the SQL filter. Fixes *"does not pick up deliveries at max attempts (circuit open)"*.

2. **`loanEndpoints` build-cancel / build-reject test** — the test shipped broken: it posted to `/loans/...` and `/admin/loans/...` (missing the `/api` prefix) with fake tokens and no dependency mocks, so every request returned 404. Rewrote it against the real `/api` routes with a proper db / sorobanService / cache mock harness and JWTs minted for the loan owner and an admin wallet. Now exercises the real cancel/reject endpoints (200 happy paths, 400 for non-cancellable loan and too-short reason).

3. **`notificationService.mapRow`** — map an absent `action_url` to `undefined` and omit it, matching how `loanId` is already handled, so the mapped shape is consistent. Fixes *"returns null actionUrl when neither loanId nor actionUrl provided"*. The frontend does not reference `actionUrl`, so the serialized-shape change is safe.

4. **`amount.toStroops`** — scale the whole part by `10 ** decimals` instead of the fixed `10 ** 7` stroop scale, so non-XLM assets convert correctly. `toStroops("12.34", 2)` now yields `1234` instead of `120000034`.

## Verification (local)

- **Backend**: 369 passed / 18 skipped; `lint`, `typecheck`, `build` clean.
- **Frontend**: 68 passed; `lint`, `typecheck`, `build` clean.

## Note

PR #1048 (`fix/express5-validation-and-ci-green`) targeted the same goal but is now ~57 commits behind `main` and conflicting, so its CI can't even run. This branch is cut fresh from current `main` and supersedes it.