### PR TITLE
fix: include amount in repay idempotency key

### DIFF
--- a/backend/src/__tests__/loanController.idempotencyKey.test.ts
+++ b/backend/src/__tests__/loanController.idempotencyKey.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../controllers/loanController.ts', import.meta.url), 'utf8');
+
+describe('repayLoan idempotency key', () => {
+  it('includes borrower, loan id, and repayment amount', () => {
+    expect(source).toContain(
+      'const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${amount}`;',
+    );
+    expect(source).not.toContain(
+      'const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${loanIdNum}`;',
+    );
+  });
+});

--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -747,7 +747,7 @@ export const repayLoan = asyncHandler(async (req: Request, res: Response) => {
   }
 
   // Idempotency: return existing unsigned tx if recently built for this borrower/loan/amount
-  const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${loanIdNum}`;
+  const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${amount}`;
   const cachedTx = await cacheService.get<{
     unsignedTxXdr: string;
     networkPassphrase: string;


### PR DESCRIPTION
## Summary
- include the repayment amount in the `repayLoan` pending transaction idempotency key
- add a static regression test that rejects the old repeated-loan-id key

Fixes #1337.

## Validation
- Static source inspection only; no local dependency install or test execution in this environment.