### PR TITLE
fix: block withdrawals during cooldown window

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -249,7 +249,7 @@ impl LendingPool {
         };
 
         let current_ledger = env.ledger().sequence();
-        if current_ledger > deposit_ledger.saturating_add(cooldown) {
+        if current_ledger < deposit_ledger.saturating_add(cooldown) {
             panic!("withdrawal_cooldown_active");
         }
     }


### PR DESCRIPTION
Fixes #1313.

This corrects `assert_withdrawal_cooldown_elapsed` so withdrawals are blocked only while the current ledger is still before `deposit_ledger + cooldown`. The previous check used `>`, which inverted the rule by allowing withdrawals during the lock window and panicking after the cooldown had elapsed.

Existing coverage already includes the immediate-withdraw panic and the after-cooldown success path.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.