### PR TITLE
fix: apply outstanding deltas in correct direction

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -773,7 +773,7 @@ impl LendingPool {
         let key = DataKey::TotalOutstanding(token.clone());
         let current = Self::read_total_outstanding(&env, &token);
         let updated = current
-            .checked_sub(delta)
+            .checked_add(delta)
             .expect("total outstanding overflow");
 
         if updated < 0 {

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -443,6 +443,24 @@ fn test_deposit_withdraw_invariants() {
     }
 }
 
+#[test]
+fn test_adjust_outstanding_applies_delta_direction() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, _stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+
+    pool_client.adjust_outstanding(&token_id, &700);
+    assert_eq!(pool_client.get_total_outstanding(&token_id), 700);
+
+    pool_client.adjust_outstanding(&token_id, &-200);
+    assert_eq!(pool_client.get_total_outstanding(&token_id), 500);
+}
 // ── Yield distribution (share-based) ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Fixes #1356.

This updates `contracts/lending_pool/src/lib.rs::adjust_outstanding` so the tracked outstanding balance applies the signed delta in the same direction as the caller provides it. The previous implementation subtracted the delta, so positive loan deployment reduced outstanding and negative repayment adjustments increased it.

I added a focused regression covering both directions:
- `+700` moves total outstanding to `700`
- `-200` then moves it down to `500`

Validation: static GitHub compare/API checks only. I did not run the Rust/Soroban test suite locally because this environment is avoiding dependency/toolchain installation or execution.