### PR TITLE
fix(backend): correct off-by-one in isValidStellarAddress regex

### DIFF
--- a/backend/src/utils/stellar.ts
+++ b/backend/src/utils/stellar.ts
@@ -33,7 +33,7 @@ export function isValidStellarAddress(address: unknown): address is string {
   // Stellar public keys are exactly 56 characters, start with 'G'
   if (address.length !== 56 || !address.startsWith("G")) return false;
   // Check if it's valid base32 (only contains A-Z and 2-7)
-  return /^G[A-Z2-7]{54}$/.test(address);
+  return /^G[A-Z2-7]{55}$/.test(address);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the off-by-one error in  regex in .

## The Bug

The regex  only matches 55 characters total (G + 54 chars), but Stellar public keys are 56 characters (G + 55 chars). The preceding length check on line 33 correctly requires , so the regex was never able to match any valid address — the function was rejecting all valid Stellar addresses.

## The Fix

Changed  →  in the regex, matching the implementation already used in  and .

## Verification

```js
addr = 'GBUQWP3BOUZX34ULNQG23RQ6F4BVWCIBTLFL2F7HVRQG5LDHNWY2QTWA' // len 56
/^G[A-Z2-7]{54}$/.test(addr) === false  // was: always fail
/^G[A-Z2-7]{55}$/.test(addr) === true   // now: correct
```

## Acceptance criteria (issue #1011)

- [x] Change the regex from {54} to {55}
- [x] Add a unit test asserting a real 56-char G... address returns true (already exists in  at line 18)
- [x] Confirm `assertValidStellarAddress` no longer throws for valid input

Fixes #1011