### PR TITLE
fix: resolve four Stellar Wave issues (#1211, #1187, #1185, #1195)

### DIFF
--- a/backend/src/__tests__/eventIndexer.test.ts
+++ b/backend/src/__tests__/eventIndexer.test.ts
@@ -647,12 +647,17 @@ describe('EventIndexer', () => {
     const stateWrites: number[] = [];
 
     mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
-      if (sql.includes('SELECT last_indexed_ledger')) {
+      if (sql.includes('SELECT last_ledger')) {
         return { rows: [], rowCount: 0 };
       }
 
       if (sql.includes('INSERT INTO indexer_state')) {
-        stateWrites.push(Number(params[0] ?? 0));
+        if (sql.includes('$1, $2')) {
+          stateWrites.push(Number(params[1] ?? 0));
+        } else {
+          const match = sql.match(/VALUES\s*\(\$1,\s*(\d+)\)/);
+          stateWrites.push(match ? Number(match[1] ?? 0) : Number(params[0] ?? 0));
+        }
         return { rows: [], rowCount: 1 };
       }
 

--- a/backend/src/__tests__/migration.test.ts
+++ b/backend/src/__tests__/migration.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import { query, getClient } from "../db/connection.js";
+import { runner as migrate } from "node-pg-migrate";
+import type { PoolClient } from "pg";
+
+let databaseAvailable = false;
+
+beforeAll(async () => {
+  try {
+    await query("SELECT 1");
+    databaseAvailable = true;
+  } catch {
+    databaseAvailable = false;
+  }
+});
+
+const describeIf = (name: string, fn: () => void) => {
+  if (databaseAvailable) {
+    describe(name, fn);
+  } else {
+    describe.skip(`${name} (skipped: no database)`, fn);
+  }
+};
+
+describeIf("Migrations", () => {
+  let client: PoolClient;
+
+  beforeAll(async () => {
+    client = await getClient();
+  });
+
+  afterAll(async () => {
+    if (client) {
+      client.release();
+    }
+  });
+
+  const runMigrations = async (direction: "up" | "down") => {
+    await migrate({
+      dbClient: client,
+      dir: "./migrations",
+      direction,
+      count: Infinity,
+    });
+  };
+
+  it("should run up then down then up without errors", async () => {
+    await runMigrations("up");
+    await runMigrations("down");
+    await runMigrations("up");
+  });
+
+  it("should have the scores table after running up", async () => {
+    const result = await query(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'scores'
+      ) AS exists`,
+    );
+    expect(result.rows[0]?.exists).toBe(true);
+  });
+
+  it("should store and retrieve a score record", async () => {
+    await query(
+      `INSERT INTO scores (borrower, score)
+       VALUES ($1, $2)
+       ON CONFLICT (borrower) DO NOTHING`,
+      ["G_MIGRATION_TEST_SCORE", 700],
+    );
+
+    const result = await query(
+      `SELECT score FROM scores WHERE borrower = $1`,
+      ["G_MIGRATION_TEST_SCORE"],
+    );
+    expect(Number(result.rows[0]?.score ?? 0)).toBe(700);
+
+    await query(`DELETE FROM scores WHERE borrower = $1`, [
+      "G_MIGRATION_TEST_SCORE",
+    ]);
+  });
+
+  it("should have the indexer_state table after running up", async () => {
+    const result = await query(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'indexer_state'
+      ) AS exists`,
+    );
+    expect(result.rows[0]?.exists).toBe(true);
+  });
+
+  it("should have last_ledger and contract columns in indexer_state", async () => {
+    const columnsResult = await query(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_name = 'indexer_state'
+       AND column_name IN ('last_ledger', 'contract')`,
+    );
+    const columns = columnsResult.rows.map(
+      (r: { column_name: string }) => r.column_name,
+    );
+    expect(columns).toContain("last_ledger");
+    expect(columns).toContain("contract");
+  });
+
+  it("should store and retrieve indexer_state with contract", async () => {
+    await query(
+      `INSERT INTO indexer_state (contract, last_ledger)
+       VALUES ($1, $2)
+       ON CONFLICT (contract) DO NOTHING`,
+      ["test_contract", 42],
+    );
+
+    const result = await query(
+      `SELECT last_ledger FROM indexer_state WHERE contract = $1`,
+      ["test_contract"],
+    );
+    expect(Number(result.rows[0]?.last_ledger ?? 0)).toBe(42);
+  });
+
+  it("should have the loan_disputes table after running up", async () => {
+    const result = await query(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'loan_disputes'
+      ) AS exists`,
+    );
+    expect(result.rows[0]?.exists).toBe(true);
+  });
+
+  it("should have the notifications table after running up", async () => {
+    const result = await query(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'notifications'
+      ) AS exists`,
+    );
+    expect(result.rows[0]?.exists).toBe(true);
+  });
+
+  it("should have the loan_events table after running up", async () => {
+    const result = await query(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'loan_events'
+      ) AS exists`,
+    );
+    expect(result.rows[0]?.exists).toBe(true);
+  });
+
+  afterAll(async () => {
+    try {
+      await query(`DELETE FROM indexer_state WHERE contract = $1`, [
+        "test_contract",
+      ]);
+    } catch {
+      // Cleanup failure is non-fatal
+    }
+  });
+});

--- a/backend/src/middleware/__tests__/jwtAuth.test.ts
+++ b/backend/src/middleware/__tests__/jwtAuth.test.ts
@@ -1,0 +1,458 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Request, Response, NextFunction } from "express";
+
+jest.unstable_mockModule("../../services/authService.js", () => ({
+  verifyJwtToken: jest.fn(),
+  extractBearerToken: jest.fn(),
+  isTokenRevoked: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../auth/rbac.js", () => ({
+  resolveRoleForWallet: jest.fn(),
+  resolveScopesForRole: jest.fn(),
+}));
+
+const mockAppErrorUnauthorized = jest.fn();
+const mockAppErrorForbidden = jest.fn();
+const mockAppErrorBadRequest = jest.fn();
+
+jest.unstable_mockModule("../../errors/AppError.js", () => ({
+  AppError: {
+    unauthorized: mockAppErrorUnauthorized,
+    forbidden: mockAppErrorForbidden,
+    badRequest: mockAppErrorBadRequest,
+  },
+}));
+
+const {
+  requireJwtAuth,
+  requireScopes,
+  requireWalletParamMatchesJwt,
+} = await import("../jwtAuth.js");
+const { verifyJwtToken, extractBearerToken, isTokenRevoked } =
+  await import("../../services/authService.js");
+const { resolveRoleForWallet, resolveScopesForRole } = await import(
+  "../../auth/rbac.js"
+);
+
+const mockVerifyJwtToken = verifyJwtToken as jest.MockedFunction<
+  typeof verifyJwtToken
+>;
+const mockExtractBearerToken = extractBearerToken as jest.MockedFunction<
+  typeof extractBearerToken
+>;
+const mockIsTokenRevoked = isTokenRevoked as jest.MockedFunction<
+  typeof isTokenRevoked
+>;
+const mockResolveRoleForWallet = resolveRoleForWallet as jest.MockedFunction<
+  typeof resolveRoleForWallet
+>;
+const mockResolveScopesForRole =
+  resolveScopesForRole as jest.MockedFunction<typeof resolveScopesForRole>;
+
+function createError(message: string, statusCode: number) {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  return err;
+}
+
+function mockAppErrorFactory(statusCode: number) {
+  return (message: string) => createError(message, statusCode);
+}
+
+describe("jwtAuth middleware", () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRequest = {
+      headers: {},
+      params: {},
+      body: {},
+    };
+
+    mockResponse = {} as Partial<Response>;
+
+    mockNext = jest.fn();
+
+    mockAppErrorUnauthorized.mockImplementation(
+      mockAppErrorFactory(401) as unknown as typeof AppError.unauthorized,
+    );
+    mockAppErrorForbidden.mockImplementation(
+      mockAppErrorFactory(403) as unknown as typeof AppError.forbidden,
+    );
+    mockAppErrorBadRequest.mockImplementation(
+      mockAppErrorFactory(400) as unknown as typeof AppError.badRequest,
+    );
+
+    mockResolveRoleForWallet.mockReturnValue("borrower");
+    mockResolveScopesForRole.mockReturnValue(["read:loans", "read:score"]);
+  });
+
+  describe("requireJwtAuth", () => {
+    it("should authenticate with valid Authorization header token", async () => {
+      const payload = {
+        publicKey: "GABCDEF123",
+        role: "borrower" as const,
+        scopes: ["read:loans"],
+        jti: "test-jti",
+        iat: 1000,
+        exp: 2000,
+      };
+      mockExtractBearerToken.mockReturnValue("valid-token");
+      mockVerifyJwtToken.mockReturnValue(payload);
+      mockIsTokenRevoked.mockResolvedValue(false);
+
+      await requireJwtAuth(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockExtractBearerToken).toHaveBeenCalledWith(
+        mockRequest.headers.authorization,
+      );
+      expect(mockVerifyJwtToken).toHaveBeenCalledWith("valid-token");
+      expect(mockIsTokenRevoked).toHaveBeenCalled();
+      expect(mockRequest.user).toBeDefined();
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should authenticate with valid cookie token when no Authorization header", async () => {
+      mockExtractBearerToken.mockReturnValue(null);
+
+      const payload = {
+        publicKey: "GCOOKIE_USER",
+        role: "lender" as const,
+        scopes: ["read:loans", "read:pool"],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockVerifyJwtToken.mockReturnValue(payload);
+      mockIsTokenRevoked.mockResolvedValue(false);
+
+      mockRequest.headers = {
+        cookie: "remitlend_jwt=valid-cookie-token",
+      };
+
+      await requireJwtAuth(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockExtractBearerToken).toHaveBeenCalledWith(undefined);
+      expect(mockVerifyJwtToken).toHaveBeenCalledWith("valid-cookie-token");
+      expect(mockRequest.user).toBeDefined();
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should throw 401 when no token is provided", async () => {
+      mockExtractBearerToken.mockReturnValue(null);
+      mockRequest.headers = {};
+
+      await expect(() =>
+        requireJwtAuth(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should throw 401 when token is invalid or expired", async () => {
+      mockExtractBearerToken.mockReturnValue("invalid-token");
+      mockVerifyJwtToken.mockReturnValue(null);
+
+      await expect(() =>
+        requireJwtAuth(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should throw 401 when token has been revoked", async () => {
+      const payload = {
+        publicKey: "GREVOKED",
+        role: "borrower" as const,
+        scopes: [],
+        jti: "some-jti",
+        iat: 1000,
+        exp: 2000,
+      };
+      mockExtractBearerToken.mockReturnValue("revoked-token");
+      mockVerifyJwtToken.mockReturnValue(payload);
+      mockIsTokenRevoked.mockResolvedValue(true);
+
+      await expect(() =>
+        requireJwtAuth(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+
+      expect(mockIsTokenRevoked).toHaveBeenCalledWith("some-jti");
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should handle URL-encoded cookie values", async () => {
+      mockExtractBearerToken.mockReturnValue(null);
+
+      const payload = {
+        publicKey: "GURLENC_USER",
+        role: "borrower" as const,
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockVerifyJwtToken.mockReturnValue(payload);
+      mockIsTokenRevoked.mockResolvedValue(false);
+
+      mockRequest.headers = {
+        cookie: "remitlend_jwt=url%40encoded%2Btoken",
+      };
+
+      await requireJwtAuth(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockVerifyJwtToken).toHaveBeenCalledWith("url@encoded+token");
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should return null for empty cookie value and throw 401", async () => {
+      mockExtractBearerToken.mockReturnValue(null);
+      mockRequest.headers = {
+        cookie: "remitlend_jwt=  ",
+      };
+
+      await expect(() =>
+        requireJwtAuth(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+    });
+
+    it("should ignore cookies with wrong name and throw 401", async () => {
+      mockExtractBearerToken.mockReturnValue(null);
+      mockRequest.headers = {
+        cookie: "other_cookie=some-value",
+      };
+
+      await expect(() =>
+        requireJwtAuth(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+    });
+  });
+
+  describe("requireScopes", () => {
+    it("should grant access to admin:all regardless of required scopes", () => {
+      mockRequest.user = {
+        publicKey: "GADMIN",
+        role: "admin",
+        scopes: ["admin:all"],
+        iat: 1000,
+        exp: 2000,
+      };
+
+      const middleware = requireScopes("read:loans", "write:repayment");
+      middleware(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should throw 403 when user is missing a required scope", () => {
+      mockRequest.user = {
+        publicKey: "GBORROWER",
+        role: "borrower",
+        scopes: ["read:loans"],
+        iat: 1000,
+        exp: 2000,
+      };
+
+      const middleware = requireScopes("write:repayment");
+
+      expect(() =>
+        middleware(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 403,
+        }),
+      );
+    });
+
+    it("should grant access when user has all required scopes", () => {
+      mockRequest.user = {
+        publicKey: "GBORROWER",
+        role: "borrower",
+        scopes: ["read:loans", "write:repayment"],
+        iat: 1000,
+        exp: 2000,
+      };
+
+      const middleware = requireScopes("read:loans", "write:repayment");
+      middleware(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should throw 401 when user is not authenticated", () => {
+      mockRequest.user = undefined;
+
+      const middleware = requireScopes("read:loans");
+
+      expect(() =>
+        middleware(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+    });
+  });
+
+  describe("requireWalletParamMatchesJwt", () => {
+    it("should pass when param matches JWT publicKey", () => {
+      mockRequest.user = {
+        publicKey: "GMATCH",
+        role: "borrower",
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = { walletId: "GMATCH" };
+
+      const middleware = requireWalletParamMatchesJwt("walletId");
+      middleware(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it("should throw 403 when param does not match JWT publicKey", () => {
+      mockRequest.user = {
+        publicKey: "GREAL_USER",
+        role: "borrower",
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = { walletId: "GDIFFERENT_USER" };
+
+      const middleware = requireWalletParamMatchesJwt("walletId");
+
+      expect(() =>
+        middleware(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 403,
+        }),
+      );
+    });
+
+    it("should throw 401 when user is not authenticated", () => {
+      mockRequest.user = undefined;
+      mockRequest.params = { walletId: "GSOME_USER" };
+
+      const middleware = requireWalletParamMatchesJwt("walletId");
+
+      expect(() =>
+        middleware(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+    });
+
+    it("should throw 400 when param is missing", () => {
+      mockRequest.user = {
+        publicKey: "GMATCH",
+        role: "borrower",
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = {};
+
+      const middleware = requireWalletParamMatchesJwt("walletId");
+
+      expect(() =>
+        middleware(
+          mockRequest as Request,
+          mockResponse as Response,
+          mockNext,
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 400,
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -285,46 +285,48 @@ export class EventIndexer {
     }
   }
 
+  private getContractId(): string {
+    return this.contractIds[0] ?? "default";
+  }
+
   private async getLastIndexedLedger(): Promise<number> {
+    const contract = this.getContractId();
     const result = await query(
-      `SELECT last_indexed_ledger
+      `SELECT last_ledger
        FROM indexer_state
+       WHERE contract = $1
        ORDER BY id DESC
        LIMIT 1`,
-      [],
+      [contract],
     );
 
     if (!result.rows.length) {
       await query(
-        `INSERT INTO indexer_state (last_indexed_ledger)
-         VALUES (0)`,
-        [],
+        `INSERT INTO indexer_state (contract, last_ledger)
+         VALUES ($1, 0)`,
+        [contract],
       );
       return 0;
     }
 
-    return Number(result.rows[0]?.last_indexed_ledger ?? 0);
+    return Number(result.rows[0]?.last_ledger ?? 0);
   }
 
   private async updateLastIndexedLedger(ledger: number): Promise<void> {
+    const contract = this.getContractId();
     const updateResult = await query(
       `UPDATE indexer_state
-       SET last_indexed_ledger = GREATEST(last_indexed_ledger, $1),
+       SET last_ledger = GREATEST(last_ledger, $1),
            updated_at = CURRENT_TIMESTAMP
-       WHERE id = (
-         SELECT id
-         FROM indexer_state
-         ORDER BY id DESC
-         LIMIT 1
-       )`,
-      [ledger],
+       WHERE contract = $2`,
+      [ledger, contract],
     );
 
     if ((updateResult.rowCount ?? 0) === 0) {
       await query(
-        `INSERT INTO indexer_state (last_indexed_ledger)
-         VALUES ($1)`,
-        [ledger],
+        `INSERT INTO indexer_state (contract, last_ledger)
+         VALUES ($1, $2)`,
+        [contract, ledger],
       );
     }
   }

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -13,7 +13,7 @@ This document lists every environment variable used by the RemitLend platform. E
 | `FRONTEND_URL` | ✓ | ✓ | ✓ | `http://localhost:3000` | Frontend base URL used for links | `backend/src/config/index.ts` |
 | `DATABASE_URL` | ✓ | ✓ | ✓ | `postgres://postgres:postgres@db:5432/remitlend` | PostgreSQL connection string | `backend/src/db/connection.js` |
 | `REDIS_URL` | ✓ | ✓ | ✓ | `redis://redis:6379` | Redis connection string | `backend/src/services/cacheService.ts` |
-| `STELLAR_NETWORK` | ✓ | ✓ | ✓ | `testnet` | Stellar network name (`testnet`, `pubnet`, `sandbox`) | `backend/src/config/stellar.ts` |
+| `STELLAR_NETWORK` | ✓ | ✓ | ✓ | `testnet` | Stellar network name (`testnet`, `mainnet`) | `backend/src/config/stellar.ts` |
 | `STELLAR_RPC_URL` | ✓ | ✓ | ✓ | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint | `backend/src/config/stellar.ts` |
 | `STELLAR_NETWORK_PASSPHRASE` | ✓ | ✓ | ✓ | `Test SDF Network ; September 2015` | Network passphrase for transaction signing | `backend/src/config/stellar.ts` |
 | `LOAN_MANAGER_CONTRACT_ID` | ✓ | ✓ | ✓ | — | Deployed loan manager contract address | `backend/src/config/stellar.ts` |


### PR DESCRIPTION
## Summary

### #1211 - [Docs] ENVIRONMENT.md lists invalid STELLAR_NETWORK values
Changed documented values from `(testnet, pubnet, sandbox)` to `(testnet, mainnet)` to match `parseNetwork()` in `backend/src/config/stellar.ts`.

### #1187 - [Backend] indexer_state rename + NOT NULL contract column drift breaks eventIndexer at runtime
Updated `eventIndexer.ts` queries to use `last_ledger` (renamed from `last_indexed_ledger`) and provide `contract` value for the NOT NULL column:
- `getLastIndexedLedger()`: SELECT/INSERT use `last_ledger` + `contract` parameter
- `updateLastIndexedLedger()`: UPDATE/INSERT use `last_ledger` + `contract` filter
- Added `getContractId()` helper to derive contract identifier from tracked contract IDs

### #1185 - [Testing] jwtAuth.ts RBAC/scope middleware has no unit tests
Added comprehensive unit tests covering:
- `requireScopes`: admin:all bypass, missing scope (403), unauthenticated (401)
- `requireJwtAuth` cookie path: valid cookie, malformed/empty cookie, wrong cookie name, URL-encoded values, token revocation check
- `requireWalletParamMatchesJwt`: mismatched param (403), unauthenticated (401), missing param (400)

### #1195 - [Testing] No migration up/down or schema integration test
Added `migration.test.ts` that:
- Runs all migrations up → down → up without errors
- Verifies key tables exist (scores, indexer_state, loan_disputes, notifications, loan_events)
- Runs smoke queries against `scores` and `indexer_state` (including `last_ledger`/contract columns)
- Uses same conditional DB pattern (`describeIf`) as existing `database.test.ts`

## Testing

All related test suites pass:
- `jwtAuth`: 16/16 ✓
- `eventIndexer`: 16/16 ✓
- `stellarConfig`: 4/4 ✓
- `migration`: skipped without DB (conditional)

Pre-existing failures (9 test suites) are unrelated to this PR (missing DB, environment config issues).

Closes #1211
Closes #1187 
Closes #1185 
Closes #1195