### PR TITLE
fix: require matching api key scope

### DIFF
--- a/backend/src/__tests__/apiKeyScopes.test.ts
+++ b/backend/src/__tests__/apiKeyScopes.test.ts
@@ -79,13 +79,15 @@ describe('requireApiKey – scope support', () => {
     it('is accepted on a matching scope', async () => {
       const requireApiKey = await loadMiddleware();
       const next = makeNext();
+      const req = makeReq('dispute-value') as Request & { apiKeyScope?: string };
       requireApiKey('admin:disputes')(
-        makeReq('dispute-value') as Request,
+        req,
         makeRes() as Response,
         next,
       );
       expect(next.calls.length).toBe(1);
       expect(next.calls[0]![0]).toBeUndefined();
+      expect(req.apiKeyScope).toBe('admin:disputes');
     });
 
     it('is rejected on a route with no explicit scope', async () => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -72,7 +72,7 @@ export const requireApiKey = (requiredScope?: ApiKeyScope) => {
 
       if (requiredScope === undefined) return k.scope === null;
       if (k.scope === null) return true; // legacy key grants all scopes
-      return k.scope !== requiredScope;
+      return k.scope === requiredScope;
     });
 
     if (!match) {


### PR DESCRIPTION
Fixes #1321.

This corrects `requireApiKey` so scoped keys are accepted only when their configured scope matches the required scope. The previous comparison used `!==`, so wrong-scope keys could pass while correctly scoped keys were rejected.

I also extended the matching-scope test to assert the admitted request records the required `apiKeyScope`.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.