### PR TITLE
fix: apply decrease_score floor as lower bound

### DIFF
--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -726,7 +726,7 @@ impl RemittanceNFT {
 
         let old_score = metadata.score;
         let decreased = old_score.saturating_sub(penalty_points);
-        let new_score = decreased.min(Self::MIN_CREDIT_SCORE);
+        let new_score = decreased.max(Self::MIN_CREDIT_SCORE);
         if new_score == old_score {
             return;
         }

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -432,6 +432,24 @@ fn test_apply_score_delta_floors_at_zero() {
 }
 
 #[test]
+fn test_decrease_score_reduces_scores_above_floor() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    let history_hash = create_test_hash(&env, 7);
+    client.mint(&user, &500, &history_hash, &create_test_uri(&env), &None);
+
+    client.decrease_score(&user, &50, &None);
+    assert_eq!(client.get_score(&user), 450);
+}
+#[test]
 fn test_decrease_score_applies_floor_at_300() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Fixes #1317.

This corrects `decrease_score` so the score floor is applied as a lower bound with `max(MIN_CREDIT_SCORE)`. The previous `min(MIN_CREDIT_SCORE)` capped every real decrease at the floor, turning a normal 500 -> 450 penalty into 300.

I added focused coverage for reducing a score above the floor while keeping the existing floor-at-300 regression intact.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.