### PR TITLE
fix: clamp webhook retry delay index

### DIFF
--- a/backend/src/services/__tests__/webhookRetryDelaySource.test.ts
+++ b/backend/src/services/__tests__/webhookRetryDelaySource.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../webhookService.ts', import.meta.url), 'utf8');
+
+describe('webhook retry delay index', () => {
+  it('clamps retry attempts to the matching delay step instead of always using the last delay', () => {
+    expect(source).toContain('Math.min(Math.max(attemptNumber - 1, 0), RETRY_DELAYS_MS.length - 1)');
+    expect(source).not.toContain('Math.max(attemptNumber - 1, RETRY_DELAYS_MS.length - 1)');
+  });
+});

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -276,7 +276,7 @@ const RETRY_DELAYS_MS = [5 * 60 * 1000, 15 * 60 * 1000, 45 * 60 * 1000] as const
 const MAX_RETRY_ATTEMPTS = RETRY_DELAYS_MS.length + 1;
 
 export const getRetryDelayMs = (attemptNumber: number): number => {
-  const delayIndex = Math.max(attemptNumber - 1, RETRY_DELAYS_MS.length - 1);
+  const delayIndex = Math.min(Math.max(attemptNumber - 1, 0), RETRY_DELAYS_MS.length - 1);
   return RETRY_DELAYS_MS[delayIndex] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!;
 };
 


### PR DESCRIPTION
Fixes #1324.

Updates ackend/src/services/webhookService.ts so getRetryDelayMs clamps the attempt index between the first and last configured delay. The previous Math.max(attemptNumber - 1, RETRY_DELAYS_MS.length - 1) expression always selected the last delay for early attempts.

Adds a focused regression in ackend/src/services/__tests__/webhookRetryDelaySource.test.ts to reject the old expression.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.