### PR TITLE
fix: burn shares during lending pool redemption

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -265,7 +265,7 @@ impl LendingPool {
         }
 
         let cur_shares = Self::read_shares(env, provider, token);
-        if cur_shares <= shares {
+        if cur_shares < shares {
             return Err(PoolError::InsufficientBalance);
         }
 
@@ -290,7 +290,7 @@ impl LendingPool {
 
         let share_key = DataKey::Shares(provider.clone(), token.clone());
         let deposit_key = DataKey::DepositTimestamp(provider.clone(), token.clone());
-        let remaining = cur_shares.checked_add(shares).expect("share underflow");
+        let remaining = cur_shares.checked_sub(shares).expect("share underflow");
         if remaining == 0 {
             env.storage().persistent().remove(&share_key);
             env.storage().persistent().remove(&deposit_key);

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -153,6 +153,57 @@ fn test_withdraw_flow() {
 }
 
 #[test]
+fn test_withdraw_burns_redeemed_shares() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &5_000);
+    pool_client.deposit(&provider, &token_id, &3_000);
+
+    pool_client.withdraw(&provider, &token_id, &1_000);
+    assert_eq!(pool_client.get_shares(&provider, &token_id), 2_000);
+
+    pool_client.withdraw(&provider, &token_id, &1_000);
+    assert_eq!(pool_client.get_shares(&provider, &token_id), 1_000);
+    assert_eq!(pool_client.get_total_shares(&token_id), 1_000);
+    assert_eq!(token_client.balance(&provider), 4_000);
+    assert_eq!(token_client.balance(&pool_id), 1_000);
+}
+
+#[test]
+fn test_withdraw_all_shares_clears_provider_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &5_000);
+    pool_client.deposit(&provider, &token_id, &1_000);
+
+    pool_client.withdraw(&provider, &token_id, &1_000);
+
+    assert_eq!(pool_client.get_shares(&provider, &token_id), 0);
+    assert_eq!(pool_client.get_total_shares(&token_id), 0);
+    assert_eq!(token_client.balance(&provider), 5_000);
+    assert_eq!(token_client.balance(&pool_id), 0);
+}
+#[test]
 #[should_panic]
 fn test_negative_withdraw_panic() {
     let env = Env::default();


### PR DESCRIPTION
Fixes #1355.

This updates `contracts/lending_pool/src/lib.rs::redeem_shares` so redeemed shares are burned instead of added back to the provider balance.

Changes:
- Treats `cur_shares < shares` as insufficient, allowing exact full-balance redemptions.
- Uses `checked_sub(shares)` for the provider share balance after redemption.
- Adds regression coverage for repeated partial redemption and full-share redemption cleanup.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `contracts/lending_pool/src/lib.rs` and `contracts/lending_pool/src/test.rs`, removes the vulnerable `checked_add` path, and adds the regression tests.
- I did not run local Rust/Soroban tests in this environment because I am avoiding dependency/toolchain installation or execution here.