### PR TITLE
fix(frontend): stabilize transactionId to fix progress UI and prevent double submission

### DIFF
--- a/frontend/src/app/hooks/useOptimisticUI.ts
+++ b/frontend/src/app/hooks/useOptimisticUI.ts
@@ -236,7 +236,11 @@ export function useTransaction(id: string) {
     sign: (message?: string) => store.signTransaction(id, message),
     fail: (error: string) => store.failTransaction(id, error),
     clear: () => store.clearTransaction(id),
-    isLoading: transaction?.status === "pending" || transaction?.status === "signing",
+    isLoading:
+      transaction?.status === "pending" ||
+      transaction?.status === "signing" ||
+      transaction?.status === "submitted" ||
+      transaction?.status === "confirming",
     isSigning: transaction?.status === "signing",
     isSubmitted: transaction?.status === "submitted",
     isConfirming: transaction?.status === "confirming",

--- a/frontend/src/app/hooks/useRepaymentOperation.ts
+++ b/frontend/src/app/hooks/useRepaymentOperation.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTransaction } from "./useOptimisticUI";
 import { useWallet } from "../components/providers/WalletProvider";
@@ -47,7 +47,8 @@ export function useRepaymentOperation(options?: {
   onError?: (error: Error) => void;
 }) {
   const queryClient = useQueryClient();
-  const transactionId = `repayment-${Date.now()}`;
+  const uid = useId();
+  const transactionId = `repayment-${uid}`;
   const transaction = useTransaction(transactionId);
   const [error, setError] = useState<string | null>(null);
 
@@ -126,7 +127,8 @@ export function useDepositOperation(options?: {
   const buildDeposit = useDepositToPool();
   const { data: poolStats } = usePoolStats();
 
-  const transactionId = `deposit-${Date.now()}`;
+  const uid = useId();
+  const transactionId = `deposit-${uid}`;
   const transaction = useTransaction(transactionId);
   const [error, setError] = useState<string | null>(null);
 
@@ -217,7 +219,8 @@ export function useWithdrawalOperation(options?: {
   const buildWithdraw = useWithdrawFromPool();
   const { data: poolStats } = usePoolStats();
 
-  const transactionId = `withdrawal-${Date.now()}`;
+  const uid = useId();
+  const transactionId = `withdrawal-${uid}`;
   const transaction = useTransaction(transactionId);
   const [error, setError] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary

- Closes #1105
- Closes #1103
- Closes #1104
- Closes #1106

## Problem

In `useDepositOperation`, `useWithdrawalOperation`, and `useRepaymentOperation`, the transaction ID was computed with `Date.now()` on **every render**:

```ts
const transactionId = `deposit-${Date.now()}`; // new id each render
```

Because `useTransaction` subscribes to the Zustand store, every state write inside `executeDeposit` (start → sign → submit → confirm) triggered a re-render, which minted a **new** ID. The in-flight closure kept writing to the original ID, but the component was reading from the new one — so `transaction` was always `undefined`. Consequences:

- `OperationProgress` hit its `if (!transaction) return null` guard and showed nothing during signing/submitting/confirming
- `depositOp.isLoading` / `withdrawalOp.isLoading` stayed `false`, so the Deposit/Withdraw buttons were never disabled mid-flight, allowing duplicate submissions with a second click

## Fix

**`useRepaymentOperation.ts`** — replaced `Date.now()` with React's `useId()` in all three hooks (`useRepaymentOperation`, `useDepositOperation`, `useWithdrawalOperation`). `useId()` returns a stable value across all renders for the lifetime of the hook instance.

**`useOptimisticUI.ts`** — extended `isLoading` in `useTransaction` to cover `submitted` and `confirming` states in addition to `pending` and `signing`, so buttons stay disabled for the entire in-flight window until the operation settles.

## Files changed

- `frontend/src/app/hooks/useRepaymentOperation.ts`
- `frontend/src/app/hooks/useOptimisticUI.ts`