### PR TITLE
fix: refund liquidation surplus to borrower

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1666,7 +1666,7 @@ impl LoanManager {
         if borrower_refund > 0 {
             token_client.transfer(
                 &env.current_contract_address(),
-                &liquidator,
+                &loan.borrower,
                 &borrower_refund,
             );
         }


### PR DESCRIPTION
Fixes #1352.

This updates `contracts/loan_manager/src/lib.rs::liquidate` so any liquidation surplus refund is returned to `loan.borrower` instead of being paid to the liquidator. The liquidator still receives only the capped liquidation bonus.

The existing liquidation regression already asserts the intended flow for a 1,400 collateral / 1,000 debt case:
- pool receives 1,000 debt recovery
- liquidator receives 140 bonus
- borrower receives the remaining 260 refund

Validation: static GitHub compare/API checks only. I did not run the Rust/Soroban test suite locally because this environment is avoiding dependency/toolchain installation or execution.