### PR TITLE
fix(backend): avoid duplicate REDIS_URL in env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -103,4 +103,5 @@ TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
 # Redis Configuration (Local)
-REDIS_URL=redis://localhost:6379
+# For local Redis outside Docker, use:
+# REDIS_URL=redis://localhost:6379


### PR DESCRIPTION
## Summary
- Keeps the Docker default `REDIS_URL=redis://redis:6379` as the single live Redis URL in `backend/.env.example`.
- Moves the local Redis alternative to a commented example so copied env files do not override the Docker service hostname.
- Verified no other keys are duplicated in `backend/.env.example`.

## Validation
- PASS: duplicate-key scan over `backend/.env.example`
- PASS: `git diff --check`

Closes #1209