### PR TITLE
fix: enforce admin transfer reproposal cooldown

### DIFF
--- a/contracts/multisig_governance/src/lib.rs
+++ b/contracts/multisig_governance/src/lib.rs
@@ -229,7 +229,7 @@ impl GovernanceContract {
             .get::<Symbol, u64>(&KEY_LAST_CANCELLED_AT)
         {
             let now = env.ledger().timestamp();
-            if now > last_cancelled_at.saturating_add(REPROPOSAL_COOLDOWN_SECONDS) {
+            if now < last_cancelled_at.saturating_add(REPROPOSAL_COOLDOWN_SECONDS) {
                 return Err(GovernanceError::ReproposalCooldownActive);
             }
         }


### PR DESCRIPTION
Fixes #1316.

This corrects the reproposal cooldown check in `propose_admin_transfer`. A cancelled proposal should block fresh proposals only while `now` is still before `last_cancelled_at + REPROPOSAL_COOLDOWN_SECONDS`; the previous `>` comparison inverted that behavior.

Existing coverage already includes the during-cooldown rejection and after-cooldown reproposal success paths.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.