### PR TITLE
fix: compute asset value from share ratio

### DIFF
--- a/backend/src/services/__tests__/yieldHistoryService.test.ts
+++ b/backend/src/services/__tests__/yieldHistoryService.test.ts
@@ -76,6 +76,28 @@ describe('yieldHistoryService', () => {
     expect(latest.currentValue).toBeGreaterThanOrEqual(1000);
     expect(latest.netYield).toBeGreaterThanOrEqual(0);
   });
+  it('values shares as shares times pool balance divided by total shares', async () => {
+    const now = new Date();
+    const yesterday = new Date(now);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { event_type: 'Deposit', amount: '1000', ledger_closed_at: yesterday, value: null },
+        { event_type: 'YieldDistributed', amount: '500', ledger_closed_at: now, value: null },
+      ],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ event_type: 'Deposit', amount: '100', ledger_closed_at: yesterday, value: null }],
+    });
+
+    const history = await buildDepositorYieldHistory('GDepositor', 'GToken', 7);
+    const latest = history[history.length - 1]!;
+
+    expect(latest.depositedValue).toBe(100);
+    expect(latest.currentValue).toBe(150);
+    expect(latest.netYield).toBe(50);
+  });
 
   // Issue #1171 — previously uncovered paths
 

--- a/backend/src/services/yieldHistoryService.ts
+++ b/backend/src/services/yieldHistoryService.ts
@@ -61,7 +61,7 @@ function assetValueFromShares(shares: number, poolBalance: number, totalShares: 
   if (shares <= 0 || totalShares <= 0) {
     return 0;
   }
-  return (shares * totalShares) / poolBalance;
+  return (shares * poolBalance) / totalShares;
 }
 
 function applyPoolEvent(


### PR DESCRIPTION
Fixes #1325.

Updates ackend/src/services/yieldHistoryService.ts so ssetValueFromShares computes shares * poolBalance / totalShares. The previous formula inverted the ratio and returned incorrect depositor value whenever share price differed from 1.

Adds a regression in ackend/src/services/__tests__/yieldHistoryService.test.ts where a depositor with 100 of 1000 shares in a pool worth 1500 assets is valued at 150 assets.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.