### PR TITLE
fix: order loan request xdr arguments

### DIFF
--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./soroban.ts", import.meta.url), "utf8");
+
+describe("buildUnsignedLoanRequestXdr", () => {
+  it("passes request_loan arguments as borrower, amount, term", () => {
+    expect(source).toContain("functionName: \"request_loan\"");
+    expect(source).toContain("args: [borrowerScVal, amountScVal, termScVal]");
+    expect(source).not.toContain("args: [borrowerScVal, termScVal, amountScVal]");
+  });
+});

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -55,7 +55,7 @@ export async function buildUnsignedLoanRequestXdr({
           new xdr.InvokeContractArgs({
             contractAddress: Address.fromString(contractId).toScAddress(),
             functionName: "request_loan",
-            args: [borrowerScVal, termScVal, amountScVal],
+            args: [borrowerScVal, amountScVal, termScVal],
           }),
         ),
         auth: [],


### PR DESCRIPTION
Fixes #1350.

This updates `frontend/src/app/utils/soroban.ts::buildUnsignedLoanRequestXdr` so the generated `request_loan` call passes arguments in the contract signature order: borrower, amount, term.

The previous order sent borrower, term, amount, so the contract received amount and term transposed.

I added a small regression in `frontend/src/app/utils/soroban.test.ts` that locks the `request_loan` argument order and rejects the previous swapped order.

Validation: static GitHub compare/API checks only. I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain installation or execution.