### PR TITLE
fix: compute refinance outstanding delta from new amount

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1993,9 +1993,8 @@ impl LoanManager {
             core::cmp::Ordering::Equal => {}
         }
 
-        let outstanding_delta = loan
-            .amount
-            .checked_sub(new_amount)
+        let outstanding_delta = new_amount
+            .checked_sub(loan.amount)
             .expect("outstanding delta overflow");
         Self::adjust_total_outstanding(&env, &token, outstanding_delta);
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -2839,6 +2839,7 @@ fn test_refinance_loan_increases_principal_draws_from_pool() {
     // Approve a 1_000-unit loan, then set collateral high enough for refinance.
     let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
     manager.approve_loan(&loan_id);
+    assert_eq!(manager.get_total_outstanding(&token_id), 1_000);
 
     // Inject collateral directly so the contract accepts the larger amount.
     stellar_token.mint(&manager.address, &5_000);
@@ -2859,6 +2860,7 @@ fn test_refinance_loan_increases_principal_draws_from_pool() {
     assert_eq!(loan.amount, 2_000);
     assert_eq!(loan.principal_paid, 0); // reset on refinance
     assert_eq!(loan.status, LoanStatus::Approved);
+    assert_eq!(manager.get_total_outstanding(&token_id), 2_000);
     // Borrower received the additional 1_000 from the pool.
     assert_eq!(
         token_client.balance(&borrower),


### PR DESCRIPTION
Fixes #1354.

This updates `contracts/loan_manager/src/lib.rs::refinance_loan` so the outstanding-balance adjustment is computed as `new_amount - loan.amount`. The previous `loan.amount - new_amount` sign made an upward refinance reduce tracked outstanding, which can corrupt liquidity/share-price accounting and allow over-borrowing.

I also tightened the existing increase-refinance test to assert total outstanding before and after the refinance:
- approved 1,000 loan records 1,000 outstanding
- refinancing to 2,000 records 2,000 outstanding

Validation: static GitHub compare/API checks only. I did not run the Rust/Soroban test suite locally because this environment is avoiding dependency/toolchain installation or execution.