### PR TITLE
fix: correct cancel loan status set

### DIFF
--- a/backend/src/__tests__/loanControllerCancelStatus.test.ts
+++ b/backend/src/__tests__/loanControllerCancelStatus.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../controllers/loanController.ts', import.meta.url), 'utf8');
+
+describe('buildCancelLoanTx cancellable statuses', () => {
+  it('allows pending and open loans but not defaulted loans', () => {
+    expect(source).toContain("['PENDING', 'OPEN'].includes(loan.status as string)");
+    expect(source).not.toContain("['PENDING', 'DEFAULTED'].includes(loan.status as string)");
+  });
+});

--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -63,7 +63,7 @@ export const buildCancelLoanTx = async (req: Request, res: Response, next: NextF
       });
     }
 
-    if (!['PENDING', 'DEFAULTED'].includes(loan.status as string)) {
+    if (!['PENDING', 'OPEN'].includes(loan.status as string)) {
       return res.status(400).json({
         message: 'Loan cannot be cancelled',
       });


### PR DESCRIPTION
Fixes #1331.

Updates ackend/src/controllers/loanController.ts so uildCancelLoanTx allows the cancellable PENDING and OPEN states while rejecting DEFAULTED loans. Adds a small regression test that locks the allowed-status set.

Validation: static source inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.