### PR TITLE
fix: escrow lending pool deposits

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -483,8 +483,8 @@ impl LendingPool {
         }
 
         TokenClient::new(&env, &token).transfer(
-            &env.current_contract_address(),
             &provider,
+            &env.current_contract_address(),
             &amount,
         );
 


### PR DESCRIPTION
Fixes #1357.

This updates `contracts/lending_pool/src/lib.rs::deposit` so deposits transfer tokens from the provider into the pool contract. The previous direction transferred from the pool contract to the provider while still minting pool shares, which could drain pool assets.

The existing `test_deposit_flow` regression already asserts the intended balance movement after deposit: provider balance decreases and pool balance increases.

Validation: static GitHub compare/API checks only. I did not run the Rust/Soroban test suite locally because this environment is avoiding dependency/toolchain installation or execution.