### PR TITLE
fix: only trigger level up on strict increase

### DIFF
--- a/frontend/src/app/stores/stores.test.ts
+++ b/frontend/src/app/stores/stores.test.ts
@@ -325,6 +325,23 @@ describe("useGamificationStore", () => {
       expect(state.pendingLevelUp).toBeNull();
     });
 
+    it("does not trigger level-up when recalculated level equals current level", () => {
+      useGamificationStore.setState({
+        xp: 100,
+        level: 2,
+        kingdomTitle: "Merchant",
+        showLevelUpModal: false,
+        pendingLevelUp: null,
+      });
+
+      useGamificationStore.getState().checkLevelUp();
+
+      const state = useGamificationStore.getState();
+      expect(state.level).toBe(2);
+      expect(state.kingdomTitle).toBe("Merchant");
+      expect(state.showLevelUpModal).toBe(false);
+      expect(state.pendingLevelUp).toBeNull();
+    });
     it("dismissLevelUp clears the modal and pending reward", () => {
       useGamificationStore.getState().addXP(100);
       useGamificationStore.getState().dismissLevelUp();

--- a/frontend/src/app/stores/useGamificationStore.ts
+++ b/frontend/src/app/stores/useGamificationStore.ts
@@ -236,7 +236,7 @@ export const useGamificationStore = create<GamificationStore>()(
           const { xp, level } = get();
           const newLevel = calculateLevel(xp);
 
-          if (newLevel >= level) {
+          if (newLevel > level) {
             const levelUpReward = LEVEL_THRESHOLDS.find((t) => t.level === newLevel);
             if (levelUpReward) {
               set(


### PR DESCRIPTION
Fixes #1348.

This updates `frontend/src/app/stores/useGamificationStore.ts::checkLevelUp` so the level-up path only runs when the recalculated level is strictly greater than the current level.

The previous inclusive `newLevel >= level` check could reopen the level-up modal when XP recalculated to the same level.

I added a regression in `frontend/src/app/stores/stores.test.ts` that sets XP and level to the same calculated threshold, calls `checkLevelUp`, and verifies no modal/reward is created.

Validation: static GitHub compare/API checks only. I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain installation or execution.