### PR TITLE
fix: require ledgers past due before default check

### DIFF
--- a/backend/src/services/__tests__/defaultCheckerOverdueBoundary.test.ts
+++ b/backend/src/services/__tests__/defaultCheckerOverdueBoundary.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../defaultChecker.ts', import.meta.url), 'utf8');
+
+describe('DefaultChecker overdue ledger boundary', () => {
+  it('only selects loans after the current ledger passes the due ledger', () => {
+    expect(source).toContain('WHERE due_ledger < $2');
+    expect(source).not.toContain('WHERE due_ledger <= $2');
+  });
+});

--- a/backend/src/services/defaultChecker.ts
+++ b/backend/src/services/defaultChecker.ts
@@ -169,7 +169,7 @@ export class DefaultChecker {
       )
       SELECT loan_id
       FROM active
-      WHERE due_ledger <= $2
+      WHERE due_ledger < $2
       ORDER BY due_ledger ASC, loan_id ASC
       LIMIT $3
       `,


### PR DESCRIPTION
Fixes #1319.

Updates ackend/src/services/defaultChecker.ts so etchOverdueLoanIds uses the same strict due-ledger boundary as the stats query: a loan is selected only when due_ledger < currentLedger, not when the current ledger is exactly the due ledger.

Adds a small regression in ackend/src/services/__tests__/defaultCheckerOverdueBoundary.test.ts to reject the old inclusive comparison.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.