### PR TITLE
fix: enforce admin transfer timelock before finalize

### DIFF
--- a/contracts/multisig_governance/src/lib.rs
+++ b/contracts/multisig_governance/src/lib.rs
@@ -385,7 +385,7 @@ impl GovernanceContract {
         let now = env.ledger().timestamp();
 
         // INV-1: timelock must have elapsed
-        if now > pending.executable_after {
+        if now < pending.executable_after {
             return Err(GovernanceError::TimelockNotElapsed);
         }
 


### PR DESCRIPTION
Fixes #1315.

This corrects `finalize_admin_transfer` so finalization is rejected only while `now` is still before `pending.executable_after`. The previous `>` comparison inverted the timelock, allowing early finalization and blocking execution after the delay elapsed.

Existing coverage already includes before-timelock rejection and after-timelock success paths.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.