### PR TITLE
fix: report no next page at pagination end

### DIFF
--- a/backend/src/utils/__tests__/pagination.test.ts
+++ b/backend/src/utils/__tests__/pagination.test.ts
@@ -1,0 +1,15 @@
+import { createPaginatedResponse } from '../pagination.js';
+
+describe('createPaginatedResponse', () => {
+  it('does not advertise a next page when returned rows reach the total count', () => {
+    const response = createPaginatedResponse(['c', 'd'], 4, 2, 2, 2);
+
+    expect(response.page_info.has_next).toBe(false);
+  });
+
+  it('advertises a next page only when more rows remain', () => {
+    const response = createPaginatedResponse(['a', 'b'], 5, 2, 2, 2);
+
+    expect(response.page_info.has_next).toBe(true);
+  });
+});

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -110,7 +110,7 @@ export function createPaginatedResponse<T>(
       offset,
       count: currentCount,
       has_previous: offset > 0,
-      has_next: offset + currentCount <= totalCount,
+      has_next: offset + currentCount < totalCount,
     },
   };
 }


### PR DESCRIPTION
Fixes #1300.

This corrects `createPaginatedResponse` so `page_info.has_next` is false when the returned rows exactly reach `total_count`. The previous `<=` comparison advertised a next page on the final page.

I added focused utility coverage for the final-page boundary and the more-rows-remaining case.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.