### PR TITLE
fix: subtract score decay points

### DIFF
--- a/backend/src/services/__tests__/scoreDecayServiceSource.test.ts
+++ b/backend/src/services/__tests__/scoreDecayServiceSource.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../scoreDecayService.ts', import.meta.url), 'utf8');
+
+describe('score decay direction', () => {
+  it('subtracts decay points from inactive borrower scores', () => {
+    expect(source).toContain('Math.max(MIN_SCORE, borrower.score - decay)');
+    expect(source).not.toContain('Math.max(MIN_SCORE, borrower.score + decay)');
+  });
+});

--- a/backend/src/services/scoreDecayService.ts
+++ b/backend/src/services/scoreDecayService.ts
@@ -37,7 +37,7 @@ export async function applyScoreDecay(borrower: InactiveBorrower) {
     );
   }
   const decay = monthsInactive * DECAY_PER_MONTH;
-  const newScore = Math.max(MIN_SCORE, borrower.score + decay);
+  const newScore = Math.max(MIN_SCORE, borrower.score - decay);
   await query(`UPDATE scores SET score = $1, updated_at = CURRENT_TIMESTAMP WHERE borrower = $2`, [
     newScore,
     borrower.borrower,


### PR DESCRIPTION
Fixes #1326.

Updates ackend/src/services/scoreDecayService.ts so pplyScoreDecay subtracts inactivity decay from the borrower score instead of adding it. Existing behavioral tests already expect decayed scores such as 700 -> 695; this patch aligns the implementation with that behavior.

Adds a small source regression in ackend/src/services/__tests__/scoreDecayServiceSource.test.ts to reject the old additive expression.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.