### PR TITLE
fix(a11y): associate Token and Memo labels in RemittanceForm

### DIFF
--- a/frontend/src/app/components/remittance/RemittanceForm.test.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.test.tsx
@@ -116,9 +116,7 @@ describe("RemittanceForm", () => {
     await user.type(addressInput, VALID_ADDRESS);
     await user.type(amountInput, "100");
 
-    const memoInput = screen.getByPlaceholderText(
-      "Add a note for the recipient (max 28 characters)",
-    );
+    const memoInput = screen.getByLabelText(/^Memo/);
     // Use fireEvent.change to bypass the textarea's maxLength attribute
     fireEvent.change(memoInput, {
       target: { value: "This is a very long memo that exceeds the limit" },
@@ -136,9 +134,7 @@ describe("RemittanceForm", () => {
     const user = userEvent.setup();
     render(<RemittanceForm onSuccess={mockOnSuccess} />);
 
-    const memoInput = screen.getByPlaceholderText(
-      "Add a note for the recipient (max 28 characters)",
-    );
+    const memoInput = screen.getByLabelText(/^Memo/);
     await user.type(memoInput, "Test memo");
 
     await waitFor(() => {
@@ -150,7 +146,7 @@ describe("RemittanceForm", () => {
     const user = userEvent.setup();
     render(<RemittanceForm onSuccess={mockOnSuccess} />);
 
-    const tokenSelect = screen.getByDisplayValue("USDC");
+    const tokenSelect = screen.getByLabelText(/^Token/);
     expect(tokenSelect).toBeInTheDocument();
 
     await user.selectOptions(tokenSelect, "EURC");

--- a/frontend/src/app/components/remittance/RemittanceForm.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.tsx
@@ -170,10 +170,14 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
 
             {/* Token Selection */}
             <div className="space-y-2">
-              <label className="block text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              <label
+                htmlFor="token"
+                className="block text-sm font-semibold text-zinc-900 dark:text-zinc-50"
+              >
                 Token <span className="text-red-600">*</span>
               </label>
               <select
+                id="token"
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
                 disabled={mutation.isPending}
@@ -212,10 +216,14 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
 
             {/* Memo (Optional) */}
             <div className="space-y-2">
-              <label className="block text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              <label
+                htmlFor="memo"
+                className="block text-sm font-semibold text-zinc-900 dark:text-zinc-50"
+              >
                 Memo <span className="text-zinc-400">(optional)</span>
               </label>
               <textarea
+                id="memo"
                 placeholder="Add a note for the recipient (max 28 characters)"
                 value={memo}
                 onChange={(e) => handleMemoChange(e.target.value)}

--- a/frontend/src/app/components/remittance/RemittanceForm.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.tsx
@@ -230,8 +230,9 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
                 disabled={mutation.isPending}
                 maxLength={28}
                 rows={2}
-                className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-600 dark:focus:ring-indigo-400 resize-none dark:border-zinc-700 ${errors.memo ? "border-red-600" : "border-zinc-300"
-                  }`}
+                className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-600 dark:focus:ring-indigo-400 resize-none dark:border-zinc-700 ${
+                  errors.memo ? "border-red-600" : "border-zinc-300"
+                }`}
               />
               {errors.memo && (
                 <div className="flex items-start gap-2 text-sm text-red-600">


### PR DESCRIPTION
## Summary
- Add `htmlFor`/`id` pairs for the Token select (`token`) and Memo textarea (`memo`) in `RemittanceForm`
- Update tests to query both controls via `getByLabelText` instead of placeholder/display value

## Why
Labels were visually present but not programmatically associated with their controls (WCAG 1.3.1 / 4.1.2). Screen readers and Testing Library could not resolve accessible names for these fields.

## Test plan
- [x] Token select is reachable via `getByLabelText(/^Token/)`
- [x] Memo textarea is reachable via `getByLabelText(/^Memo/)`
- [ ] `npm test -- --testPathPattern=RemittanceForm.test` (local env had incomplete `node_modules`)

Closes #1230