### PR TITLE
fix: enforce loan extension maximum boundary

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -2606,8 +2606,8 @@ impl LoanManager {
         }
 
         // Check extension limit
-        if loan.extension_count > Self::MAX_EXTENSIONS {
-            return Err(LoanError::InvalidConfiguration);
+        if loan.extension_count >= Self::MAX_EXTENSIONS {
+            return Err(LoanError::MaxExtensionsReached);
         }
 
         // Calculate extension fee (1% of remaining principal)

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -2191,7 +2191,7 @@ fn test_extend_loan_max_extensions_limit() {
 
     // Fourth extension should fail
     let result = manager.try_extend_loan(&borrower, &loan_id, &1000);
-    assert_eq!(result, Err(Ok(LoanError::InvalidConfiguration)));
+    assert_eq!(result, Err(Ok(LoanError::MaxExtensionsReached)));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1310.

This enforces the loan extension cap before granting another extension. The previous guard used `>` so a loan at `MAX_EXTENSIONS` could still be extended once more; the check now uses `>=` and returns the specific `MaxExtensionsReached` error.

The existing max-extension regression was updated to expect that specific cap error on the fourth extension attempt.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.