### PR TITLE
fix: clamp scores at documented maximum

### DIFF
--- a/backend/src/__tests__/score.test.ts
+++ b/backend/src/__tests__/score.test.ts
@@ -150,6 +150,33 @@ describe('POST /api/score/update', () => {
     expect(response.body.newScore).toBe(515);
   });
 
+
+  it('should clamp updated scores at the documented maximum', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ current_score: 845 }],
+      command: 'SELECT',
+      rowCount: 1,
+      oid: 0,
+      fields: [],
+    });
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ current_score: 850 }],
+      command: 'INSERT',
+      rowCount: 1,
+      oid: 0,
+      fields: [],
+    });
+
+    const response = await request(app)
+      .post('/api/score/update')
+      .set('x-api-key', 'test-internal-key')
+      .send({ userId: 'cap-user', repaymentAmount: 500, onTime: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.newScore).toBe(850);
+    expect(mockedQuery.mock.calls[1][0]).toContain('LEAST(850, GREATEST(300');
+    expect(mockedQuery.mock.calls[1][0]).not.toContain('LEAST(8500');
+  });
   it('should reject negative repaymentAmount', async () => {
     const response = await request(app)
       .post('/api/score/update')

--- a/backend/src/controllers/scoreController.ts
+++ b/backend/src/controllers/scoreController.ts
@@ -109,7 +109,7 @@ export const updateScore = asyncHandler(async (req: Request, res: Response) => {
      VALUES ($1, $2)
      ON CONFLICT (user_id) 
      DO UPDATE SET 
-       current_score = LEAST(8500, GREATEST(300, scores.current_score + $3)),
+       current_score = LEAST(850, GREATEST(300, scores.current_score + $3)),
        updated_at = CURRENT_TIMESTAMP
      RETURNING current_score`,
     [userId, 500 + delta, delta],


### PR DESCRIPTION
## Summary
- clamp score updates at the documented maximum score of 850 instead of 8500
- add a regression assertion for the generated update SQL and response score

Fixes #1338.

## Validation
- Static source inspection only; no local dependency install or test execution in this environment.