### PR TITLE
fix: LOG_LEVEL support, dedupe REDIS_URL, defaultChecker tests, disable mutation retry

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,13 @@
 # See docs/ENVIRONMENT.md for full reference
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+
+# Logging
+# One of: error, warn, info, http, debug. Falls back to debug (dev) / info (other envs) when unset or invalid.
+LOG_LEVEL=
 FRONTEND_URL=http://localhost:3000
 
 DATABASE_URL=postgres://postgres:postgres@db:5432/remitlend
+# Docker default (use redis://localhost:6379 if running Redis outside docker-compose)
 REDIS_URL=redis://redis:6379
 
 # Stellar Configuration
@@ -101,6 +106,3 @@ ADMIN_WEBHOOK_URL=
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
-
-# Redis Configuration (Local)
-REDIS_URL=redis://localhost:6379

--- a/backend/src/services/__tests__/defaultChecker.test.ts
+++ b/backend/src/services/__tests__/defaultChecker.test.ts
@@ -1,0 +1,189 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+} from "@jest/globals";
+import { Account, Keypair, StrKey } from "@stellar/stellar-sdk";
+
+type MockQueryResult = { rows: unknown[]; rowCount?: number };
+
+const mockQuery: jest.MockedFunction<
+  (text: string, params?: unknown[]) => Promise<MockQueryResult>
+> = jest.fn();
+
+const mockSetNotExists: jest.MockedFunction<
+  (key: string, value: unknown, ttlSeconds: number) => Promise<boolean>
+> = jest.fn();
+const mockDelete: jest.MockedFunction<(key: string) => Promise<void>> =
+  jest.fn();
+
+const mockRecordSuccess = jest.fn();
+const mockRecordFailure = jest.fn();
+
+const fakeServer = {
+  getAccount: jest.fn<(publicKey: string) => Promise<Account>>(),
+  getLatestLedger: jest.fn<() => Promise<{ sequence: number }>>(),
+  prepareTransaction: jest.fn<(tx: unknown) => Promise<unknown>>(),
+  sendTransaction: jest.fn<
+    (tx: unknown) => Promise<{ hash?: string; status?: string }>
+  >(),
+  pollTransaction: jest.fn<() => Promise<{ status: string }>>(),
+};
+
+const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
+
+jest.unstable_mockModule("../../db/connection.js", () => ({
+  default: { query: mockQuery },
+  query: mockQuery,
+  getClient: jest.fn(),
+  closePool: jest.fn(),
+}));
+
+jest.unstable_mockModule("../cacheService.js", () => ({
+  cacheService: {
+    setNotExists: mockSetNotExists,
+    delete: mockDelete,
+  },
+}));
+
+jest.unstable_mockModule("../jobMetricsService.js", () => ({
+  jobMetricsService: {
+    recordSuccess: mockRecordSuccess,
+    recordFailure: mockRecordFailure,
+  },
+}));
+
+jest.unstable_mockModule("../../config/stellar.js", () => ({
+  createSorobanRpcServer: () => fakeServer,
+  getStellarNetworkPassphrase: () => "Test SDF Network ; September 2015",
+}));
+
+const { DefaultChecker } = await import("../defaultChecker.js");
+
+const overdueStatsRow = () => ({
+  rows: [{ overdue_count: "0", oldest_due_ledger: null }],
+});
+
+describe("DefaultChecker", () => {
+  const signerSecret = Keypair.random().secret();
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.LOAN_MANAGER_CONTRACT_ID = TEST_CONTRACT_ID;
+    process.env.LOAN_MANAGER_ADMIN_SECRET = signerSecret;
+
+    mockQuery.mockResolvedValue(overdueStatsRow());
+    fakeServer.getLatestLedger.mockResolvedValue({ sequence: 100 });
+    fakeServer.getAccount.mockImplementation(async (publicKey: string) =>
+      new Account(publicKey, "1"),
+    );
+  });
+
+  describe("acquireLock", () => {
+    it("returns null without submitting when the lock is not acquired", async () => {
+      mockSetNotExists.mockResolvedValue(false);
+      const checker = new DefaultChecker();
+
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result).toBeNull();
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(fakeServer.prepareTransaction).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submission failures", () => {
+    beforeEach(() => {
+      mockSetNotExists.mockResolvedValue(true);
+    });
+
+    it("reports prepareTransaction failures as a batch error instead of throwing", async () => {
+      fakeServer.prepareTransaction.mockRejectedValue(new Error("boom"));
+      const checker = new DefaultChecker();
+
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result).not.toBeNull();
+      expect(result!.batches).toHaveLength(1);
+      expect(result!.batches[0]!.error).toContain(
+        "prepareTransaction failed: boom",
+      );
+      expect(result!.successfulSubmissions).toBe(0);
+      expect(result!.failedSubmissions).toBe(1);
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports sendTransaction failures as a batch error instead of throwing", async () => {
+      fakeServer.prepareTransaction.mockImplementation(async (tx: unknown) => tx);
+      fakeServer.sendTransaction.mockRejectedValue(new Error("network down"));
+      const checker = new DefaultChecker();
+
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result!.batches[0]!.error).toContain(
+        "sendTransaction failed: network down",
+      );
+      expect(result!.failedSubmissions).toBe(1);
+      expect(result!.successfulSubmissions).toBe(0);
+    });
+
+    it("counts successful and failed batches across a multi-batch run", async () => {
+      process.env.DEFAULT_CHECK_BATCH_SIZE = "1";
+      fakeServer.prepareTransaction.mockImplementation(async (tx: unknown) => tx);
+      // First call succeeds, second call fails
+      fakeServer.sendTransaction
+        .mockResolvedValueOnce({ hash: "abc", status: "PENDING" })
+        .mockRejectedValueOnce(new Error("rejected"));
+      fakeServer.pollTransaction.mockResolvedValue({ status: "SUCCESS" });
+
+      const checker = new DefaultChecker();
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result!.batches).toHaveLength(2);
+      expect(result!.successfulSubmissions).toBe(1);
+      expect(result!.failedSubmissions).toBe(1);
+      expect(mockRecordSuccess).toHaveBeenCalledWith(
+        "defaultChecker",
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe("batch timeout", () => {
+    it("resolves with timedOut: true when a batch exceeds batchTimeoutMs", async () => {
+      mockSetNotExists.mockResolvedValue(true);
+      process.env.DEFAULT_CHECK_BATCH_TIMEOUT_MS = "20";
+      fakeServer.prepareTransaction.mockImplementation(
+        () => new Promise(() => {}), // never resolves
+      );
+
+      const checker = new DefaultChecker();
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result!.batches).toHaveLength(1);
+      expect(result!.batches[0]!.timedOut).toBe(true);
+      expect(result!.failedSubmissions).toBe(1);
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("releaseLock", () => {
+    it("releases the lock even when the run throws", async () => {
+      mockSetNotExists.mockResolvedValue(true);
+      delete process.env.LOAN_MANAGER_CONTRACT_ID;
+
+      const checker = new DefaultChecker();
+
+      await expect(checker.checkOverdueLoans([1, 2])).rejects.toThrow(
+        "LOAN_MANAGER_CONTRACT_ID",
+      );
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockRecordFailure).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/src/utils/__tests__/logger.test.ts
+++ b/backend/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,39 @@
+import { jest } from "@jest/globals";
+
+describe("logger level resolution", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses LOG_LEVEL when set to a valid level", async () => {
+    process.env.LOG_LEVEL = "warn";
+    jest.resetModules();
+    const { default: logger } = await import("../logger.js");
+    expect(logger.level).toBe("warn");
+  });
+
+  it("falls back to the NODE_ENV default when LOG_LEVEL is unset", async () => {
+    delete process.env.LOG_LEVEL;
+    process.env.NODE_ENV = "production";
+    jest.resetModules();
+    const { default: logger } = await import("../logger.js");
+    expect(logger.level).toBe("info");
+  });
+
+  it("falls back to the NODE_ENV default when LOG_LEVEL is invalid", async () => {
+    process.env.LOG_LEVEL = "verbose";
+    process.env.NODE_ENV = "development";
+    jest.resetModules();
+    const { default: logger } = await import("../logger.js");
+    expect(logger.level).toBe("debug");
+  });
+
+  it("is case-insensitive when matching LOG_LEVEL", async () => {
+    process.env.LOG_LEVEL = "ERROR";
+    jest.resetModules();
+    const { default: logger } = await import("../logger.js");
+    expect(logger.level).toBe("error");
+  });
+});

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -9,10 +9,19 @@ const levels = {
   debug: 4,
 };
 
-const level = () => {
+const validLevels = Object.keys(levels);
+
+const defaultLevelForEnv = () => {
   const env = process.env.NODE_ENV || "development";
-  const isDevelopment = env === "development";
-  return isDevelopment ? "debug" : "info";
+  return env === "development" ? "debug" : "info";
+};
+
+const level = () => {
+  const configured = process.env.LOG_LEVEL?.toLowerCase();
+  if (configured && validLevels.includes(configured)) {
+    return configured;
+  }
+  return defaultLevelForEnv();
 };
 
 const colors = {

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -8,6 +8,7 @@ This document lists every environment variable used by the RemitLend platform. E
 
 | Variable | Dev | Staging | Prod | Default | Description | Source |
 |---|---|---|---|---|---|---|
+| `LOG_LEVEL` | — | — | — | `debug` (dev) / `info` (other envs) | Winston log level override (`error`, `warn`, `info`, `http`, `debug`). Falls back to the `NODE_ENV` default when unset or invalid. | `backend/src/utils/logger.ts` |
 | `CORS_ALLOWED_ORIGINS` | ✓ | ✓ | ✓ | `http://localhost:3000,http://localhost:3001` | Comma-separated origins allowed by CORS | `backend/src/config/index.ts` |
 | `FRONTEND_URL` | ✓ | ✓ | ✓ | `http://localhost:3000` | Frontend base URL used for links | `backend/src/config/index.ts` |
 | `DATABASE_URL` | ✓ | ✓ | ✓ | `postgres://postgres:postgres@db:5432/remitlend` | PostgreSQL connection string | `backend/src/db/connection.js` |

--- a/frontend/src/app/components/providers/QueryProvider.tsx
+++ b/frontend/src/app/components/providers/QueryProvider.tsx
@@ -43,13 +43,10 @@ export function QueryProvider({ children }: QueryProviderProps) {
             refetchOnReconnect: true,
           },
           mutations: {
-            // Retry failed mutations once
-            retry: (failureCount) => {
-              if (typeof navigator !== "undefined" && navigator.onLine === false) {
-                return false;
-              }
-              return failureCount < 2;
-            },
+            // Never retry mutations: most mutationFns are non-idempotent
+            // (loan repayment, remittance creation, etc.) and retrying after
+            // a transient error can duplicate a request the server already processed.
+            retry: false,
           },
         },
       }),

--- a/frontend/src/app/hooks/useApi.mutationRetry.test.tsx
+++ b/frontend/src/app/hooks/useApi.mutationRetry.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * hooks/useApi.mutationRetry.test.ts
+ *
+ * Regression test for #1217: non-idempotent mutations (loan repayment,
+ * remittance creation) must not be retried by TanStack Query after a
+ * transient server error, since the server may have already processed
+ * the request.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useRepayLoan, useCreateRemittance } from "./useApi";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      // Mirrors the app's QueryProvider default of disabling mutation retries.
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("mutation retry behavior", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("useRepayLoan calls the mutationFn exactly once on a non-network 5xx", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({ message: "boom" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useRepayLoan(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ loanId: 1, amount: 100, borrowerAddress: "GABC" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("useCreateRemittance calls the mutationFn exactly once on a non-network 5xx", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+      json: async () => ({ message: "unavailable" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCreateRemittance(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      amount: 100,
+      fromCurrency: "USD",
+      toCurrency: "EUR",
+      recipientAddress: "GABC",
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **#1213**: `logger.ts` now reads `LOG_LEVEL` from the environment, validates it against the defined winston levels (case-insensitive), and falls back to the `NODE_ENV` default (`debug` in dev, `info` otherwise) when unset or invalid. Documented in `.env.example` and `ENVIRONMENT.md`.
- **#1209**: Removed the duplicate `REDIS_URL` assignment in `backend/.env.example` (was set to `redis://redis:6379` then overwritten by `redis://localhost:6379` later in the file, so a copied `.env` couldn't reach the docker-compose Redis service). Kept the docker default as the single live assignment, moved the local alternative to a comment. Verified no other keys are duplicated.
- **#1204**: Added `defaultChecker.test.ts` covering previously untested failure paths: lock-not-acquired returns `null` without submitting, `prepareTransaction`/`sendTransaction` failures are captured as batch errors instead of throwing, a batch exceeding `batchTimeoutMs` resolves with `timedOut: true`, and `releaseLock` runs in the `finally` block on both success and thrown paths. Also asserts `successfulSubmissions`/`failedSubmissions` counts and `jobMetrics` recording.
- **#1217**: Set `mutations.retry: false` globally in `QueryProvider.tsx` so non-idempotent mutation hooks (`useRepayLoan`, `useCreateRemittance`, `useCreateLoan`) never auto-retry after a transient error and duplicate a request the server already processed. Added a test asserting `useRepayLoan`/`useCreateRemittance` call their `mutationFn` exactly once on a non-network 5xx.

Closes #1209
Closes #1213
Closes #1204
Closes #1217

## Test plan

- [x] `backend`: `logger.test.ts` — 4/4 passing (LOG_LEVEL override, fallback on unset, fallback on invalid, case-insensitivity)
- [x] `backend`: `defaultChecker.test.ts` — 6/6 passing (lock skip, prepare/send failures, multi-batch counts, timeout, releaseLock-on-throw)
- [x] `backend`: full suite — 390 passing (2 pre-existing failures unrelated to this change, require a live Postgres connection)
- [x] `frontend`: `useApi.mutationRetry.test.tsx` — 2/2 passing
- [x] `frontend`: full suite — 68/68 passing
- [x] `node scripts/check-env-docs.mjs` passes (LOG_LEVEL documented, no missing keys)