### PR TITLE
fix: reject zero capped limits

### DIFF
--- a/backend/src/__tests__/queryHelpers.test.ts
+++ b/backend/src/__tests__/queryHelpers.test.ts
@@ -1,0 +1,15 @@
+import { parseCappedLimit } from '../utils/queryHelpers.js';
+
+describe('parseCappedLimit', () => {
+  it('falls back to the default limit when limit is zero', () => {
+    const req = { query: { limit: '0' } } as any;
+
+    expect(parseCappedLimit(req, 25)).toBe(25);
+  });
+
+  it('caps positive integer limits at the maximum', () => {
+    const req = { query: { limit: '250' } } as any;
+
+    expect(parseCappedLimit(req, 25)).toBe(100);
+  });
+});

--- a/backend/src/utils/queryHelpers.ts
+++ b/backend/src/utils/queryHelpers.ts
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT = 20;
 export function parseCappedLimit(req: Request, defaultLimit: number = DEFAULT_LIMIT): number {
   const rawLimit = Number(req.query.limit);
 
-  if (!Number.isFinite(rawLimit) || rawLimit < 0 || rawLimit !== Math.floor(rawLimit)) {
+  if (!Number.isFinite(rawLimit) || rawLimit <= 0 || rawLimit !== Math.floor(rawLimit)) {
     return defaultLimit;
   }
 


### PR DESCRIPTION
Fixes #1302.

This updates `parseCappedLimit` so `limit=0` is treated as invalid and falls back to the configured default limit instead of collapsing capped-limit endpoints to zero rows.

I added focused coverage for the zero-limit fallback and kept the existing positive-limit cap behavior covered.

Validation: static GitHub API/source inspection only; I did not run the backend test suite locally because this environment is avoiding dependency/toolchain execution.