### PR TITLE
fix: right-pad fractional stroop amounts

### DIFF
--- a/frontend/src/app/utils/amount.ts
+++ b/frontend/src/app/utils/amount.ts
@@ -58,7 +58,7 @@ export function toStroops(value: string, decimals = STROOP_DECIMALS): bigint | n
   }
 
   const [whole = "0", fraction = ""] = value.split(".");
-  const normalizedFraction = fraction.padStart(decimals, "0");
+  const normalizedFraction = fraction.padEnd(decimals, "0");
 
   try {
     // Scale by the requested precision, not the fixed 7-decimal stroop scale,


### PR DESCRIPTION
Fixes #1303.

This corrects `toStroops` fractional normalization so shorter fractional inputs are right-padded to the asset precision. The previous `padStart` understated values like `1.5` by shifting the fractional digit to the least-significant position; `padEnd` preserves the intended decimal place.

Existing `amount.test.ts` coverage already asserts `toStroops("1.5", 7) === 15000000` and `toStroops("0.01", 2) === 1`.

Validation: static GitHub API/source inspection only; I did not run the frontend test suite locally because this environment is avoiding dependency/toolchain execution.