### PR TITLE
fix: store remittance sender and recipient correctly

### DIFF
--- a/backend/src/__tests__/remittanceService.test.ts
+++ b/backend/src/__tests__/remittanceService.test.ts
@@ -34,6 +34,7 @@ const { remittanceService } = await import('../services/remittanceService.js');
 const USDC_ISSUER = Keypair.random().publicKey();
 const SENDER = Keypair.random().publicKey();
 const RECIPIENT = Keypair.random().publicKey();
+let lastInsertParams: unknown[] = [];
 
 function mockRemittanceInsert() {
   mockWithTransaction.mockImplementation(async (...args: unknown[]) => {
@@ -44,6 +45,7 @@ function mockRemittanceInsert() {
     let xdrValue = '';
     const result = await callback({
       query: async (_sql: string, queryParams: unknown[]) => {
+        lastInsertParams = queryParams;
         xdrValue = queryParams[8] as string;
         return {
           rows: [
@@ -124,6 +126,20 @@ describe('remittanceService.createRemittance', () => {
 
     expect(payment.asset.getCode()).toBe('USDC');
     expect(payment.asset.getIssuer()).toBe(USDC_ISSUER);
+  });
+
+  it('stores sender and recipient in their matching remittance columns', async () => {
+    await remittanceService.createRemittance({
+      recipientAddress: RECIPIENT,
+      amount: 25,
+      fromCurrency: 'XLM',
+      toCurrency: 'XLM',
+      memo: 'test',
+      senderAddress: SENDER,
+    });
+
+    expect(lastInsertParams[1]).toBe(SENDER);
+    expect(lastInsertParams[2]).toBe(RECIPIENT);
   });
 
   it("builds the payment XDR from the sender's live Stellar sequence", async () => {

--- a/backend/src/services/remittanceService.ts
+++ b/backend/src/services/remittanceService.ts
@@ -127,8 +127,8 @@ export const remittanceService = {
            RETURNING *`,
           [
             id,
-            payload.recipientAddress,
             payload.senderAddress,
+            payload.recipientAddress,
             payload.amount,
             normalizedFromCurrency,
             normalizedToCurrency,


### PR DESCRIPTION
Fixes #1328.

This corrects the `createRemittance` insert parameter order so `sender_id` receives `payload.senderAddress` and `recipient_address` receives `payload.recipientAddress`. I also added a service test assertion that captures the insert params and verifies those fields are stored in the matching columns.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.