### PR TITLE
fix: increase optimistic total repaid

### DIFF
--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -1602,7 +1602,7 @@ export function useRepayLoan() {
           return {
             ...old,
             totalOwed: newOwed,
-            totalRepaid: old.totalRepaid - amount,
+            totalRepaid: old.totalRepaid + amount,
             status: newOwed <= 0 ? ("repaid" as const) : old.status,
           };
         },


### PR DESCRIPTION
## Summary
- update `useRepayLoan` optimistic loan detail state so `totalRepaid` increases by the repayment amount
- keep the existing rollback/invalidation behavior unchanged

Fixes #1342.

## Validation
- Existing regression coverage in `frontend/src/app/hooks/useApi.optimisticRollback.test.tsx` expects a 100 repayment to move `totalRepaid` from 200 to 300.
- Static source inspection only; no local dependency install or test execution in this environment.