### PR TITLE
fix: compare requested wallet to authenticated wallet

### DIFF
--- a/backend/src/middleware/__tests__/jwtAuth.test.ts
+++ b/backend/src/middleware/__tests__/jwtAuth.test.ts
@@ -24,7 +24,7 @@ jest.unstable_mockModule('../../errors/AppError.js', () => ({
   },
 }));
 
-const { requireJwtAuth, requireScopes, requireWalletParamMatchesJwt } =
+const { requireJwtAuth, requireScopes, requireWalletOwnership, requireWalletParamMatchesJwt } =
   await import('../jwtAuth.js');
 const { verifyJwtToken, extractBearerToken, isTokenRevoked } =
   await import('../../services/authService.js');
@@ -301,6 +301,90 @@ describe('jwtAuth middleware', () => {
     });
   });
 
+  describe('requireWalletOwnership', () => {
+    it('should pass when requested wallet matches JWT publicKey from params', () => {
+      mockRequest.user = {
+        publicKey: 'GMATCH',
+        role: 'borrower',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = { wallet: 'GMATCH' };
+
+      requireWalletOwnership(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it('should throw 403 when requested wallet differs from JWT publicKey', () => {
+      mockRequest.user = {
+        publicKey: 'GREAL_USER',
+        role: 'borrower',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = { wallet: 'GOTHER_USER' };
+
+      expect(() =>
+        requireWalletOwnership(mockRequest as Request, mockResponse as Response, mockNext),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 403,
+        }),
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should use body.wallet when no wallet param is present', () => {
+      mockRequest.user = {
+        publicKey: 'GBODY_USER',
+        role: 'borrower',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.body = { wallet: 'GBODY_USER' };
+
+      requireWalletOwnership(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it('should throw 401 when user is not authenticated', () => {
+      mockRequest.user = undefined;
+      mockRequest.params = { wallet: 'GSOME_USER' };
+
+      expect(() =>
+        requireWalletOwnership(mockRequest as Request, mockResponse as Response, mockNext),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 401,
+        }),
+      );
+    });
+
+    it('should throw 400 when no requested wallet is provided', () => {
+      mockRequest.user = {
+        publicKey: 'GMATCH',
+        role: 'borrower',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+      mockRequest.params = {};
+      mockRequest.body = {};
+
+      expect(() =>
+        requireWalletOwnership(mockRequest as Request, mockResponse as Response, mockNext),
+      ).toThrow(
+        expect.objectContaining({
+          statusCode: 400,
+        }),
+      );
+    });
+  });
   describe('requireWalletParamMatchesJwt', () => {
     it('should pass when param matches JWT publicKey', () => {
       mockRequest.user = {

--- a/backend/src/middleware/jwtAuth.ts
+++ b/backend/src/middleware/jwtAuth.ts
@@ -126,7 +126,7 @@ export const requireWalletOwnership = (req: Request, _res: Response, next: NextF
     throw AppError.badRequest('Wallet address is required');
   }
 
-  if (requestedWallet !== requestedWallet) {
+  if (requestedWallet !== authenticatedWallet) {
     throw AppError.forbidden('You are not authorized to access this wallet');
   }
 


### PR DESCRIPTION
Fixes #1363.

This updates `backend/src/middleware/jwtAuth.ts::requireWalletOwnership` so the requested wallet is compared against the authenticated JWT wallet instead of being compared to itself.

Changes:
- Replaces the always-false self-comparison with `requestedWallet !== authenticatedWallet`.
- Adds regression tests for matching wallet params, mismatched wallet params, `body.wallet`, missing authentication, and missing requested wallet.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `backend/src/middleware/jwtAuth.ts` and `backend/src/middleware/__tests__/jwtAuth.test.ts`, removes the vulnerable self-comparison, and adds the ownership regression coverage.
- I did not run local package tests in this environment because I am avoiding dependency/toolchain installation or execution here.