### PR TITLE
fix: enforce jwt expiration during verification

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from '@jest/globals';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import app from '../app.js';
 import { Keypair } from '@stellar/stellar-sdk';
 
@@ -279,6 +280,42 @@ describe('authService unit tests', () => {
     });
   });
 
+  describe('verifyJwtToken', () => {
+    it('should return payload for a valid unexpired token', () => {
+      process.env.JWT_SECRET = 'test-secret-key-for-jest';
+      const token = jwt.sign(
+        {
+          publicKey: 'GVALID',
+          role: 'borrower',
+          scopes: ['read:loans'],
+          jti: 'valid-jti',
+        },
+        process.env.JWT_SECRET,
+        { algorithm: 'HS256', expiresIn: '1h' },
+      );
+
+      const result = authService.verifyJwtToken(token);
+
+      expect(result?.publicKey).toBe('GVALID');
+      expect(result?.jti).toBe('valid-jti');
+    });
+
+    it('should return null for an expired token', () => {
+      process.env.JWT_SECRET = 'test-secret-key-for-jest';
+      const token = jwt.sign(
+        {
+          publicKey: 'GEXPIRED',
+          role: 'borrower',
+          scopes: ['read:loans'],
+          jti: 'expired-jti',
+        },
+        process.env.JWT_SECRET,
+        { algorithm: 'HS256', expiresIn: -1 },
+      );
+
+      expect(authService.verifyJwtToken(token)).toBeNull();
+    });
+  });
   describe('verifyChallengeTimestamp', () => {
     it('should accept timestamp at the window edge', () => {
       const maxAge = 5 * 60 * 1000; // 5 minutes

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -99,7 +99,6 @@ export function verifyJwtToken(token: string): JwtPayload | null {
     const secret = getJwtSecret();
     const decoded = jwt.verify(token, secret, {
       algorithms: ['HS256'],
-      ignoreExpiration: true,
     }) as JwtPayload;
 
     return decoded;


### PR DESCRIPTION
Fixes #1359.

This updates `backend/src/services/authService.ts::verifyJwtToken` so JWT expiration is enforced during verification.

Changes:
- Removes `ignoreExpiration: true` from the `jwt.verify(...)` options.
- Keeps the `HS256` algorithm allowlist in place.
- Adds authService regression tests for a valid unexpired token and an expired token returning `null`.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `backend/src/services/authService.ts` and `backend/src/__tests__/auth.test.ts`, removes `ignoreExpiration`, and adds expiry regression coverage.
- I did not run local package tests in this environment because I am avoiding dependency/toolchain installation or execution here.