### PR TITLE
fix: detect score reconciliation divergence

### DIFF
--- a/backend/src/services/__tests__/scoreReconciliationSource.test.ts
+++ b/backend/src/services/__tests__/scoreReconciliationSource.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../scoreReconciliationService.ts', import.meta.url), 'utf8');
+
+describe('score reconciliation divergence check', () => {
+  it('marks scores divergent only when DB score is missing or differs from contract score', () => {
+    expect(source).toContain('dbScore === null || dbScore !== contractScore');
+    expect(source).not.toContain('dbScore === null || dbScore === contractScore');
+  });
+});

--- a/backend/src/services/scoreReconciliationService.ts
+++ b/backend/src/services/scoreReconciliationService.ts
@@ -162,7 +162,7 @@ class ScoreReconciliationService {
           checkedBorrowerCount += 1;
           const { dbScore, contractScore } = result.value;
           const absoluteDifference = dbScore === null ? null : Math.abs(contractScore - dbScore);
-          const isDivergent = dbScore === null || dbScore === contractScore;
+          const isDivergent = dbScore === null || dbScore !== contractScore;
 
           if (!isDivergent) {
             return;


### PR DESCRIPTION
Fixes #1327.

Updates ackend/src/services/scoreReconciliationService.ts so reconciliation marks a borrower divergent when the DB score is missing or differs from the on-chain score. The previous equality check treated matching scores as divergent and skipped real drift.

Adds a small source regression in ackend/src/services/__tests__/scoreReconciliationSource.test.ts to reject the old equality condition.

Validation: static source/API inspection only; local backend tests were not run because this environment is avoiding dependency/toolchain installation or execution.