### PR TITLE
fix: descale pool share price ratio

### DIFF
--- a/backend/src/controllers/poolController.ts
+++ b/backend/src/controllers/poolController.ts
@@ -389,7 +389,7 @@ export const getPoolSharePrice = asyncHandler(async (req: Request, res: Response
   }
 
   const sharePrice = await sorobanService.getSharePrice(token);
-  const sharePriceRatio = sharePrice * SHARE_PRICE_SCALE;
+  const sharePriceRatio = sharePrice / SHARE_PRICE_SCALE;
 
   const data = { sharePrice, sharePriceRatio };
 


### PR DESCRIPTION
## Summary
- de-scale `getPoolSharePrice` by dividing the raw on-chain share price by `SHARE_PRICE_SCALE`
- keep the existing share-price tests as the regression coverage for `1_050_000 -> 1.05`

Fixes #1333.

## Validation
- Existing `backend/src/__tests__/poolController.sharePrice.test.ts` expects the corrected human-readable ratio.
- Static source inspection only; no local dependency install or test execution in this environment.