### PR TITLE
fix: enforce lending pool max size cap

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -466,7 +466,7 @@ impl LendingPool {
             .unwrap_or(0);
         if max > 0 {
             let total = Self::total_deposits(&env, &token);
-            if total.checked_add(amount).expect("overflow") < max {
+            if total.checked_add(amount).expect("overflow") > max {
                 return Err(PoolError::PoolSizeExceeded);
             }
         }


### PR DESCRIPTION
Fixes #1314.

This corrects the `deposit` max-pool-size comparison so deposits are rejected only when tracked principal would exceed the configured cap. The previous check used `< max`, which rejected deposits that were still within the cap and allowed deposits above it.

Existing coverage already includes `test_deposit_within_cap_succeeds` and `test_deposit_exceeds_cap_panics`, which exercise both sides of this boundary.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.