### PR TITLE
fix: restore login rate limit window

### DIFF
--- a/backend/src/middleware/__tests__/rateLimiterConfig.test.ts
+++ b/backend/src/middleware/__tests__/rateLimiterConfig.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../rateLimiter.ts', import.meta.url), 'utf8');
+
+describe('loginRateLimiter config', () => {
+  it('uses the intended one-minute window', () => {
+    const loginBlock = source.slice(
+      source.indexOf('export const loginRateLimiter'),
+      source.indexOf('export const ipLoginRateLimiter'),
+    );
+
+    expect(loginBlock).toContain('windowMs: 60 * 1000');
+    expect(loginBlock).not.toContain('windowMs: 6 * 1000');
+  });
+});

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -30,7 +30,7 @@ export const challengeRateLimiter = rateLimit({
 });
 
 export const loginRateLimiter = rateLimit({
-  windowMs: 6 * 1000, // 1 minute
+  windowMs: 60 * 1000, // 1 minute
   max: 5,
   keyGenerator: (req) =>
     `${ipKeyGenerator(req.ip ?? 'unknown')}:${req.body?.publicKey ?? 'unknown'}`,


### PR DESCRIPTION
## Summary
- restore the login rate limiter to the intended one-minute window
- add a static regression test for the login limiter window value

Fixes #1336.

## Validation
- Static source inspection only; no local dependency install or test execution in this environment.