### PR TITLE
fix: pin Rust toolchain, cache tarpaulin, check fuzz targets, guard s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,14 +234,12 @@ jobs:
      
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: wasm32-unknown-unknown
-          components: rustfmt, clippy
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: contracts
+          workspaces: |
+            contracts
+            contracts/fuzz
       - name: Format check
         run: cargo fmt --all -- --check
         working-directory: contracts
@@ -285,7 +283,18 @@ jobs:
           path: contracts/target/wasm32-unknown-unknown/release/*.wasm
           if-no-files-found: error
       - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
       - name: Run coverage
         run: cargo tarpaulin --out Xml
         working-directory: contracts
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-coverage
+          path: contracts/cobertura.xml
+          retention-days: 7
+      - name: Check fuzz targets compile
+        run: cargo check
+        working-directory: contracts/fuzz

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -773,6 +773,15 @@ class SorobanService {
       status: sendResult.status,
     });
 
+    if (sendResult.status === 'ERROR' || sendResult.status === 'TRY_AGAIN_LATER') {
+      logger.withContext().warn('Transaction rejected at submission', {
+        txHash,
+        status: sendResult.status,
+        errorResult: sendResult.errorResult?.toXDR('base64'),
+      });
+      return { txHash, status: sendResult.status };
+    }
+
     // Poll for final result
     const polled = await server.pollTransaction(txHash, {
       attempts: 30,

--- a/contracts/rust-toolchain.toml
+++ b/contracts/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
…endTransaction status

Closes #1159 — add contracts/rust-toolchain.toml pinning channel to 1.85.0 (targets + components moved from the floating CI step so WASM hashes are reproducible across builds).

Closes #1160 — replace from-source `cargo install cargo-tarpaulin` with taiki-e/install-action (pre-built binary, no compile step) and upload cobertura.xml as a CI artifact instead of discarding it.

Closes #1161 — add `cargo check` in contracts/fuzz so all five fuzz targets are compiled on every push/PR; also extend Swatinem/rust-cache to cover the fuzz workspace so the check stays fast.

Closes #1164 — inspect sendResult.status immediately after sendTransaction; return early with the status (and log the errorResult XDR) when the network returns ERROR or TRY_AGAIN_LATER instead of polling a doomed hash for ~30 s.

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
