### PR TITLE
fix(frontend): improve loan amount formatting and localized SEO metadata

### DIFF
--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -88,7 +88,9 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
     }
 
     if (numAmount > totalOwed) {
-      setError(`Amount cannot exceed total owed (${totalOwed} USDC)`);
+      setError(
+  `Amount cannot exceed total owed (${formatCurrency(totalOwed).replace("$", "")} USDC)`
+);
       return false;
     }
 
@@ -138,7 +140,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
               <div className="flex justify-between items-center">
                 <span className="text-xs text-gray-500 dark:text-zinc-500">Minimum Payment</span>
                 <span className="text-sm font-medium text-gray-700 dark:text-zinc-300">
-                  {minPayment} USDC
+                  {formatCurrency(minPayment).replace("$", "")} USDC
                 </span>
               </div>
             )}

--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -20,6 +20,7 @@ import {
   formatAmountOnBlur,
   getAssetDecimals,
 } from "../../utils/amount";
+import { formatCurrency } from "./loanFormatters";
 
 interface LoanRepaymentFormProps {
   loanId: number;
@@ -82,7 +83,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
     }
 
     if (minPayment > 0 && numAmount < minPayment) {
-      setError(`Minimum payment is ${minPayment} USDC`);
+      setError(`Minimum payment is ${formatCurrency(minPayment).replace("$", "")} USDC`);
       return false;
     }
 
@@ -130,7 +131,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
             <div className="flex justify-between items-center mb-2">
               <span className="text-sm text-gray-600 dark:text-zinc-400">Total Owed</span>
               <span className="text-2xl font-bold text-gray-900 dark:text-zinc-100">
-                {totalOwed} USDC
+                {formatCurrency(totalOwed).replace("$", "")} USDC
               </span>
             </div>
             {minPayment > 0 && (
@@ -163,7 +164,7 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
             />
 
             <Button variant="ghost" size="sm" onClick={handlePayFullAmount} className="w-full">
-              Pay Full Amount ({totalOwed} USDC)
+              Pay Full Amount ({formatCurrency(totalOwed).replace("$", "")} USDC)
             </Button>
           </div>
 

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,5 +1,23 @@
 import type { MetadataRoute } from "next";
 
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://remitlend.com";
+
+const locales = ["en", "es", "tl"] as const;
+
+const privateRoutes = [
+  "/activity",
+  "/admin",
+  "/analytics",
+  "/loans",
+  "/notifications",
+  "/remittances",
+  "/repay",
+  "/request-loan",
+  "/send-remittance",
+  "/settings",
+  "/wallet",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
@@ -8,20 +26,12 @@ export default function robots(): MetadataRoute.Robots {
         allow: ["/"],
         disallow: [
           "/api/",
-          "/[locale]/activity",
-          "/[locale]/admin",
-          "/[locale]/analytics",
-          "/[locale]/loans",
-          "/[locale]/notifications",
-          "/[locale]/remittances",
-          "/[locale]/repay",
-          "/[locale]/request-loan",
-          "/[locale]/send-remittance",
-          "/[locale]/settings",
-          "/[locale]/wallet",
+          ...locales.flatMap((locale) =>
+            privateRoutes.map((route) => `/${locale}${route}`)
+          ),
         ],
       },
     ],
-    sitemap: `${process.env.NEXT_PUBLIC_APP_URL ?? "https://remitlend.com"}/sitemap.xml`,
+    sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -2,31 +2,45 @@ import type { MetadataRoute } from "next";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://remitlend.com";
 
+const locales = ["en", "es", "tl"] as const;
+
+function getAlternates(path: string) {
+  return {
+    languages: Object.fromEntries(
+      locales.map((locale) => [locale, `${BASE_URL}/${locale}${path}`])
+    ),
+  };
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: BASE_URL,
+      url: `${BASE_URL}/en`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
+      alternates: getAlternates(""),
     },
     {
-      url: `${BASE_URL}/lend`,
+      url: `${BASE_URL}/en/lend`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.8,
+      alternates: getAlternates("/lend"),
     },
     {
-      url: `${BASE_URL}/liquidations`,
+      url: `${BASE_URL}/en/liquidations`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.7,
+      alternates: getAlternates("/liquidations"),
     },
     {
-      url: `${BASE_URL}/kingdom`,
+      url: `${BASE_URL}/en/kingdom`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.6,
+      alternates: getAlternates("/kingdom"),
     },
   ];
 }


### PR DESCRIPTION
 **Summary**

This PR improves SEO and UI consistency by updating localized metadata generation and standardizing loan repayment amount formatting across the borrower experience.

 **Changes**

* Updated the loan repayment form to use the shared currency formatter for:

  * Total Owed
  * Minimum Payment
  * Pay Full Amount button label
  * Related validation messages
* Updated the sitemap to generate locale-prefixed URLs for localized routes
* Added `hreflang` alternates (`en`, `es`, `tl`) for sitemap entries
* Updated `robots.ts` to generate locale-prefixed disallow rules for private routes instead of using literal `/[locale]/` paths
* Refactored sitemap and robots generation to reduce duplication and improve maintainability

**Testing**

* Verified repayment amounts display with consistent thousands separators and decimal precision
* Verified the Pay Full Amount button uses the formatted amount
* Verified localized sitemap URLs resolve correctly and include language alternates
* Verified localized private routes (e.g. `/en/wallet`, `/es/settings`) are disallowed in `robots.txt`
* Verified public routes remain crawlable

Closes #1234
Closes #1235
Closes #1236
closes #1233 
