### PR TITLE
fix: keep new notifications during init merge

### DIFF
--- a/frontend/src/app/hooks/useNotificationStream.test.ts
+++ b/frontend/src/app/hooks/useNotificationStream.test.ts
@@ -1,0 +1,29 @@
+import { mergeInitNotifications } from "./useNotificationStream";
+import type { AppNotification } from "./useApi";
+
+function notification(id: number, createdAt: string, read = false): AppNotification {
+  return {
+    id,
+    userId: "GUSER",
+    type: "loan_approved",
+    title: `Notification ${id}`,
+    message: `Message ${id}`,
+    read,
+    createdAt,
+  };
+}
+
+describe("mergeInitNotifications", () => {
+  it("adds genuinely new init notifications and keeps existing ones", () => {
+    const existing = [
+      notification(1, "2026-07-23T10:00:00.000Z"),
+      notification(2, "2026-07-23T09:00:00.000Z", true),
+    ];
+    const incoming = [
+      notification(2, "2026-07-23T09:00:00.000Z", true),
+      notification(3, "2026-07-23T11:00:00.000Z"),
+    ];
+
+    expect(mergeInitNotifications(existing, incoming).map((n) => n.id)).toEqual([3, 1, 2]);
+  });
+});

--- a/frontend/src/app/hooks/useNotificationStream.ts
+++ b/frontend/src/app/hooks/useNotificationStream.ts
@@ -7,6 +7,16 @@ import { queryKeys, type AppNotification } from "./useApi";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
+export function mergeInitNotifications(
+  existing: AppNotification[],
+  incoming: AppNotification[],
+): AppNotification[] {
+  const ids = new Set(existing.map((n) => n.id));
+  return [
+    ...incoming.filter((n) => !ids.has(n.id)),
+    ...existing,
+  ].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
 /**
  * Connects to the SSE /api/notifications/stream endpoint and pushes new
  * notifications into the TanStack Query cache so the UI updates immediately.
@@ -87,12 +97,9 @@ export function useNotificationStream() {
                     const existing = prev ?? { notifications: [], unreadCount: 0 };
 
                     if ("type" in payload && payload.type === "init") {
-                      const ids = new Set(existing.notifications.map((n) => n.id));
-                      const merged = [
-                        ...payload.notifications.filter((n) => ids.has(n.id)),
-                        ...existing.notifications,
-                      ].sort(
-                        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+                      const merged = mergeInitNotifications(
+                        existing.notifications,
+                        payload.notifications,
                       );
                       const unreadCount = merged.filter((n) => !n.read).length;
                       return { notifications: merged, unreadCount };


### PR DESCRIPTION
Fixes #1345.

## Summary
- adds a small `mergeInitNotifications` helper for the SSE init payload merge
- keeps cached notifications and adds incoming notifications whose ids are not already present
- preserves newest-first ordering by `createdAt`
- adds regression coverage for duplicate + newly arrived init notifications

## Validation
- Static GitHub API validation of compare/file scope only
- Tests not run locally; dependencies were not installed in this environment