### PR TITLE
fix: truncate decimals to requested precision

### DIFF
--- a/frontend/src/app/utils/precision.test.ts
+++ b/frontend/src/app/utils/precision.test.ts
@@ -1,0 +1,25 @@
+import { getAssetPrecision, truncateDecimals } from "./precision";
+
+describe("precision utils", () => {
+  describe("truncateDecimals", () => {
+    it("truncates to exactly the requested decimal count", () => {
+      expect(truncateDecimals("12.345", 2)).toBe("12.34");
+      expect(truncateDecimals("0.12345678", 7)).toBe("0.1234567");
+    });
+
+    it("supports zero-decimal truncation", () => {
+      expect(truncateDecimals("42.9", 0)).toBe("42.");
+    });
+
+    it("keeps only the first decimal segment when multiple points are typed", () => {
+      expect(truncateDecimals("1.234.56", 2)).toBe("1.23");
+    });
+  });
+
+  describe("getAssetPrecision", () => {
+    it("returns configured asset precisions", () => {
+      expect(getAssetPrecision("XLM")).toBe(7);
+      expect(getAssetPrecision("USDC")).toBe(2);
+    });
+  });
+});

--- a/frontend/src/app/utils/precision.ts
+++ b/frontend/src/app/utils/precision.ts
@@ -17,7 +17,7 @@ export function truncateDecimals(value: string, decimals: number): string {
   }
 
   if (parts.length === 2 && parts[1].length > decimals) {
-    return `${parts[0]}.${parts[1].slice(0, decimals + 1)}`;
+    return `${parts[0]}.${parts[1].slice(0, decimals)}`;
   }
 
   return value;


### PR DESCRIPTION
Fixes #1304.

This corrects the off-by-one in `truncateDecimals` so the decimal slice keeps exactly the requested precision instead of one extra digit.

I added focused frontend utility coverage for two-decimal truncation, Stellar-style seven-decimal truncation, zero-decimal truncation, and the existing multiple-decimal-point path.

Validation: static GitHub API/source inspection only; I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain execution.