### PR TITLE
fix: resolve issues #1189 #1174 #1181 #1178

### DIFF
--- a/backend/src/__tests__/errorHandling.test.ts
+++ b/backend/src/__tests__/errorHandling.test.ts
@@ -1,8 +1,13 @@
 import { jest } from "@jest/globals";
 import request from "supertest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { generateJwtToken } from "../services/authService.js";
 import app from "../app.js";
 
 jest.setTimeout(20000);
+
+process.env.JWT_SECRET = "test-jwt-secret-min-32-chars-long!!";
+const authHeader = `Bearer ${generateJwtToken(Keypair.random().publicKey())}`;
 
 describe("Centralized Error Handling", () => {
   /* ── 404 Not Found ────────────────────────────────────────── */
@@ -38,7 +43,10 @@ describe("Centralized Error Handling", () => {
 
   describe("Zod validation errors", () => {
     it("should return 400 with validation failed message and error code", async () => {
-      const response = await request(app).post("/api/simulate").send({});
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({});
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
@@ -56,7 +64,8 @@ describe("Centralized Error Handling", () => {
     it("should include field and message in each validation error detail", async () => {
       const response = await request(app)
         .post("/api/simulate")
-        .send({ userId: "user1" });
+        .set("Authorization", authHeader)
+        .send({});
 
       expect(response.status).toBe(400);
       // Legacy format

--- a/backend/src/__tests__/swaggerDocs.test.ts
+++ b/backend/src/__tests__/swaggerDocs.test.ts
@@ -74,4 +74,26 @@ describe("Swagger docs", () => {
     await request(app).get("/docs/").expect(200);
     await request(app).get("/docs.json").expect(200);
   });
+
+  it("API routes do not have unsafe-inline in script-src CSP", async () => {
+    process.env.NODE_ENV = "test";
+    delete process.env.ENABLE_SWAGGER;
+
+    const res = await request(app).get("/");
+    const csp = res.headers["content-security-policy"] ?? "";
+    const scriptSrc =
+      csp.split(";").find((d) => d.trim().startsWith("script-src")) ?? "";
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it("/docs route has unsafe-inline in script-src for Swagger UI", async () => {
+    process.env.NODE_ENV = "test";
+    delete process.env.ENABLE_SWAGGER;
+
+    const res = await request(app).get("/docs/");
+    const csp = res.headers["content-security-policy"] ?? "";
+    const scriptSrc =
+      csp.split(";").find((d) => d.trim().startsWith("script-src")) ?? "";
+    expect(scriptSrc).toContain("'unsafe-inline'");
+  });
 });

--- a/backend/src/__tests__/validation.test.ts
+++ b/backend/src/__tests__/validation.test.ts
@@ -1,5 +1,9 @@
 import request from "supertest";
 import { jest } from "@jest/globals";
+import { Keypair } from "@stellar/stellar-sdk";
+import { generateJwtToken } from "../services/authService.js";
+
+process.env.JWT_SECRET = "test-jwt-secret-min-32-chars-long!!";
 
 // Setup mocks BEFORE importing the app
 const mockQuery =
@@ -34,47 +38,49 @@ jest.unstable_mockModule("../services/cacheService.js", () => ({
 await import("../db/connection.js");
 const { default: app } = await import("../app.js");
 
+const TEST_WALLET = Keypair.random().publicKey();
+const OTHER_WALLET = Keypair.random().publicKey();
+const authHeader = `Bearer ${generateJwtToken(TEST_WALLET)}`;
+
 describe("Input Validation", () => {
   describe("POST /api/simulate", () => {
-    it("should accept valid input", async () => {
-      // Mock score fetch
+    it("should return 401 without authentication", async () => {
+      const response = await request(app).post("/api/simulate").send({
+        amount: 500,
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should accept valid input with authentication", async () => {
       mockQuery.mockResolvedValueOnce({
         rows: [{ current_score: 500 }],
       });
 
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-        amount: 500,
-      });
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({ amount: 500 });
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
 
-    it("should reject missing userId", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        amount: 500,
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
-      expect(response.body.message).toBe("Validation failed");
-    });
-
     it("should reject missing amount", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-      });
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({});
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
     });
 
     it("should reject negative amount", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-        amount: -100,
-      });
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({ amount: -100 });
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
@@ -82,52 +88,30 @@ describe("Input Validation", () => {
     });
 
     it("should reject amount exceeding maximum", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-        amount: 2000000,
-      });
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({ amount: 2000000 });
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
     });
 
     it("should reject zero amount", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-        amount: 0,
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
-    });
-
-    it("should reject empty userId", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "",
-        amount: 500,
-      });
-
-      expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
-    });
-
-    it("should reject userId that is too long", async () => {
       const response = await request(app)
         .post("/api/simulate")
-        .send({
-          userId: "a".repeat(101),
-          amount: 500,
-        });
+        .set("Authorization", authHeader)
+        .send({ amount: 0 });
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
     });
 
     it("should reject non-numeric amount", async () => {
-      const response = await request(app).post("/api/simulate").send({
-        userId: "user123",
-        amount: "five hundred",
-      });
+      const response = await request(app)
+        .post("/api/simulate")
+        .set("Authorization", authHeader)
+        .send({ amount: "five hundred" });
 
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
@@ -135,19 +119,36 @@ describe("Input Validation", () => {
   });
 
   describe("GET /api/history/:userId", () => {
-    it("should accept valid userId", async () => {
-      // Mock score fetch and events fetch
-      mockQuery
-        .mockResolvedValueOnce({ rows: [{ current_score: 500 }] }) // score
-        .mockResolvedValueOnce({ rows: [] }); // events
+    it("should return 401 without authentication", async () => {
+      const response = await request(app).get(
+        `/api/history/${TEST_WALLET}`,
+      );
 
-      const response = await request(app).get("/api/history/user123");
-
-      expect(response.status).toBe(200);
-      expect(response.body.userId).toBe("user123");
+      expect(response.status).toBe(401);
     });
 
-    it("should reject empty userId", async () => {
+    it("should return 403 when wallet does not match JWT", async () => {
+      const response = await request(app)
+        .get(`/api/history/${OTHER_WALLET}`)
+        .set("Authorization", authHeader);
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should accept matching wallet with authentication", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ current_score: 500 }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await request(app)
+        .get(`/api/history/${TEST_WALLET}`)
+        .set("Authorization", authHeader);
+
+      expect(response.status).toBe(200);
+      expect(response.body.userId).toBe(TEST_WALLET);
+    });
+
+    it("should return 404 for empty userId segment", async () => {
       const response = await request(app).get("/api/history/");
 
       expect(response.status).toBe(404);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -69,7 +69,7 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         "default-src": ["'self'"],
-        "script-src": ["'self'", "'unsafe-inline'"],
+        "script-src": ["'self'"],
         "style-src": ["'self'", "https:", "'unsafe-inline'"],
         "img-src": ["'self'", "data:", "https:"],
         "font-src": ["'self'", "https:", "data:"],

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -68,6 +68,12 @@ export function mountSwaggerDocs(app: Express): void {
       return;
     }
 
+    // Swagger UI requires inline scripts. Override helmet's global script-src
+    // with a /docs-scoped policy so API routes stay hardened.
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; frame-ancestors 'self'",
+    );
     docsRouter(req, res, next);
   });
 

--- a/backend/src/controllers/simulationController.ts
+++ b/backend/src/controllers/simulationController.ts
@@ -82,7 +82,8 @@ export const getRemittanceHistory = asyncHandler(
 
 export const simulatePayment = asyncHandler(
   async (req: Request, res: Response) => {
-    const { userId, amount } = req.body;
+    const { amount } = req.body;
+    const userId = req.user!.publicKey;
 
     // Fetch current score
     const scoreResult = await query(

--- a/backend/src/routes/eventRoutes.ts
+++ b/backend/src/routes/eventRoutes.ts
@@ -25,7 +25,6 @@ const router = Router();
  *     tags: [Events]
  *     security:
  *       - BearerAuth: []
- *       - ApiKeyAuth: []
  *     parameters:
  *       - in: query
  *         name: borrower
@@ -34,7 +33,7 @@ const router = Router();
  *         description: >
  *           Borrower's Stellar address. When provided, only events for this
  *           borrower are streamed (JWT must match). When omitted, all events
- *           are streamed (API key required).
+ *           are streamed (admin JWT required).
  *       - in: header
  *         name: Last-Event-ID
  *         schema:

--- a/backend/src/routes/indexerRoutes.ts
+++ b/backend/src/routes/indexerRoutes.ts
@@ -138,7 +138,7 @@ router.get(
  *         name: limit
  *         schema:
  *           type: integer
- *           default: 20
+ *           default: 50
  *       - in: query
  *         name: eventType
  *         schema:

--- a/backend/src/routes/remittanceRoutes.ts
+++ b/backend/src/routes/remittanceRoutes.ts
@@ -94,7 +94,7 @@ router.post(
  *         name: limit
  *         schema:
  *           type: integer
- *           default: 20
+ *           default: 50
  *           maximum: 100
  *       - in: query
  *         name: cursor

--- a/backend/src/routes/simulationRoutes.ts
+++ b/backend/src/routes/simulationRoutes.ts
@@ -9,6 +9,10 @@ import {
   simulatePaymentSchema,
 } from "../schemas/simulationSchemas.js";
 import { simulationRateLimiter } from "../middleware/rateLimiter.js";
+import {
+  requireJwtAuth,
+  requireWalletParamMatchesJwt,
+} from "../middleware/jwtAuth.js";
 
 const router = Router();
 
@@ -17,8 +21,10 @@ const router = Router();
  * /history/{userId}:
  *   get:
  *     summary: Get remittance history for a user
- *     description: Retrieve the remittance history for a specific user by their ID.
+ *     description: Retrieve the remittance history for the authenticated user. The userId path parameter must match the JWT wallet.
  *     tags: [Simulation]
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: userId
@@ -32,6 +38,18 @@ const router = Router();
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/RemittanceHistory'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Authenticated wallet does not match userId.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
  *         description: User not found or no remittance history available.
  *         content:
@@ -43,6 +61,8 @@ const router = Router();
 router.get(
   "/history/:userId",
   simulationRateLimiter,
+  requireJwtAuth,
+  requireWalletParamMatchesJwt("userId"),
   validate(getRemittanceHistorySchema),
   getRemittanceHistory,
 );
@@ -52,8 +72,10 @@ router.get(
  * /simulate:
  *   post:
  *     summary: Simulate a remittance payment
- *     description: Simulate a remittance payment and return the updated user score.
+ *     description: Simulate a remittance payment for the authenticated user and return the projected score change.
  *     tags: [Simulation]
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -61,14 +83,10 @@ router.get(
  *           schema:
  *             type: object
  *             properties:
- *               userId:
- *                 type: string
- *                 description: ID of the user.
  *               amount:
  *                 type: number
  *                 description: Amount to simulate remittance for.
  *             required:
- *               - userId
  *               - amount
  *     responses:
  *       200:
@@ -83,10 +101,17 @@ router.get(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post(
   "/simulate",
   simulationRateLimiter,
+  requireJwtAuth,
   validate(simulatePaymentSchema),
   simulatePayment,
 );

--- a/backend/src/schemas/simulationSchemas.ts
+++ b/backend/src/schemas/simulationSchemas.ts
@@ -10,13 +10,9 @@ export const getRemittanceHistorySchema = z.object({
   }),
 });
 
-// Schema for POST /simulate
+// Schema for POST /simulate — userId is derived from the JWT, not the request body
 export const simulatePaymentSchema = z.object({
   body: z.object({
-    userId: z
-      .string()
-      .min(1, "User ID is required")
-      .max(100, "User ID is too long"),
     amount: z
       .number()
       .positive("Amount must be positive")

--- a/backend/src/services/__tests__/notificationService.test.ts
+++ b/backend/src/services/__tests__/notificationService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
 
 type QueryResult = { rows: Record<string, unknown>[]; rowCount: number };
 const mockQuery =
@@ -149,6 +149,79 @@ describe("notificationService", () => {
       });
 
       expect(notification.actionUrl).toBeUndefined();
+    });
+  });
+
+  describe("notifyAdmins", () => {
+    const originalAdminWallets = process.env.ADMIN_WALLETS;
+    const originalAdminEmail = process.env.ADMIN_EMAIL;
+
+    afterEach(() => {
+      if (originalAdminWallets === undefined) {
+        delete process.env.ADMIN_WALLETS;
+      } else {
+        process.env.ADMIN_WALLETS = originalAdminWallets;
+      }
+      if (originalAdminEmail === undefined) {
+        delete process.env.ADMIN_EMAIL;
+      } else {
+        process.env.ADMIN_EMAIL = originalAdminEmail;
+      }
+    });
+
+    const makeNotificationRow = (userId: string, loanId: number | null) => ({
+      id: 1,
+      user_id: userId,
+      type: "loan_defaulted",
+      title: "Loan Default",
+      message: "A loan has defaulted",
+      loan_id: loanId,
+      action_url: loanId != null ? `/loans/${loanId}` : null,
+      read: false,
+      status: "unread",
+      created_at: new Date("2026-05-28T12:00:00.000Z"),
+    });
+
+    it("inserts a notification for each wallet in ADMIN_WALLETS without querying role", async () => {
+      process.env.ADMIN_WALLETS = "wallet1,wallet2";
+      delete process.env.ADMIN_EMAIL;
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [makeNotificationRow("wallet1", 99)], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [makeNotificationRow("wallet2", 99)], rowCount: 1 });
+
+      await notificationService.notifyAdmins({
+        title: "Loan Default",
+        message: "A loan has defaulted",
+        loanId: 99,
+      });
+
+      const sqls = (mockQuery.mock.calls as [string, unknown[]][]).map((c) => c[0]);
+      expect(sqls.some((s) => s.includes("WHERE role"))).toBe(false);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+
+      const params0 = mockQuery.mock.calls[0][1] as unknown[];
+      const params1 = mockQuery.mock.calls[1][1] as unknown[];
+      expect(params0[0]).toBe("wallet1");
+      expect(params1[0]).toBe("wallet2");
+    });
+
+    it("does nothing when ADMIN_WALLETS is unset", async () => {
+      delete process.env.ADMIN_WALLETS;
+      delete process.env.ADMIN_EMAIL;
+
+      await notificationService.notifyAdmins({ title: "Test", message: "Test" });
+
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when ADMIN_WALLETS is empty or whitespace-only", async () => {
+      process.env.ADMIN_WALLETS = " , , ";
+      delete process.env.ADMIN_EMAIL;
+
+      await notificationService.notifyAdmins({ title: "Test", message: "Test" });
+
+      expect(mockQuery).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -490,13 +490,12 @@ class NotificationService {
 
     // 2. Push SSE notification to every admin currently connected
     try {
-      const adminResult = await query(
-        `SELECT public_key FROM user_profiles WHERE role = 'admin'`,
-        [],
-      );
+      const adminWallets = (process.env.ADMIN_WALLETS ?? "")
+        .split(",")
+        .map((w) => w.trim())
+        .filter((w) => w.length > 0);
 
-      for (const row of adminResult.rows) {
-        const adminId = row.public_key as string;
+      for (const adminId of adminWallets) {
         const actionUrl = loanId != null ? `/loans/${loanId}` : null;
         const result = await query(
           `INSERT INTO notifications (user_id, type, title, message, loan_id, action_url, status)


### PR DESCRIPTION
  ## Summary

  - Fixes **#1189**: `notificationService.notifyAdmins()` no longer queries the
    non-existent `user_profiles.role` column; admin identities are sourced from
    `ADMIN_WALLETS` env var, consistent with the existing RBAC model in `rbac.ts`.
  - Fixes **#1174**: `GET /history/:userId` and `POST /simulate` now require a
    Bearer JWT. The history endpoint enforces `requireWalletParamMatchesJwt` so
    callers can only read their own data; `simulatePayment` uses
    `req.user.publicKey` rather than the unvalidated body field.
  - Fixes **#1181**: Removed `'unsafe-inline'` from the global helmet `script-src`
    CSP; Swagger UI retains its relaxed CSP via a `/docs`-scoped `res.setHeader`
    override in `mountSwaggerDocs`, so all API routes stay hardened.
  - Fixes **#1178**: Removed `ApiKeyAuth` from the `/events/stream` OpenAPI
    security block (route only accepts Bearer JWT) and corrected the description
    text; fixed `default: 20` → `default: 50` pagination docs in
    `remittanceRoutes.ts` and `indexerRoutes.ts` to match `DEFAULT_LIMIT` in
    `pagination.ts`.

  ## Test plan
  - [ ] `npm test` passes (395 tests pass; 2 pre-existing failures in
    `score.test.ts` and `remittance.integration.test.ts` are unrelated)
  - [ ] `GET /` or `GET /health` CSP header has no `unsafe-inline` in `script-src`
  - [ ] Swagger UI loads at `/docs`
  - [ ] `GET /api/history/:userId` → 401 without token, 403 with mismatched
    wallet, 200 with matching wallet
  - [ ] `POST /api/simulate` → 401 without token, 200 with valid JWT

  Closes #1189, Closes #1174, Closes #1181, Closes #1178