### PR TITLE
fix: resolve lender wallets to lender role

### DIFF
--- a/backend/src/auth/rbac.test.ts
+++ b/backend/src/auth/rbac.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { resolveRoleForWallet, resolveScopesForRole } from '../rbac.js';
+
+const ORIGINAL_ADMIN_WALLETS = process.env.ADMIN_WALLETS;
+const ORIGINAL_LENDER_WALLETS = process.env.LENDER_WALLETS;
+
+afterEach(() => {
+  process.env.ADMIN_WALLETS = ORIGINAL_ADMIN_WALLETS;
+  process.env.LENDER_WALLETS = ORIGINAL_LENDER_WALLETS;
+});
+
+describe('resolveRoleForWallet', () => {
+  it('resolves configured admin wallets to admin', () => {
+    process.env.ADMIN_WALLETS = 'GADMIN_ONE, GADMIN_TWO';
+    process.env.LENDER_WALLETS = 'GLENDER_ONE';
+
+    expect(resolveRoleForWallet('GADMIN_TWO')).toBe('admin');
+  });
+
+  it('resolves configured lender wallets to lender, not admin', () => {
+    process.env.ADMIN_WALLETS = 'GADMIN_ONE';
+    process.env.LENDER_WALLETS = 'GLENDER_ONE, GLENDER_TWO';
+
+    expect(resolveRoleForWallet('GLENDER_TWO')).toBe('lender');
+    expect(resolveScopesForRole(resolveRoleForWallet('GLENDER_TWO'))).not.toContain('admin:all');
+  });
+
+  it('defaults unknown wallets to borrower', () => {
+    process.env.ADMIN_WALLETS = 'GADMIN_ONE';
+    process.env.LENDER_WALLETS = 'GLENDER_ONE';
+
+    expect(resolveRoleForWallet('GBORROWER')).toBe('borrower');
+  });
+});

--- a/backend/src/auth/rbac.ts
+++ b/backend/src/auth/rbac.ts
@@ -34,7 +34,7 @@ export const resolveRoleForWallet = (publicKey: string): UserRole => {
 
   const lenderWallets = parseWalletSet(process.env.LENDER_WALLETS);
   if (lenderWallets.has(publicKey)) {
-    return 'admin';
+    return 'lender';
   }
 
   return 'borrower';


### PR DESCRIPTION
Fixes #1366.

This updates `backend/src/auth/rbac.ts::resolveRoleForWallet` so configured lender wallets resolve to `lender` instead of `admin`.

Changes:
- Keeps `ADMIN_WALLETS` resolving to `admin`.
- Changes `LENDER_WALLETS` resolution from `admin` to `lender`.
- Adds unit coverage for admin, lender, and default borrower resolution, including a regression that lender scopes do not include `admin:all`.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `backend/src/auth/rbac.ts` and `backend/src/auth/rbac.test.ts`, removes the lender-to-admin path, and adds role-resolution regression coverage.
- I did not run local package tests in this environment because I am avoiding dependency/toolchain installation or execution here.