### PR TITLE
fix: classify on-time repayments by deadline

### DIFF
--- a/backend/src/__tests__/scoreBreakdownDeadline.test.ts
+++ b/backend/src/__tests__/scoreBreakdownDeadline.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../controllers/scoreController.ts', import.meta.url), 'utf8');
+
+describe('score breakdown repayment timing query', () => {
+  it('classifies repayments against approved ledger plus term ledgers', () => {
+    expect(source).toContain(
+      'CASE WHEN r.repaid_ledger <= a.approved_ledger + a.term_ledgers',
+    );
+    expect(source).not.toContain(
+      'CASE WHEN r.repaid_ledger <= a.approved_ledger - a.term_ledgers',
+    );
+  });
+});

--- a/backend/src/controllers/scoreController.ts
+++ b/backend/src/controllers/scoreController.ts
@@ -207,7 +207,7 @@ export const getScoreBreakdown = asyncHandler(async (req: Request, res: Response
            r.loan_id,
            r.repaid_ledger,
            r.repaid_at,
-           CASE WHEN r.repaid_ledger <= a.approved_ledger - a.term_ledgers
+           CASE WHEN r.repaid_ledger <= a.approved_ledger + a.term_ledgers
                 THEN true ELSE false END AS on_time,
            (r.repaid_ledger - a.approved_ledger) AS repayment_ledgers
          FROM repaid_loans r


### PR DESCRIPTION
## Summary
- classify score-breakdown repayments against the actual deadline (`approved_ledger + term_ledgers`)
- add a static regression test that rejects the old subtractive deadline comparison

Fixes #1334.

## Validation
- Static source inspection only; no local dependency install or test execution in this environment.