### PR TITLE
fix: order repayment xdr arguments

### DIFF
--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./soroban.ts", import.meta.url), "utf8");
+
+describe("buildUnsignedRepaymentXdr", () => {
+  it("passes repay arguments as borrower, loan id, amount", () => {
+    expect(source).toContain('functionName: "repay"');
+    expect(source).toContain("args: [borrowerScVal, loanIdScVal, amountScVal]");
+    expect(source).not.toContain("args: [borrowerScVal, amountScVal, loanIdScVal]");
+  });
+});

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -93,7 +93,7 @@ export async function buildUnsignedRepaymentXdr({
           new xdr.InvokeContractArgs({
             contractAddress: Address.fromString(contractId).toScAddress(),
             functionName: "repay",
-            args: [borrowerScVal, amountScVal, loanIdScVal],
+            args: [borrowerScVal, loanIdScVal, amountScVal],
           }),
         ),
         auth: [],


### PR DESCRIPTION
## Summary
- order the repayment XDR arguments as borrower, loan id, amount
- add a static regression test for the repay argument order

Fixes #1341.

## Validation
- Static source inspection only; no local dependency install or test execution in this environment.