### PR TITLE
fix(ci): Trivy CRITICAL gate should fail only on critical vulns

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -78,6 +78,12 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL'
           exit-code: '1'
+          # Without this, trivy-action builds the SARIF with ALL severities and
+          # the exit-code then trips on any vulnerability (e.g. the existing
+          # HIGH axios advisories) — not just CRITICAL as the step intends.
+          # Limiting the report to the requested severity makes the gate fail
+          # only on genuine CRITICAL findings.
+          limit-severities-for-sarif: 'true'
           trivyignores: '.trivyignore'
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
## Why

The **Deploy Staging** `CRITICAL - fail` Trivy step uses `format: sarif`. With SARIF output the trivy-action builds the report with **all** severities (`Building SARIF report with all severities` in the logs), so `exit-code: 1` trips on **any** vulnerability present — the existing HIGH `axios` advisories — rather than on CRITICAL findings as the step name and `severity: CRITICAL` intend.

There are **no critical vulnerabilities** in the image (the uploaded SARIF tops out at HIGH: axios, minimatch, brace-expansion, etc.), so the deploy fails on a gate that should pass.

This was masked until now because the scan never actually ran (image-ref casing, #1050) — fixing that exposed the misconfigured gate.

## Fix

Add `limit-severities-for-sarif: 'true'` so the scan and the `exit-code` honour the `severity: CRITICAL` filter and the gate fails only on genuine CRITICAL findings. HIGH advisories are still surfaced by the warn-only step above.

## Verification

Deploy Staging is push-to-main only, so this runs on the post-merge run, not the PR. Change is limited to the workflow; it does not touch the PR-gating RemitLend CI.