### PR TITLE
fix(backend): unbreak main RemitLend CI on app.ts prettier

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -145,7 +145,8 @@ app.get("/version", (_req: Request, res: Response) => {
       loanManager: process.env.LOAN_MANAGER_CONTRACT_ID ?? "unknown",
       lendingPool: process.env.LENDING_POOL_CONTRACT_ID ?? "unknown",
       remittanceNft: process.env.REMITTANCE_NFT_CONTRACT_ID ?? "unknown",
-      multisigGovernance: process.env.MULTISIG_GOVERNANCE_CONTRACT_ID ?? "unknown",
+      multisigGovernance:
+        process.env.MULTISIG_GOVERNANCE_CONTRACT_ID ?? "unknown",
     },
   });
 });


### PR DESCRIPTION
## Summary
`backend/src/app.ts:148` exceeds the prettier printWidth after the `/version` endpoint was merged in #977. Every PR since has been failing the backend lint step on this one line. Wrap the `multisigGovernance` assignment so the lint step passes.

## Verification
```
cd backend && npx prettier --check src/app.ts
```
clean after the change.