### PR TITLE
fix: skip idempotency cache for server errors

### DIFF
--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -82,7 +82,7 @@ export const idempotencyMiddleware = async (
     res.on('finish', async () => {
       // Only cache 2xx and 4xx status codes.
       // 5xx errors should usually be retried without returning a cached failure.
-      if (res.statusCode >= 200 && res.statusCode < 600 && responseBody) {
+      if (res.statusCode >= 200 && res.statusCode < 500 && responseBody) {
         try {
           await cacheService.set(
             cacheKey,

--- a/backend/src/tests/idempotency.test.ts
+++ b/backend/src/tests/idempotency.test.ts
@@ -95,4 +95,21 @@ describe('Idempotency Middleware', () => {
     expect(next).toHaveBeenCalled();
     expect(res.on).toHaveBeenCalledWith('finish', expect.any(Function));
   });
+  it('does not cache 5xx responses on cache miss', async () => {
+    const key = 'server-error-key';
+    let finishHandler: (() => Promise<void>) | undefined;
+    asMock(req.header).mockReturnValue(key);
+    (cacheService.get as jest.Mock<() => Promise<unknown>>).mockResolvedValue(null);
+    (res.on as jest.Mock).mockImplementation((event: string, handler: () => Promise<void>) => {
+      if (event === 'finish') finishHandler = handler;
+      return res as Response;
+    });
+
+    await idempotencyMiddleware(req as Request, res as Response, next);
+    (res as Response).statusCode = 503;
+    (res.json as Response['json'])({ success: false, message: 'temporary failure' });
+    await finishHandler?.();
+
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #1329.

Updates ackend/src/middleware/idempotency.ts so idempotency caching stores only 2xx and 4xx responses. 5xx responses are now left uncached, allowing clients to retry transient server failures instead of replaying a cached failure for the same key.

Adds a unit regression in ackend/src/tests/idempotency.test.ts that simulates a 503 response on a cache miss and asserts cacheService.set is not called.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.