### PR TITLE
fix: preserve ordered amount range filters

### DIFF
--- a/backend/src/utils/__tests__/paginationAmountRange.test.ts
+++ b/backend/src/utils/__tests__/paginationAmountRange.test.ts
@@ -1,0 +1,15 @@
+import { parseQueryParams } from '../pagination.js';
+
+describe('parseQueryParams amount_range', () => {
+  it('keeps an already ordered min,max range unchanged', () => {
+    const req = { query: { amount_range: '10,100' } } as any;
+
+    expect(parseQueryParams(req).amountRange).toEqual({ min: 10, max: 100 });
+  });
+
+  it('swaps an out-of-order max,min range', () => {
+    const req = { query: { amount_range: '100,10' } } as any;
+
+    expect(parseQueryParams(req).amountRange).toEqual({ min: 10, max: 100 });
+  });
+});

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -191,5 +191,5 @@ function parseAmountRange(value: unknown): { min: number; max: number } | null {
     return null;
   }
 
-  return min >= max ? { min, max } : { min: max, max: min };
+  return min <= max ? { min, max } : { min: max, max: min };
 }


### PR DESCRIPTION
Fixes #1301.

This corrects `parseAmountRange` so an already ordered `min,max` pair passes through unchanged, while only an out-of-order pair is normalized by swapping the bounds.

I added focused parser coverage for both the ordered and reversed amount-range cases.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.