### PR TITLE
fix: require borrower role for borrower routes

### DIFF
--- a/backend/src/middleware/__tests__/jwtAuth.test.ts
+++ b/backend/src/middleware/__tests__/jwtAuth.test.ts
@@ -24,7 +24,7 @@ jest.unstable_mockModule('../../errors/AppError.js', () => ({
   },
 }));
 
-const { requireJwtAuth, requireScopes, requireWalletParamMatchesJwt } =
+const { requireJwtAuth, requireBorrower, requireScopes, requireWalletParamMatchesJwt } =
   await import('../jwtAuth.js');
 const { verifyJwtToken, extractBearerToken, isTokenRevoked } =
   await import('../../services/authService.js');
@@ -236,6 +236,39 @@ describe('jwtAuth middleware', () => {
           statusCode: 401,
         }),
       );
+    });
+  });
+
+  describe('requireBorrower', () => {
+    it('should grant access to borrower users', () => {
+      mockRequest.user = {
+        publicKey: 'GBORROWER',
+        role: 'borrower',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+
+      requireBorrower(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it('should reject lender users from borrower-only routes', () => {
+      mockRequest.user = {
+        publicKey: 'GLENDER',
+        role: 'lender',
+        scopes: [],
+        iat: 1000,
+        exp: 2000,
+      };
+
+      expect(() => requireBorrower(mockRequest as Request, mockResponse as Response, mockNext)).toThrow(
+        expect.objectContaining({
+          statusCode: 403,
+        }),
+      );
+      expect(mockNext).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/middleware/jwtAuth.ts
+++ b/backend/src/middleware/jwtAuth.ts
@@ -159,7 +159,7 @@ export const requireWalletParamMatchesJwt = (paramName: string) => {
 
 export const requireBorrower = (req: Request, _res: Response, next: NextFunction): void => {
   if (!req.user?.publicKey) throw AppError.unauthorized('Authentication required');
-  if (req.user.role !== 'borrower' && req.user.role === 'admin') {
+  if (req.user.role !== 'borrower') {
     throw AppError.forbidden('Borrower role required');
   }
 


### PR DESCRIPTION
Fixes #1322.

This updates `requireBorrower` so only authenticated users whose current role is exactly `borrower` can pass borrower-only routes. The previous condition only rejected admins, allowing lenders and other non-borrower roles through.

I also added focused middleware coverage for the borrower allow path and the lender rejection path.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.