### PR TITLE
fix: format loan repayment as debit

### DIFF
--- a/frontend/src/app/utils/transactionFormatter.test.ts
+++ b/frontend/src/app/utils/transactionFormatter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatLoanRepayment } from "./transactionFormatter";
+
+describe("formatLoanRepayment", () => {
+  it("formats repayment as a USDC debit", () => {
+    const preview = formatLoanRepayment({ loanId: 42, amount: 125 });
+
+    expect(preview.balanceChanges).toEqual([
+      {
+        token: "USDC",
+        change: "-125",
+        isPositive: false,
+      },
+    ]);
+  });
+});

--- a/frontend/src/app/utils/transactionFormatter.ts
+++ b/frontend/src/app/utils/transactionFormatter.ts
@@ -87,7 +87,7 @@ export function formatLoanRepayment(params: LoanRepaymentParams): TransactionPre
     {
       token: "USDC",
       change: `-${params.amount}`,
-      isPositive: true,
+      isPositive: false,
     },
   ];
 


### PR DESCRIPTION
Fixes #1347.

This updates `frontend/src/app/utils/transactionFormatter.ts::formatLoanRepayment` so a loan repayment balance change is marked as a debit/outflow (`isPositive: false`). The rendered change string was already negative, but the positive flag made the history treat it like money coming in.

I added `frontend/src/app/utils/transactionFormatter.test.ts` to lock the repayment preview as `USDC / -amount / isPositive: false`.

Validation: static GitHub compare/API checks only. I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain installation or execution.