### PR TITLE
fix: report pool utilization on 10000 bps scale

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -670,7 +670,7 @@ impl LendingPool {
         // Utilisation: portion of tracked principal currently out on loan.
         let utilization_bps = if total_deposits > 0 && pool_token_balance < total_deposits {
             let borrowed = total_deposits - pool_token_balance;
-            ((borrowed * 1_000) / total_deposits) as u32
+            ((borrowed * 10_000) / total_deposits) as u32
         } else {
             0
         };


### PR DESCRIPTION
Fixes #1298.

This corrects `get_pool_stats` so utilization is reported on the standard 10,000 bps scale instead of a 1,000-point scale. A 40% utilized pool now reports `4000` bps, matching the existing pool stats regression expectation.

The existing `test_pool_stats_reflect_funds_allocated_and_returned` already covers the borrowed/deposit ratio boundary for this fix.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.