### PR TITLE
fix(backend): distributed-lock fencing, metrics on RPC failure, webhook retry consolidation, yield history tests

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,9 +17,9 @@ import {
   stopDefaultCheckerScheduler,
 } from './services/defaultChecker.js';
 import {
-  startWebhookRetryScheduler,
-  stopWebhookRetryScheduler,
-} from './services/webhookRetryScheduler.js';
+  startWebhookRetryProcessor,
+  stopWebhookRetryProcessor,
+} from './services/webhookRetryProcessor.js';
 import { eventStreamService } from './services/eventStreamService.js';
 import {
   startNotificationCleanupScheduler,
@@ -66,8 +66,8 @@ const server = app.listen(port, () => {
   // Start periodic on-chain default checks (if configured)
   startDefaultCheckerScheduler();
 
-  // Start webhook retry scheduler
-  startWebhookRetryScheduler();
+  // Start webhook retry processor (single-sourced retry path via WebhookService.processRetries)
+  startWebhookRetryProcessor();
 
   // Start scheduled score reconciliation against on-chain state
   startScoreReconciliationScheduler();
@@ -100,7 +100,7 @@ const shutdown = async (signal: 'SIGTERM' | 'SIGINT') => {
 
     await stopIndexer();
     stopDefaultCheckerScheduler();
-    stopWebhookRetryScheduler();
+    stopWebhookRetryProcessor();
     stopScoreReconciliationScheduler();
     stopNotificationCleanupScheduler();
 

--- a/backend/src/middleware/metrics.ts
+++ b/backend/src/middleware/metrics.ts
@@ -25,6 +25,16 @@ export const indexerLagLedgersGauge = new client.Gauge({
   registers: [metricsRegistry],
 });
 
+export const indexerRpcFetchErrorsCounter = new client.Counter({
+  name: 'indexer_rpc_fetch_errors_total',
+  help: 'Total number of failures fetching the latest ledger sequence from the RPC endpoint.',
+  registers: [metricsRegistry],
+});
+
+export function incrementIndexerRpcFetchErrors(): void {
+  indexerRpcFetchErrorsCounter.inc();
+}
+
 export const webhookRetryQueueDepthGauge = new client.Gauge({
   name: 'webhook_retry_queue_depth',
   help: 'Number of webhook deliveries currently waiting for retry.',

--- a/backend/src/services/__tests__/yieldHistoryService.test.ts
+++ b/backend/src/services/__tests__/yieldHistoryService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { nativeToScVal } from '@stellar/stellar-sdk';
 
 const mockQuery = jest.fn<(sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>>();
 
@@ -9,6 +10,11 @@ jest.unstable_mockModule('../../db/connection.js', () => ({
 const { buildDepositorYieldHistory, computeApy, normalizeYieldHistoryDays } = await import(
   '../yieldHistoryService.js'
 );
+
+/** Encode [assetAmount, shares] as a base64 Soroban ScVec XDR string. */
+function makeXdrValue(assetAmount: bigint, shares: bigint): string {
+  return nativeToScVal([assetAmount, shares]).toXDR('base64');
+}
 
 describe('yieldHistoryService', () => {
   beforeEach(() => {
@@ -34,6 +40,145 @@ describe('yieldHistoryService', () => {
 
     const history = await buildDepositorYieldHistory('GDepositor', 'GToken', 30);
     expect(history).toEqual([]);
+  });
+
+  it('reduces cost-basis proportionally on Withdraw (value=null)', async () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now);
+    twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
+    const yesterday = new Date(now);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+
+    // Pool: deposit 1000 then withdraw 500 (no XDR value, so shares == assetAmount)
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { event_type: 'Deposit', amount: '1000', ledger_closed_at: twoDaysAgo, value: null },
+        { event_type: 'Withdraw', amount: '500', ledger_closed_at: yesterday, value: null },
+      ],
+    });
+    // Depositor mirrors the pool events
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { event_type: 'Deposit', amount: '1000', ledger_closed_at: twoDaysAgo, value: null },
+        { event_type: 'Withdraw', amount: '500', ledger_closed_at: yesterday, value: null },
+      ],
+    });
+
+    const history = await buildDepositorYieldHistory('GDepositor', 'GToken', 7);
+    expect(history.length).toBeGreaterThan(0);
+
+    // After deposit 1000 then withdraw 500 (shareRatio = 0.5), costBasis = 500
+    const latest = history[history.length - 1]!;
+    expect(latest.depositedValue).toBeCloseTo(500, 5);
+    // netYield must not be negative
+    expect(latest.netYield).toBeGreaterThanOrEqual(0);
+  });
+
+  it('decodes shares from base64 XDR ScVec and converts BigInt to Number', async () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now);
+    twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
+    const yesterday = new Date(now);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+
+    // Deposit: 1000 asset, 800_000 shares (encoded in XDR as BigInts)
+    const depositXdr = makeXdrValue(1000n, 800_000n);
+    // Withdraw: 400 asset, 320_000 shares (shareRatio = 320000/800000 = 0.4 → costBasis drops to 600)
+    const withdrawXdr = makeXdrValue(400n, 320_000n);
+
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          event_type: 'Deposit',
+          amount: '1000',
+          ledger_closed_at: twoDaysAgo,
+          value: depositXdr,
+        },
+        {
+          event_type: 'Withdraw',
+          amount: '400',
+          ledger_closed_at: yesterday,
+          value: withdrawXdr,
+        },
+      ],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          event_type: 'Deposit',
+          amount: '1000',
+          ledger_closed_at: twoDaysAgo,
+          value: depositXdr,
+        },
+        {
+          event_type: 'Withdraw',
+          amount: '400',
+          ledger_closed_at: yesterday,
+          value: withdrawXdr,
+        },
+      ],
+    });
+
+    const history = await buildDepositorYieldHistory('GDepositor', 'GToken', 7);
+    expect(history.length).toBeGreaterThan(0);
+
+    // shareRatio = 320000 / 800000 = 0.4, costBasis after = 1000 * (1 - 0.4) = 600
+    const afterWithdraw = history[history.length - 1]!;
+    expect(afterWithdraw.depositedValue).toBeCloseTo(600, 4);
+    expect(afterWithdraw.netYield).toBeGreaterThanOrEqual(0);
+  });
+
+  it('treats EmergencyWithdraw the same as Withdraw for cost-basis reduction', async () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now);
+    twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
+    const yesterday = new Date(now);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+
+    // EmergencyWithdraw with XDR value encoding 800 shares out of 1000 (shareRatio = 0.8)
+    const depositXdr = makeXdrValue(1000n, 1000n);
+    const emergencyWithdrawXdr = makeXdrValue(800n, 800n);
+
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          event_type: 'Deposit',
+          amount: '1000',
+          ledger_closed_at: twoDaysAgo,
+          value: depositXdr,
+        },
+        {
+          event_type: 'EmergencyWithdraw',
+          amount: '800',
+          ledger_closed_at: yesterday,
+          value: emergencyWithdrawXdr,
+        },
+      ],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          event_type: 'Deposit',
+          amount: '1000',
+          ledger_closed_at: twoDaysAgo,
+          value: depositXdr,
+        },
+        {
+          event_type: 'EmergencyWithdraw',
+          amount: '800',
+          ledger_closed_at: yesterday,
+          value: emergencyWithdrawXdr,
+        },
+      ],
+    });
+
+    const history = await buildDepositorYieldHistory('GDepositor', 'GToken', 7);
+    expect(history.length).toBeGreaterThan(0);
+
+    // shareRatio = 800/1000 = 0.8, costBasis = 1000 * 0.2 = 200, shares = 200
+    const latest = history[history.length - 1]!;
+    expect(latest.depositedValue).toBeCloseTo(200, 4);
+    expect(latest.netYield).toBeGreaterThanOrEqual(0);
   });
 
   it('aggregates deposit and yield into increasing net yield', async () => {

--- a/backend/src/services/cacheService.ts
+++ b/backend/src/services/cacheService.ts
@@ -130,6 +130,34 @@ class CacheService {
   }
 
   /**
+   * Atomically delete a key only if its stored value matches expectedValue.
+   * Uses a Lua script to ensure the compare-and-delete is atomic, preventing
+   * a lock owner from releasing a lock it no longer holds (e.g. after TTL expiry).
+   * @param key The cache key
+   * @param expectedValue The value that must be present for the key to be deleted
+   * @returns true if the key was deleted, false if the value did not match or key was absent
+   */
+  async deleteIfEqual(key: string, expectedValue: string): Promise<boolean> {
+    const lua = `
+      if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('del', KEYS[1])
+      else
+        return 0
+      end
+    `;
+    try {
+      await this.ensureConnected();
+      const result = await this.client!.eval(lua, { keys: [key], arguments: [expectedValue] });
+      return result === 1;
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'test') {
+        logger.withContext().error(`Error in deleteIfEqual for key ${key}`, { error });
+      }
+      return false;
+    }
+  }
+
+  /**
    * Invalidate multiple keys by a pattern (e.g. prefix)
    * Note: KEYS is generally not recommended in production, but suitable for exact or bounded patterns.
    */

--- a/backend/src/services/defaultChecker.ts
+++ b/backend/src/services/defaultChecker.ts
@@ -91,6 +91,7 @@ export class DefaultChecker {
   private pollAttempts: number;
   private pollSleepMs: number;
   private concurrency: number;
+  private lockToken: string | null = null;
 
   constructor() {
     this.contractId = process.env.LOAN_MANAGER_CONTRACT_ID || '';
@@ -380,12 +381,16 @@ export class DefaultChecker {
 
   /**
    * Acquires a distributed lock using Redis SET NX with TTL.
+   * Stores a unique fencing token so releaseLock can safely compare-and-delete.
    * Returns true if lock acquired, false if another instance is running.
    */
   private async acquireLock(): Promise<boolean> {
     try {
       const lockValue = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
       const acquired = await cacheService.setNotExists(LOCK_KEY, lockValue, LOCK_TTL_SECONDS);
+      if (acquired) {
+        this.lockToken = lockValue;
+      }
       return acquired;
     } catch (error) {
       logger.withContext().error('Failed to acquire default checker lock', { error });
@@ -394,11 +399,16 @@ export class DefaultChecker {
   }
 
   /**
-   * Releases the distributed lock.
+   * Releases the distributed lock only if the stored token still matches.
+   * Uses an atomic Lua compare-and-delete to avoid releasing a lock acquired
+   * by a different instance after this run's TTL expired.
    */
   private async releaseLock(): Promise<void> {
+    const token = this.lockToken;
+    this.lockToken = null;
+    if (!token) return;
     try {
-      await cacheService.delete(LOCK_KEY);
+      await cacheService.deleteIfEqual(LOCK_KEY, token);
     } catch (error) {
       logger.withContext().error('Failed to release default checker lock', { error });
     }

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -13,7 +13,7 @@ import { notificationService, type NotificationType } from './notificationServic
 import { sorobanService } from './sorobanService.js';
 import { updateUserScoresBulk } from './scoresService.js';
 import { AppError } from '../errors/AppError.js';
-import { recordIndexerLedgers } from '../middleware/metrics.js';
+import { recordIndexerLedgers, incrementIndexerRpcFetchErrors } from '../middleware/metrics.js';
 
 const EVENT_TYPE_ALIASES: Record<string, WebhookEventType> = {
   Mint: 'NFTMinted',
@@ -254,6 +254,12 @@ export class EventIndexer {
     const lastIndexedLedger = await this.getLastIndexedLedger();
     const latestLedger = await this.getLatestLedgerSequence();
 
+    if (latestLedger === null) {
+      // RPC fetch failed — skip metrics so we do not reset the lag gauge to 0
+      // and misrepresent an outage as a healthy (caught-up) state.
+      return;
+    }
+
     if (latestLedger <= lastIndexedLedger) {
       recordIndexerLedgers(lastIndexedLedger, latestLedger);
       return;
@@ -267,7 +273,7 @@ export class EventIndexer {
     recordIndexerLedgers(result.lastProcessedLedger, latestLedger);
   }
 
-  private async getLatestLedgerSequence(): Promise<number> {
+  private async getLatestLedgerSequence(): Promise<number | null> {
     try {
       const latest = (await (
         this.rpc as unknown as {
@@ -278,10 +284,18 @@ export class EventIndexer {
       const candidate = latest.sequence ?? latest.sequenceNumber ?? latest.seq ?? latest.id;
       const sequence = Number(candidate);
 
-      return Number.isFinite(sequence) && sequence > 0 ? sequence : 0;
+      if (!Number.isFinite(sequence) || sequence <= 0) {
+        incrementIndexerRpcFetchErrors();
+        logger.withContext().warn('Latest ledger sequence is not a positive finite number', {
+          candidate,
+        });
+        return null;
+      }
+      return sequence;
     } catch (error) {
+      incrementIndexerRpcFetchErrors();
       logger.withContext().warn('Failed to fetch latest ledger sequence', { error });
-      return 0;
+      return null;
     }
   }
 


### PR DESCRIPTION
_Note: this contribution was authored with AI assistance (Claude Code)._

## Summary

This batch PR addresses four backend issues assigned in Wave 6: atomic distributed-lock release, suppressing false-healthy metrics on RPC failure, wiring the correct webhook retry implementation, and adding missing test coverage for yield history share/cost-basis logic.

closes #1163
closes #1201
closes #1167
closes #1171

## Changes

- **#1163 — Atomic lock release in defaultChecker**: `acquireLock` now stores the unique fencing token it set in Redis. `releaseLock` calls a new `cacheService.deleteIfEqual` method that runs an atomic Lua compare-and-delete (`GET + DEL` in one round-trip). A run that outlives the 10-minute `LOCK_TTL` can no longer delete a lock acquired by a subsequent instance, preventing the overlapping `check_defaults` submissions the lock was designed to prevent.

- **#1201 — Skip lag/chain-tip metrics on RPC tip-fetch failure**: `getLatestLedgerSequence` now returns `null` instead of `0` on error, and increments a new `indexer_rpc_fetch_errors_total` Prometheus counter. `pollOnce` skips `recordIndexerLedgers` when the tip is `null`, so an RPC outage no longer resets `indexer_lag_ledgers` to 0 and silently defeats the behind-chain-tip alert.

- **#1167 — Wire webhookRetryProcessor as the single live retry path**: `index.ts` now starts `startWebhookRetryProcessor` (which drives `WebhookService.processRetries`) instead of `startWebhookRetryScheduler`. This makes the retry schedule single-sourced: `processRetries` respects the `next_retry_at` timestamps stored by `sendToWebhook` (RETRY_DELAYS_MS: 5m/15m/45m, MAX_RETRY_ATTEMPTS=4). The old scheduler's independent BACKOFF=[60,300,1800]s that ignored stored `next_retry_at` is no longer the live path.

- **#1171 — Test coverage for Withdraw/EmergencyWithdraw cost-basis and XDR share-decoding**: Three new tests in `yieldHistoryService.test.ts`:
  1. Withdraw with `value=null` — asserts cost-basis is reduced proportionally via `shareRatio`
  2. Deposit + Withdraw with a base64 XDR ScVec value — asserts `parseDepositWithdrawAmounts` decodes shares as BigInt and converts to Number correctly
  3. EmergencyWithdraw encoded in XDR — follows the same cost-basis reduction path as Withdraw

## Test plan

- Existing `webhookRetryProcessor.test.ts` covers `WebhookService.processRetries` (the now-live path)
- New tests in `yieldHistoryService.test.ts` cover the three acceptance criteria for #1171
- `defaultChecker.test.ts` covers lock acquisition; the new `deleteIfEqual` is a thin Lua wrapper tested via integration

---

Not built/tested locally (dependencies not installed in the Wave workspace); relying on CI for compilation and full test-suite validation.