### PR TITLE
fix(backend): drop lockfile from prod image to clear false Trivy critical

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,9 +18,12 @@ FROM node:22-alpine AS production
 
 WORKDIR /app
 
-# Install only production dependencies
+# Install only production dependencies. Drop the lockfile afterwards: it is a
+# build-time artifact, not needed at runtime, and if left in the image the
+# container scanner reads it and reports devDependency advisories (e.g. a
+# critical in handlebars) for packages that are never actually installed here.
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && rm -f package-lock.json
 
 # Copy compiled output from builder
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Why

With the Trivy image-ref now fixed (#1050), the **Deploy Staging** CRITICAL gate runs and fails on a `handlebars` advisory. But `handlebars` is a **devDependency** — the production stage installs prod-only deps (`npm ci --omit=dev`), so it is never actually in the image.

The failure comes from `package-lock.json`: it is copied in for `npm ci` and then left in the image. Trivy reads the lockfile's full dependency tree (including devDependencies) and reports their advisories against the image, even though those packages aren't installed.

## Fix

Remove the lockfile after install:

```dockerfile
RUN npm ci --omit=dev && rm -f package-lock.json
```

It's a build-time artifact with no runtime purpose. Dropping it makes the scan reflect what's actually installed (production deps only). The remaining `axios` advisories are HIGH, which the warn-only Trivy step reports without failing the build.

## Verification

Deploy Staging only runs on push to `main`, so it can't run on this PR — it'll execute on the post-merge run. Change is limited to the backend production Docker stage; it does not affect the PR-gating RemitLend CI job or the app at runtime.