### PR TITLE
fix(ci): use lowercase owner in Trivy image-ref so staging scan can run

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (HIGH - warn)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ghcr.io/${{ github.repository_owner }}/remitlend-backend:staging-${{ github.sha }}'
+          image-ref: 'ghcr.io/${{ env.OWNER_LC }}/remitlend-backend:staging-${{ github.sha }}'
           format: 'table'
           severity: 'HIGH'
           exit-code: '0'
@@ -73,7 +73,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (CRITICAL - fail)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ghcr.io/${{ github.repository_owner }}/remitlend-backend:staging-${{ github.sha }}'
+          image-ref: 'ghcr.io/${{ env.OWNER_LC }}/remitlend-backend:staging-${{ github.sha }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL'


### PR DESCRIPTION
## Why

The **Deploy Staging** workflow (the remaining red check on `main`) fails on every push at the Trivy scan:

```
FATAL  run error: image scan error: ... failed to parse the image name:
could not parse reference: ghcr.io/LabsCrypt/remitlend-backend:staging-<sha>
```

The images are built and pushed with `${{ env.OWNER_LC }}` (lowercase, as OCI requires), but the two Trivy steps referenced the image via `${{ github.repository_owner }}` = `LabsCrypt` (capitals). OCI image references must be lowercase, so Trivy can't parse the reference, exits 1, the CRITICAL step is skipped, and the upload step fails with `Path does not exist: trivy-results.sarif`.

## Fix

Point both Trivy `image-ref` values at `${{ env.OWNER_LC }}` so they match the pushed tags and the scan can actually run.

## Note on verification

This workflow only triggers on `push` to `main`, so it can't run on this PR — it'll first execute on the post-merge run on `main`. The change is isolated to the Deploy Staging workflow and cannot affect the PR-gating RemitLend CI job.