### PR TITLE
fix: keep remittance xdr amount aligned with record

### DIFF
--- a/backend/src/__tests__/remittanceService.test.ts
+++ b/backend/src/__tests__/remittanceService.test.ts
@@ -126,6 +126,26 @@ describe('remittanceService.createRemittance', () => {
     expect(payment.asset.getIssuer()).toBe(USDC_ISSUER);
   });
 
+  it('builds the payment XDR with the same amount stored in the remittance record', async () => {
+    const remittance = await remittanceService.createRemittance({
+      recipientAddress: RECIPIENT,
+      amount: 25,
+      fromCurrency: 'XLM',
+      toCurrency: 'XLM',
+      memo: 'test',
+      senderAddress: SENDER,
+    });
+
+    const tx = TransactionBuilder.fromXDR(
+      remittance.xdr!,
+      Networks.TESTNET,
+    ) as import('@stellar/stellar-sdk').Transaction;
+    const payment = tx.operations[0] as { amount: string };
+
+    expect(remittance.amount).toBe(25);
+    expect(payment.amount).toBe('25.0000000');
+  });
+
   it("builds the payment XDR from the sender's live Stellar sequence", async () => {
     const remittance = await remittanceService.createRemittance({
       recipientAddress: RECIPIENT,

--- a/backend/src/services/remittanceService.ts
+++ b/backend/src/services/remittanceService.ts
@@ -109,7 +109,7 @@ export const remittanceService = {
           Operation.payment({
             destination: payload.recipientAddress,
             asset: paymentAsset,
-            amount: (payload.amount * 10).toString(),
+            amount: payload.amount.toString(),
           }),
         )
         .setTimeout(30)


### PR DESCRIPTION
Fixes #1367.

This updates `backend/src/services/remittanceService.ts::createRemittance` so the Stellar payment operation uses the same requested amount that is persisted in the remittance record.

Changes:
- Removes the `payload.amount * 10` multiplier from the on-chain payment operation.
- Adds a regression test that parses the generated XDR and asserts the payment amount matches the stored remittance amount.

Validation:
- Static GitHub API checks confirmed the branch is 1 commit ahead / 0 behind `main`, only touches `backend/src/services/remittanceService.ts` and `backend/src/__tests__/remittanceService.test.ts`, removes the x10 multiplier, and adds the XDR amount regression coverage.
- I did not run local package tests in this environment because I am avoiding dependency/toolchain installation or execution here.