### PR TITLE
fix: correct jwt expiry comparison

### DIFF
--- a/frontend/src/app/lib/session.test.ts
+++ b/frontend/src/app/lib/session.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { isJwtExpired } from './session';
+
+function base64UrlEncode(value: unknown): string {
+  return window
+    .btoa(JSON.stringify(value))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function tokenWithPayload(payload: Record<string, unknown>): string {
+  return `${base64UrlEncode({ alg: 'none', typ: 'JWT' })}.${base64UrlEncode(payload)}.`;
+}
+
+describe('isJwtExpired', () => {
+  it('returns false for a token expiring in the future', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    expect(isJwtExpired(tokenWithPayload({ exp: 1_700_000_060 }))).toBe(false);
+  });
+
+  it('returns true for a token expiring in the past', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    expect(isJwtExpired(tokenWithPayload({ exp: 1_699_999_940 }))).toBe(true);
+  });
+
+  it('treats a token expiring exactly now as expired', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    expect(isJwtExpired(tokenWithPayload({ exp: 1_700_000_000 }))).toBe(true);
+  });
+
+  it('returns false for malformed tokens or missing numeric exp', () => {
+    expect(isJwtExpired('not-a-jwt')).toBe(false);
+    expect(isJwtExpired(tokenWithPayload({ exp: '1700000000' }))).toBe(false);
+    expect(isJwtExpired(tokenWithPayload({ sub: 'GUSER' }))).toBe(false);
+  });
+});

--- a/frontend/src/app/lib/session.ts
+++ b/frontend/src/app/lib/session.ts
@@ -34,7 +34,7 @@ export function isJwtExpired(token: string): boolean {
   const payload = decodeJwtPayload(token);
   const exp = payload?.exp;
 
-  return typeof exp === "number" && exp * 1000 >= Date.now();
+  return typeof exp === "number" && exp * 1000 <= Date.now();
 }
 
 export function clearSessionState() {


### PR DESCRIPTION
Fixes #1340.

This updates `frontend/src/app/lib/session.ts::isJwtExpired` so only tokens whose `exp` timestamp is at or before `Date.now()` are treated as expired.

Changes:
- Replaces the inverted `exp * 1000 >= Date.now()` comparison with `exp * 1000 <= Date.now()`.
- Adds regression tests for future-valid, past-expired, exactly-now expired, malformed token, string `exp`, and missing `exp` cases.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `frontend/src/app/lib/session.ts` and `frontend/src/app/lib/session.test.ts`, removes the inverted comparison, and adds the expiry regression coverage.
- I did not run local frontend tests in this environment because I am avoiding dependency/toolchain installation or execution here.