### PR TITLE
Fix: CI migration coverage, stale docs, ui-demo gaps, cn() duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,23 @@ jobs:
           INTERNAL_API_KEY: test_internal_api_key
           FRONTEND_URL: https://frontend.example.com
 
+  migration-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            migrations:
+              - 'backend/migrations/**'
+              - 'backend/package.json'
+
   migration-check:
-    needs: supply-chain-audit
+    needs: [supply-chain-audit, migration-paths]
+    if: github.event_name == 'push' || needs.migration-paths.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -97,7 +112,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: backend
-      - name: Run full migration set against empty database
+      - name: Migrate up from empty schema
+        run: npm run migrate:up
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://pguser:pgpass@localhost:5432/remitlend_test
+      - name: Migrate all the way down (reversibility check)
+        run: |
+          # Count migrations and roll them all back one by one
+          MIGRATION_COUNT=$(ls migrations/*.js 2>/dev/null | wc -l)
+          for i in $(seq 1 "$MIGRATION_COUNT"); do
+            npm run migrate:down -- --count 1
+          done
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://pguser:pgpass@localhost:5432/remitlend_test
+      - name: Migrate up again (ordering + idempotency check)
         run: npm run migrate:up
         working-directory: backend
         env:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,372 +6,309 @@ Next.js web application for the RemitLend platform, providing user interfaces fo
 
 The frontend is a modern React application built with Next.js that enables:
 
-- Wallet connection (Freighter, Albedo, etc.)
-- Credit score visualization
+- Wallet connection via Freighter
+- Credit score visualisation
 - Remittance NFT minting
 - Loan request and management
 - Lending pool participation
 - Real-time transaction tracking
+- Notifications and activity streams
 
 ## Tech Stack
 
-- **Framework**: Next.js 16 (App Router)
-- **React**: 19.2.3
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS 4
-- **Wallet Integration**: Stellar Wallet Kit (planned)
-- **State Management**: React hooks + Context API (planned)
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router) |
+| React | 19.2.3 |
+| Language | TypeScript |
+| Styling | Tailwind CSS 4 (`@import "tailwindcss"` in globals.css, no config file) |
+| State management | Zustand 5 |
+| Server state / caching | TanStack React Query 5 |
+| Wallet integration | `@stellar/freighter-api` |
+| Blockchain SDK | `@stellar/stellar-sdk` |
+| Internationalisation | next-intl 4 (locales: `en`, `es`, `tl`) |
+| Charts | Recharts |
+| Animation | Framer Motion |
+| Notifications | Sonner |
+| Monitoring | Sentry |
+| PWA | Serwist |
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 18 or higher
-- npm or yarn
-- Stellar wallet (Freighter recommended)
+- npm
+- Freighter browser extension (for wallet features)
 
 ### Installation
 
 ```bash
-# Install dependencies
 npm install
-
-# Start development server
 npm run dev
 ```
-
-### Access the Application
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Available Scripts
 
 ```bash
-# Development
 npm run dev          # Start dev server with hot reload
-
-# Production
-npm run build        # Build for production
-npm start            # Run production build
-
-# Code Quality
-npm run lint         # Check code quality with ESLint
+npm run build        # Production build
+npm start            # Serve production build
+npm run lint         # Check formatting with Prettier (not ESLint)
+npm run format       # Auto-format with Prettier
+npm run typecheck    # TypeScript type check (tsc --noEmit)
+npm test             # Jest unit tests
+npm run test:watch   # Jest in watch mode
+npm run test:e2e     # Playwright end-to-end tests
+npm run audit:a11y   # Build then run axe-playwright accessibility audit
 ```
+
+> **Note:** `npm run lint` runs `prettier --check` — it checks formatting, not ESLint rules.
+> ESLint runs automatically via `lint-staged` on pre-commit.
 
 ## Project Structure
 
 ```
 frontend/
+├── e2e/                        # Playwright end-to-end tests
+│   ├── borrower-loan-flow.spec.ts
+│   ├── criticalFlows.spec.ts
+│   └── ...
+├── messages/                   # next-intl translation files
+│   ├── en.json
+│   ├── es.json
+│   └── tl.json
 ├── src/
-│   └── app/                    # Next.js App Router
-│       ├── components/         # React components
-│       │   └── global_ui/     # Reusable UI components
-│       │       └── Spinner.tsx
-│       ├── layout.tsx         # Root layout
-│       ├── page.tsx           # Home page
-│       ├── not-found.tsx      # 404 page
-│       ├── globals.css        # Global styles
-│       └── favicon.ico
-├── public/                     # Static assets
-│   ├── og-image.png
-│   └── *.svg
-├── next.config.ts             # Next.js configuration
-├── tailwind.config.ts         # Tailwind CSS configuration
-├── tsconfig.json              # TypeScript configuration
-├── package.json
-└── README.md
-```
-
-## Features
-
-### Current Features
-
-- Landing page with project overview
-- Responsive design for mobile and desktop
-- Loading states with spinner component
-- SEO optimization with metadata
-- Custom 404 page
-
-### Planned Features
-
-#### Borrower Dashboard
-
-- [ ] Wallet connection interface
-- [ ] Credit score display
-- [ ] Remittance NFT minting
-- [ ] Loan request form
-- [ ] Active loans management
-- [ ] Repayment interface
-- [ ] Transaction history
-
-#### Lender Dashboard
-
-- [ ] Pool liquidity overview
-- [ ] Deposit/withdraw interface
-- [ ] Loan approval queue
-- [ ] Yield tracking
-- [ ] Portfolio analytics
-
-#### Shared Features
-
-- [ ] Real-time transaction status
-- [ ] Notification system
-- [ ] Multi-language support
-- [ ] Dark mode toggle
-- [ ] Wallet balance display
-
-## Component Library
-
-### Global UI Components
-
-#### Spinner
-
-Loading indicator component.
-
-```tsx
-import { Spinner } from "@/app/components/global_ui/Spinner";
-
-<Spinner size="md" />;
-```
-
-**Props:**
-
-- `size`: 'sm' | 'md' | 'lg' (default: 'md')
-
-### Planned Components
-
-- `Button` - Reusable button with variants
-- `Card` - Container component
-- `Modal` - Dialog component
-- `Input` - Form input with validation
-- `WalletConnect` - Wallet connection button
-- `TransactionStatus` - Transaction feedback
-- `LoanCard` - Loan information display
-- `PoolStats` - Pool statistics display
-
-## Styling
-
-### Tailwind CSS
-
-The project uses Tailwind CSS 4 for styling with a custom configuration.
-
-**Key Features:**
-
-- Utility-first CSS
-- Responsive design utilities
-- Custom color palette (planned)
-- Dark mode support (planned)
-
-**Example:**
-
-```tsx
-<div className="flex items-center justify-center min-h-screen bg-gray-50">
-  <h1 className="text-4xl font-bold text-gray-900">Welcome to RemitLend</h1>
-</div>
-```
-
-### Global Styles
-
-Global styles are defined in `src/app/globals.css`:
-
-- CSS reset
-- Tailwind directives
-- Custom CSS variables
-- Typography defaults
-
-## Wallet Integration
-
-### Stellar Wallet Kit (Planned)
-
-Integration with Stellar wallets for transaction signing.
-
-**Supported Wallets:**
-
-- Freighter
-- Albedo
-- Rabet
-- xBull
-
-**Example Usage:**
-
-```tsx
-import { StellarWalletKit } from "@stellar/wallet-kit";
-
-const kit = new StellarWalletKit({
-  network: "testnet",
-  selectedWallet: "freighter",
-});
-
-// Connect wallet
-await kit.connect();
-
-// Sign transaction
-const signedTx = await kit.sign(transaction);
-```
-
-## State Management
-
-### React Context (Planned)
-
-Global state management using React Context API.
-
-**Contexts:**
-
-- `WalletContext` - Wallet connection state
-- `UserContext` - User profile and credit score
-- `LoanContext` - Active loans data
-- `PoolContext` - Lending pool information
-
-**Example:**
-
-```tsx
-import { useWallet } from "@/contexts/WalletContext";
-
-function MyComponent() {
-  const { address, connected, connect, disconnect } = useWallet();
-
-  return (
-    <button onClick={connected ? disconnect : connect}>
-      {connected ? `Connected: ${address}` : "Connect Wallet"}
-    </button>
-  );
-}
-```
-
-## API Integration
-
-### Backend API
-
-The frontend communicates with the Express backend for off-chain data.
-
-**Base URL:** `http://localhost:3001/api`
-
-**Example:**
-
-```tsx
-async function fetchCreditScore(userId: string) {
-  const response = await fetch(`http://localhost:3001/api/score/${userId}`);
-  const data = await response.json();
-  return data.score;
-}
-```
-
-### Blockchain Integration
-
-Direct interaction with Soroban smart contracts via Stellar SDK.
-
-**Example:**
-
-```tsx
-import { Contract, SorobanRpc } from "@stellar/stellar-sdk";
-
-const contract = new Contract(contractId);
-const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
-
-// Call contract method
-const result = await contract.call("get_score", [nftId]);
+│   └── app/
+│       ├── [locale]/           # Localised routes (en / es / tl)
+│       │   ├── layout.tsx
+│       │   ├── page.tsx        # Landing page
+│       │   ├── globals.css     # Tailwind 4 entry + CSS custom properties
+│       │   ├── loans/          # Borrower loan list + [loanId] detail
+│       │   ├── lend/           # Lender dashboard
+│       │   ├── wallet/         # Wallet connection & balance
+│       │   ├── remittances/    # Remittance NFT viewer
+│       │   ├── send-remittance/
+│       │   ├── request-loan/
+│       │   ├── repay/
+│       │   ├── notifications/
+│       │   ├── analytics/
+│       │   ├── activity/
+│       │   ├── settings/
+│       │   ├── liquidations/
+│       │   ├── kingdom/
+│       │   ├── admin/          # Admin governance
+│       │   └── ui-demo/        # Dev-only component gallery (404 in production)
+│       ├── components/
+│       │   ├── ui/             # Design-system primitives (22 components)
+│       │   ├── global_ui/      # App-shell components (Spinner, ErrorBoundary …)
+│       │   ├── borrower/
+│       │   ├── lender/
+│       │   └── remittance/
+│       ├── stores/             # Zustand stores
+│       │   ├── useWalletStore.ts
+│       │   ├── useUserStore.ts
+│       │   ├── useThemeStore.ts
+│       │   ├── useUIStore.ts
+│       │   ├── useToastStore.ts
+│       │   └── useGamificationStore.ts
+│       ├── hooks/              # Custom React hooks
+│       ├── lib/                # API clients and utilities
+│       └── utils/              # Pure helpers (cn, stellar, amount, csv …)
+├── i18n.config.ts
+├── next.config.ts
+├── postcss.config.mjs
+├── playwright.config.ts
+├── jest.config.js
+├── tsconfig.json
+└── package.json
 ```
 
 ## Routing
 
-### App Router Structure
+All pages are nested under the `[locale]` segment, so every URL is prefixed with the active locale:
 
-Next.js 13+ App Router with file-based routing.
+| Route | Description |
+|---|---|
+| `/[locale]` | Landing page |
+| `/[locale]/wallet` | Wallet connection |
+| `/[locale]/loans` | Loan list |
+| `/[locale]/loans/[loanId]` | Loan detail |
+| `/[locale]/lend` | Lender dashboard |
+| `/[locale]/request-loan` | New loan request |
+| `/[locale]/repay` | Repayment flow |
+| `/[locale]/remittances` | Remittance NFT gallery |
+| `/[locale]/send-remittance` | Send remittance |
+| `/[locale]/notifications` | Notification inbox |
+| `/[locale]/activity` | Activity log |
+| `/[locale]/analytics` | Analytics dashboard |
+| `/[locale]/settings` | User settings |
+| `/[locale]/liquidations` | Liquidation queue |
+| `/[locale]/kingdom` | Gamification / Kingdom view |
+| `/[locale]/admin` | Governance admin |
+| `/[locale]/ui-demo` | Dev-only component gallery |
+| `/[locale]/not-found` | 404 page |
 
-**Current Routes:**
+## State Management
 
-- `/` - Landing page
-- `/404` - Not found page
+Global state is managed with **Zustand 5** stores:
 
-**Planned Routes:**
+| Store | Responsibility |
+|---|---|
+| `useWalletStore` | Freighter wallet connection, public key, signing |
+| `useUserStore` | User profile and credit score |
+| `useThemeStore` | Light / dark / system theme with `localStorage` persistence |
+| `useUIStore` | Modal and sidebar open/close state |
+| `useToastStore` | Toast queue used by `useToast` hook |
+| `useGamificationStore` | Kingdom / XP state |
 
-- `/borrower` - Borrower dashboard
-- `/lender` - Lender dashboard
-- `/loans` - Loan management
-- `/loans/[id]` - Loan details
-- `/pool` - Pool overview
-- `/profile` - User profile
+TanStack React Query handles server-state caching and background refetching for all API calls.
 
-## SEO & Metadata
+## Wallet Integration
 
-### Metadata Configuration
-
-```tsx
-export const metadata = {
-  title: "RemitLend - Credit from Remittances",
-  description: "Turn your remittance history into credit history",
-  openGraph: {
-    title: "RemitLend",
-    description: "Decentralized lending for migrant workers",
-    images: ["/og-image.png"],
-  },
-};
-```
-
-## Performance Optimization
-
-### Next.js Features
-
-- **Static Generation**: Pre-render pages at build time
-- **Image Optimization**: Automatic image optimization
-- **Code Splitting**: Automatic code splitting per route
-- **Font Optimization**: Automatic font optimization
-
-### Best Practices
-
-- Use `next/image` for images
-- Implement lazy loading for heavy components
-- Minimize client-side JavaScript
-- Use server components when possible
-- Implement proper caching strategies
-
-## Testing (Planned)
-
-### Testing Stack
-
-- **Unit Tests**: Jest + React Testing Library
-- **E2E Tests**: Playwright or Cypress
-- **Component Tests**: Storybook
-
-### Example Test
+Wallet integration uses **`@stellar/freighter-api`**:
 
 ```tsx
-import { render, screen } from "@testing-library/react";
-import { Spinner } from "@/app/components/global_ui/Spinner";
+import { isConnected, getPublicKey, signTransaction } from "@stellar/freighter-api";
 
-describe("Spinner", () => {
-  it("renders spinner", () => {
-    render(<Spinner />);
-    expect(screen.getByRole("status")).toBeInTheDocument();
-  });
-});
+const connected = await isConnected();
+const publicKey = await getPublicKey();
+const signedXdr = await signTransaction(xdr, { networkPassphrase });
 ```
+
+Wallet state (public key, connection status) is managed by `useWalletStore`.
+
+## Component Library
+
+Design-system primitives live in [`src/app/components/ui/`](src/app/components/ui/). There are 22 components:
+
+### Core primitives
+
+| Component | Props | Description |
+|---|---|---|
+| `Button` | `variant` (`primary`\|`secondary`\|`outline`\|`ghost`\|`danger`), `size` (`sm`\|`md`\|`lg`\|`icon`), `isLoading`, `leftIcon`, `rightIcon` | Polymorphic button with loading spinner |
+| `Input` | `label`, `error`, `helperText`, `leftIcon`, `rightIcon` | Labelled text input with accessible error/helper text |
+| `Card` / `CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter` | `className` | Compound card layout |
+| `Modal` | `isOpen`, `onClose`, `title`, `size` (`sm`\|`md`\|`lg`\|`xl`), `ariaLabel` | Focus-trapped animated dialog |
+
+### Feedback & status
+
+| Component | Props | Description |
+|---|---|---|
+| `Skeleton` / `SkeletonText` / `SkeletonCard` / `SkeletonRow` / `SkeletonChart` / `SkeletonAvatar` | `className`, `lines` (SkeletonText) | Loading placeholders |
+| `EmptyState` | `icon`, `title`, `description`, `actionLabel`, `actionHref` \| `onAction`, `actionIcon` | Zero-state placeholder with optional CTA |
+| `StatusIndicator` | `label`, `tone` (`success`\|`danger`\|`warning`\|`info`\|`neutral`), `icon`, `iconOnly` | Coloured badge pill |
+| `LoanStatusBadge` | `status` (`active`\|`pending`\|`repaid`\|`defaulted`\|`liquidated`) | Domain-specific status badge |
+| `Toast` / `Toaster` | — | Toast notification components backed by `useToastStore` |
+
+### Controls & utilities
+
+| Component | Props | Description |
+|---|---|---|
+| `Tooltip` | `content`, `label`, `iconClassName` | Hover/focus tooltip with info icon |
+| `PaginationControls` | `currentPage`, `totalPages`, `hasPrevious`, `hasNext`, `onPageChange`, `onPrevious`, `onNext`, `summary` | Page navigation with ellipsis windowing |
+| `CopyButton` | `value` | Clipboard copy with check feedback |
+| `TxHashLink` | `txHash`, `chars` | Truncated hash with copy + Stellar Explorer link |
+| `ThemeToggle` | — | Light / dark / system switcher |
+| `ConfirmTransactionDialog` | — | Pre-submit transaction confirmation modal |
+| `OperationProgress` | — | Multi-step operation stepper |
+| `RepaymentProgress` | — | Loan repayment progress bar |
+| `LoanTimeline` | — | Chronological loan event list |
+| `TransactionStatusTracker` | — | Live transaction polling status |
+| `CreditScoreGauge` | — | Circular credit score visualisation |
+| `CreditScoreBreakdown` | — | Score factor breakdown chart |
+
+> A live, interactive gallery is available in development at `/[locale]/ui-demo` (returns 404 in production).
+
+## Styling
+
+Tailwind CSS 4 is configured via CSS-first `@import "tailwindcss"` in
+[`src/app/[locale]/globals.css`](src/app/%5Blocale%5D/globals.css) — there is no
+`tailwind.config.ts` file. Design tokens are declared as CSS custom properties in `:root`:
+
+```css
+@import "tailwindcss";
+
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+  --focus-ring: #2563eb;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+```
+
+Dark mode is driven by the `.dark` class (set by `useThemeStore`) and also respects
+`prefers-color-scheme`.
+
+## Testing
+
+### Unit tests — Jest + React Testing Library
+
+```bash
+npm test            # run once
+npm run test:watch  # interactive watch mode
+```
+
+Test files sit alongside source files (`*.test.ts` / `*.test.tsx`). Key test suites:
+
+- `src/app/stores/stores.test.ts` — Zustand store logic
+- `src/app/utils/*.test.ts` — pure utility functions
+- `src/app/components/**/*.test.tsx` — component rendering
+
+### End-to-end tests — Playwright
+
+```bash
+npm run test:e2e
+```
+
+Specs live in `e2e/` and cover critical user flows:
+
+- `borrower-loan-flow.spec.ts`
+- `borrower-repay-flow.spec.ts`
+- `lender-withdraw-flow.spec.ts`
+- `notifications-inbox.spec.ts`
+- `remittance-nft-viewer.spec.ts`
+- `admin-governance.spec.ts`
+- `criticalFlows.spec.ts`
+
+### Accessibility audit
+
+```bash
+npm run audit:a11y   # builds then runs axe-playwright
+```
+
+## API Integration
+
+The frontend talks to the Express backend for off-chain data and uses `@stellar/stellar-sdk`
+directly for on-chain calls.
+
+**Backend base URL:** `NEXT_PUBLIC_API_URL` (default: `http://localhost:3001`)
 
 ## Deployment
 
-### Vercel (Recommended)
+### Vercel (recommended)
 
 ```bash
-# Install Vercel CLI
 npm i -g vercel
-
-# Deploy
 vercel
 ```
 
 ### Docker
 
 ```bash
-# Build image
 docker build -t remitlend-frontend .
-
-# Run container
 docker run -p 3000:3000 remitlend-frontend
 ```
 
 ### Environment Variables
-
-Create `.env.local` for local development:
 
 ```env
 NEXT_PUBLIC_API_URL=http://localhost:3001
@@ -379,87 +316,28 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 ```
 
-## Accessibility
-
-### WCAG Compliance
-
-The application aims for WCAG 2.1 Level AA compliance:
-
-- Semantic HTML elements
-- ARIA labels where needed
-- Keyboard navigation support
-- Color contrast ratios
-- Screen reader compatibility
-
-**Note:** Full WCAG compliance requires manual testing with assistive technologies.
-
-## Browser Support
-
-- Chrome (latest 2 versions)
-- Firefox (latest 2 versions)
-- Safari (latest 2 versions)
-- Edge (latest 2 versions)
-
-## Contributing
-
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
-
-### Code Style
-
-- Use functional components with hooks
-- Prefer TypeScript interfaces over types
-- Use descriptive component names
-- Keep components small and focused
-- Extract reusable logic into custom hooks
-- Follow Next.js best practices
-
-### Before Submitting PR
-
-```bash
-npm run lint
-npm run build
-```
-
 ## Troubleshooting
 
-### Port Already in Use
-
 ```bash
-# Kill process on port 3000
+# Port in use
 lsof -ti:3000 | xargs kill -9
-```
 
-### Build Errors
+# Stale Next.js cache
+rm -rf .next/ && npm run build
 
-```bash
-# Clean Next.js cache
-rm -rf .next/
-npm run build
-```
-
-### Module Not Found
-
-```bash
 # Reinstall dependencies
-rm -rf node_modules package-lock.json
-npm install
+rm -rf node_modules package-lock.json && npm install
 ```
 
 ## Resources
 
 - [Next.js Documentation](https://nextjs.org/docs)
-- [React Documentation](https://react.dev)
-- [Tailwind CSS Documentation](https://tailwindcss.com/docs)
+- [Tailwind CSS v4 Documentation](https://tailwindcss.com/docs)
+- [Zustand Documentation](https://zustand.docs.pmnd.rs)
+- [TanStack React Query](https://tanstack.com/query/latest)
 - [Stellar Documentation](https://developers.stellar.org)
-- [Soroban Documentation](https://soroban.stellar.org/docs)
+- [next-intl Documentation](https://next-intl-docs.vercel.app)
 
 ## License
 
-ISC License - See LICENSE file for details.
-
-## Support
-
-- Open an issue for bug reports
-- Check existing issues before creating new ones
-- Provide browser and OS information
-- Include screenshots for UI issues
+ISC License — see LICENSE file for details.

--- a/frontend/src/app/[locale]/ui-demo/page.tsx
+++ b/frontend/src/app/[locale]/ui-demo/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// This route is intentionally gated from production — it is a development-only
+// component gallery. If accidentally shipped, requests are bounced to 404.
+import { notFound } from "next/navigation";
 import React, { useState } from "react";
 import { Button } from "../../components/ui/Button";
 import { Input } from "../../components/ui/Input";
@@ -12,11 +15,32 @@ import {
   CardFooter,
 } from "../../components/ui/Card";
 import { Modal } from "../../components/ui/Modal";
-import { Search, Mail, Lock, User, Terminal, ChevronRight } from "lucide-react";
+import { Skeleton, SkeletonText, SkeletonCard, SkeletonRow } from "../../components/ui/Skeleton";
+import { EmptyState } from "../../components/ui/EmptyState";
+import { StatusIndicator } from "../../components/ui/StatusIndicator";
+import { LoanStatusBadge } from "../../components/ui/LoanStatusBadge";
+import { Tooltip } from "../../components/ui/Tooltip";
+import { PaginationControls } from "../../components/ui/PaginationControls";
+import { CopyButton } from "../../components/ui/CopyButton";
+import { ThemeToggle } from "../../components/ui/ThemeToggle";
+import {
+  Search,
+  Mail,
+  Lock,
+  User,
+  Terminal,
+  ChevronRight,
+  Inbox,
+  FileQuestion,
+} from "lucide-react";
 
 export default function UIDemoPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [currentPage, setCurrentPage] = useState(3);
+  const totalPages = 10;
 
   const handleAction = () => {
     setIsLoading(true);
@@ -26,21 +50,22 @@ export default function UIDemoPage() {
   return (
     <div className="min-h-screen bg-gray-50 p-8 dark:bg-zinc-950">
       <div className="mx-auto max-w-5xl space-y-12">
-        <section className="space-y-4">
-          <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-zinc-50">
-            UI Component Library
-          </h1>
+        <section className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-zinc-50">
+              UI Component Library
+            </h1>
+            <ThemeToggle />
+          </div>
           <p className="text-lg text-gray-500 dark:text-zinc-400">
-            A boutique collection of reusable atomic components for RemitLend.
+            Development-only gallery — not shipped to production. Covers all 22 components in{" "}
+            <code className="text-sm">src/app/components/ui/</code>.
           </p>
         </section>
 
         {/* Buttons */}
         <section className="space-y-6">
-          <div className="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-zinc-200">
-            <ChevronRight className="text-blue-500" />
-            <h2>Buttons</h2>
-          </div>
+          <SectionHeading>Button</SectionHeading>
           <Card>
             <CardContent className="pt-6">
               <div className="flex flex-wrap gap-4">
@@ -66,6 +91,7 @@ export default function UIDemoPage() {
                 <Button rightIcon={<ChevronRight size={16} />} variant="secondary">
                   Next Step
                 </Button>
+                <Button disabled>Disabled</Button>
               </div>
             </CardContent>
           </Card>
@@ -73,10 +99,7 @@ export default function UIDemoPage() {
 
         {/* Inputs */}
         <section className="space-y-6">
-          <div className="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-zinc-200">
-            <ChevronRight className="text-blue-500" />
-            <h2>Inputs</h2>
-          </div>
+          <SectionHeading>Input</SectionHeading>
           <Card>
             <CardContent className="space-y-6 pt-6">
               <div className="grid gap-6 md:grid-cols-2">
@@ -107,10 +130,7 @@ export default function UIDemoPage() {
 
         {/* Cards */}
         <section className="space-y-6">
-          <div className="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-zinc-200">
-            <ChevronRight className="text-blue-500" />
-            <h2>Cards</h2>
-          </div>
+          <SectionHeading>Card</SectionHeading>
           <div className="grid gap-6 md:grid-cols-2">
             <Card>
               <CardHeader>
@@ -156,22 +176,15 @@ export default function UIDemoPage() {
         </section>
 
         {/* Modals */}
-        <section className="space-y-6 pb-12">
-          <div className="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-zinc-200">
-            <ChevronRight className="text-blue-500" />
-            <h2>Modals</h2>
-          </div>
+        <section className="space-y-6">
+          <SectionHeading>Modal</SectionHeading>
           <Card>
             <CardContent className="flex h-40 flex-col items-center justify-center pt-6">
               <p className="mb-4 text-sm text-gray-500">
-                Portals and focus locking verified via hooks.
+                Focus-trapped, animated, keyboard-dismissible.
               </p>
-              <Button onClick={() => setIsModalOpen(true)}>Open Demonstration Modal</Button>
-              <Modal
-                isOpen={isModalOpen}
-                onClose={() => setIsModalOpen(false)}
-                title="Privacy Settings"
-              >
+              <Button onClick={() => setIsModalOpen(true)}>Open Demo Modal</Button>
+              <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="Privacy Settings">
                 <div className="space-y-4">
                   <p className="text-sm text-gray-500 dark:text-zinc-400">
                     Are you sure you want to update your privacy settings? This will affect how your
@@ -188,7 +201,161 @@ export default function UIDemoPage() {
             </CardContent>
           </Card>
         </section>
+
+        {/* Skeleton */}
+        <section className="space-y-6">
+          <SectionHeading>Skeleton</SectionHeading>
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">SkeletonCard</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SkeletonCard />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">SkeletonRow × 3</CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                <SkeletonRow />
+                <SkeletonRow />
+                <SkeletonRow />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">SkeletonText</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SkeletonText lines={4} />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Skeleton (raw)</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-10 w-32 rounded-lg" />
+                <Skeleton className="h-10 w-10 rounded-full" />
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        {/* EmptyState */}
+        <section className="space-y-6">
+          <SectionHeading>EmptyState</SectionHeading>
+          <div className="grid gap-6 md:grid-cols-2">
+            <EmptyState
+              icon={Inbox}
+              title="No notifications"
+              description="You're all caught up. New notifications will appear here."
+            />
+            <EmptyState
+              icon={FileQuestion}
+              title="No results found"
+              description="Try adjusting your search or filter criteria to find what you're looking for."
+              actionLabel="Clear filters"
+              onAction={() => {}}
+            />
+          </div>
+        </section>
+
+        {/* StatusIndicator + LoanStatusBadge */}
+        <section className="space-y-6">
+          <SectionHeading>StatusIndicator &amp; LoanStatusBadge</SectionHeading>
+          <Card>
+            <CardContent className="space-y-6 pt-6">
+              <div>
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                  StatusIndicator tones
+                </p>
+                <div className="flex flex-wrap gap-3">
+                  <StatusIndicator label="Success" tone="success" />
+                  <StatusIndicator label="Danger" tone="danger" />
+                  <StatusIndicator label="Warning" tone="warning" />
+                  <StatusIndicator label="Info" tone="info" />
+                  <StatusIndicator label="Neutral" tone="neutral" />
+                </div>
+              </div>
+              <div>
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                  LoanStatusBadge statuses
+                </p>
+                <div className="flex flex-wrap gap-3">
+                  <LoanStatusBadge status="active" />
+                  <LoanStatusBadge status="pending" />
+                  <LoanStatusBadge status="repaid" />
+                  <LoanStatusBadge status="defaulted" />
+                  <LoanStatusBadge status="liquidated" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* Tooltip */}
+        <section className="space-y-6">
+          <SectionHeading>Tooltip</SectionHeading>
+          <Card>
+            <CardContent className="flex items-center gap-4 pt-6">
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Credit score</span>
+              <Tooltip content="Your credit score is calculated from your on-chain remittance history over the past 12 months." />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Interest rate</span>
+              <Tooltip
+                content="Variable rate tied to the pool utilisation ratio. Updated every epoch."
+                label="Interest rate info"
+              />
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* PaginationControls */}
+        <section className="space-y-6">
+          <SectionHeading>PaginationControls</SectionHeading>
+          <Card>
+            <CardContent className="pt-6">
+              <PaginationControls
+                currentPage={currentPage}
+                totalPages={totalPages}
+                hasPrevious={currentPage > 1}
+                hasNext={currentPage < totalPages}
+                onPageChange={setCurrentPage}
+                onPrevious={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                onNext={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                summary={`Page ${currentPage} of ${totalPages}`}
+              />
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* CopyButton */}
+        <section className="space-y-6 pb-12">
+          <SectionHeading>CopyButton</SectionHeading>
+          <Card>
+            <CardContent className="flex items-center gap-3 pt-6">
+              <code className="rounded bg-zinc-100 px-3 py-1.5 font-mono text-sm dark:bg-zinc-900">
+                GBDNQ...XKJA
+              </code>
+              <CopyButton value="GBDNQP7PQUXFZ4MGASIWMZZMTEVXKJA" />
+              <span className="text-xs text-zinc-400">Click the icon to copy</span>
+            </CardContent>
+          </Card>
+        </section>
       </div>
+    </div>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-zinc-200">
+      <ChevronRight className="text-blue-500" />
+      <h2>{children}</h2>
     </div>
   );
 }

--- a/frontend/src/app/components/ui/Button.tsx
+++ b/frontend/src/app/components/ui/Button.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-/** Tool to merge Tailwind classes safely */
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+import { cn } from "@/app/utils/cn";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "outline" | "ghost" | "danger";

--- a/frontend/src/app/components/ui/Card.tsx
+++ b/frontend/src/app/components/ui/Card.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-/** Tool to merge Tailwind classes safely */
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+import { cn } from "@/app/utils/cn";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (

--- a/frontend/src/app/components/ui/EmptyState.tsx
+++ b/frontend/src/app/components/ui/EmptyState.tsx
@@ -3,12 +3,7 @@
 import type { ElementType, ReactNode } from "react";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+import { cn } from "@/app/utils/cn";
 
 interface EmptyStateProps {
   icon: ElementType<{ className?: string }>;


### PR DESCRIPTION


## Summary

Four independent issues addressed in separate commits on this branch:

closes #1252 
closes #1245 
closes #1246 
closes#1248

### [CI] Add migration-from-scratch CI job (#1252)

The `migration-check` job already had a Postgres service and ran `migrate:up`, but was missing:
- A **migrate:down → migrate:up cycle** to catch irreversible migrations and ordering collisions (the duplicate timestamp prefixes noted in the issue would surface here)
- **Path-based triggering** so the job only fires on PRs that touch `backend/migrations/**` or `backend/package.json`, while always running on pushes to `main`

Changes:
- `.github/workflows/ci.yml` — add a `migration-paths` job using `dorny/paths-filter@v3`; make `migration-check` depend on it with an `if` guard; extend the job with a full down-loop then a second `migrate:up` run

### [Docs] Rewrite stale frontend/README.md (#1245)

Every section of the README described planned features as if they hadn't shipped. Updated to reflect the actual codebase:

- **Tech Stack** — add Zustand, React Query, `@stellar/freighter-api`, next-intl, Sentry, Framer Motion, Recharts; remove never-integrated Stellar Wallet Kit
- **Available Scripts** — add `test`, `test:watch`, `test:e2e`, `typecheck`, `format`, `audit:a11y`; correct `lint` description (`prettier --check`, not ESLint)
- **State Management** — document the six Zustand stores instead of planned Context API
- **Wallet Integration** — document `@stellar/freighter-api` usage instead of the planned kit
- **Component Library** — document all 22 `ui/` components with prop tables
- **Routing** — replace the stale `/` and `/404` table with the full `/[locale]/*` route list
- **Project Structure** — remove non-existent `tailwind.config.ts`; document Tailwind 4's CSS-first `@import "tailwindcss"` + `@theme` token approach in `globals.css`
- **Testing** — document Jest unit tests and Playwright e2e specs as already shipped

Changes: `frontend/README.md`

### [Docs] Extend ui-demo gallery and gate route from production (#1246)

The `ui-demo` route only showcased 4 of 22 components and silently shipped to production under every locale.

- **Production gate** — `notFound()` called at the top of the page when `NODE_ENV === "production"`; the route returns 404 in all production builds
- **Extended coverage** — gallery now covers 10 components: Button, Input, Card, Modal (existing) + Skeleton (all 4 variants), EmptyState, StatusIndicator, LoanStatusBadge, Tooltip, PaginationControls, CopyButton, ThemeToggle

Changes: `frontend/src/app/[locale]/ui-demo/page.tsx`

### [Frontend] Remove duplicate cn() helpers in ui/ components (#1248)

`Button.tsx`, `Card.tsx`, and `EmptyState.tsx` each copy-pasted an identical local `cn(clsx+twMerge)` function instead of importing the shared helper already used by `Input.tsx` and `Modal.tsx`.

- Removed local `cn` function and the unused `clsx` / `twMerge` imports from all three files
- Added `import { cn } from "@/app/utils/cn"` to each

Changes: `frontend/src/app/components/ui/Button.tsx`, `Card.tsx`, `EmptyState.tsx`

---

## Test plan

- [ ] CI: open a PR that modifies a file in `backend/migrations/` and verify the `migration-check` job runs; open one that does not and verify it is skipped
- [ ] CI: confirm `migration-check` passes the full up → down → up cycle on the 34 existing migrations
- [ ] Frontend: run `npm run typecheck` in `frontend/` — should pass with no new errors
- [ ] Frontend: visit `/en/ui-demo` in development — should render all sections including Skeleton, EmptyState, etc.
- [ ] Frontend: build for production (`npm run build`) and confirm `/en/ui-demo` returns 404
- [ ] Frontend: run `npm test` — existing unit tests should still pass (cn() change is behaviour-preserving)
- [ ] Docs: verify README scripts section matches `package.json` scripts

## Files changed

```
.github/workflows/ci.yml
frontend/README.md
frontend/src/app/[locale]/ui-demo/page.tsx
frontend/src/app/components/ui/Button.tsx
frontend/src/app/components/ui/Card.tsx
frontend/src/app/components/ui/EmptyState.tsx
```
