### PR TITLE
fix: decrease optimistic total deposits on withdraw

### DIFF
--- a/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
+++ b/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
@@ -237,6 +237,32 @@ describe("useWithdrawFromPool optimistic rollback", () => {
     });
   });
 
+
+  it("onMutate decreases totalDeposits and depositor depositAmount optimistically", async () => {
+    global.fetch = mockFetchSuccess({
+      unsignedTxXdr: "xdr",
+      networkPassphrase: "pass",
+    }) as unknown as typeof fetch;
+    const { queryClient, wrapper } = createTestHarness();
+    seedWithdrawCache(queryClient);
+
+    const { result } = renderHook(() => useWithdrawFromPool(), { wrapper });
+
+    result.current.mutate({
+      amount: 250,
+      depositorAddress: DEPOSITOR,
+      token: "USDC",
+    });
+
+    await waitFor(() => {
+      const cachedStats = queryClient.getQueryData<PoolStats>(queryKeys.pool.stats());
+      const cachedDepositor = queryClient.getQueryData<DepositorPortfolio>(
+        queryKeys.pool.depositor(DEPOSITOR),
+      );
+      expect(cachedStats?.totalDeposits).toBe(9750);
+      expect(cachedDepositor?.depositAmount).toBe(250);
+    });
+  });
   it("onError restores exact previous pool stats and depositor portfolio", async () => {
     global.fetch = mockFetchFailure() as unknown as typeof fetch;
     const { queryClient, wrapper } = createTestHarness();
@@ -319,6 +345,32 @@ describe("useDepositToPool optimistic rollback", () => {
     });
   });
 
+
+  it("onMutate decreases totalDeposits and depositor depositAmount optimistically", async () => {
+    global.fetch = mockFetchSuccess({
+      unsignedTxXdr: "xdr",
+      networkPassphrase: "pass",
+    }) as unknown as typeof fetch;
+    const { queryClient, wrapper } = createTestHarness();
+    seedWithdrawCache(queryClient);
+
+    const { result } = renderHook(() => useWithdrawFromPool(), { wrapper });
+
+    result.current.mutate({
+      amount: 250,
+      depositorAddress: DEPOSITOR,
+      token: "USDC",
+    });
+
+    await waitFor(() => {
+      const cachedStats = queryClient.getQueryData<PoolStats>(queryKeys.pool.stats());
+      const cachedDepositor = queryClient.getQueryData<DepositorPortfolio>(
+        queryKeys.pool.depositor(DEPOSITOR),
+      );
+      expect(cachedStats?.totalDeposits).toBe(9750);
+      expect(cachedDepositor?.depositAmount).toBe(250);
+    });
+  });
   it("onError restores exact previous pool stats and depositor portfolio", async () => {
     global.fetch = mockFetchFailure() as unknown as typeof fetch;
     const { queryClient, wrapper } = createTestHarness();

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -1757,7 +1757,7 @@ export function useWithdrawFromPool() {
       // Optimistically update pool stats
       queryClient.setQueryData(queryKeys.pool.stats(), (old: PoolStats | undefined) => {
         if (!old) return old;
-        return { ...old, totalDeposits: Math.max(0, old.totalDeposits + amount) };
+        return { ...old, totalDeposits: Math.max(0, old.totalDeposits - amount) };
       });
 
       // Optimistically update depositor portfolio


### PR DESCRIPTION
Fixes #1343.

This updates `frontend/src/app/hooks/useApi.ts::useWithdrawFromPool` so the optimistic pool stats update subtracts the withdrawn amount from `totalDeposits` instead of adding it.

The depositor-side optimistic update already subtracted from `depositAmount`; this aligns pool stats with that same withdrawal direction.

I added a normal-path regression in `frontend/src/app/hooks/useApi.optimisticRollback.test.tsx` for a 250 USDC withdrawal from seeded stats, asserting:
- `totalDeposits` moves from 10,000 to 9,750
- depositor `depositAmount` moves from 500 to 250

Validation: static GitHub compare/API checks only. I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain installation or execution.