### PR TITLE
infra: add frontend/.dockerignore

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+.env
+.env.*
+*.log
+coverage
+.DS_Store


### PR DESCRIPTION
Closes #1076

### What does this PR do?

Adds `frontend/.dockerignore` to prevent local `node_modules`, `.next`, `.git`, `.env*` files, logs, coverage, and `.DS_Store` from being sent to the Docker build context and baked into the image.

Entries are consistent with the existing `backend/.dockerignore` where applicable.

### How did you verify your code works?

Verified the file content matches the acceptance criteria in #1076 and is consistent with the existing backend/.dockerignore patterns.