### PR TITLE
fix: enforce active loan cap at boundary

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1048,7 +1048,7 @@ impl LoanManager {
 
         let active_loan_count = Self::borrower_loan_count(&env, &borrower);
         let max_loans_per_borrower = Self::max_loans_per_borrower(&env);
-        if active_loan_count > max_loans_per_borrower {
+        if active_loan_count >= max_loans_per_borrower {
             return Err(LoanError::MaxLoansReached);
         }
 


### PR DESCRIPTION
Fixes #1308.

This corrects the borrower active-loan cap guard in `request_loan` so a borrower at the configured cap cannot open one additional loan. The previous strict `>` comparison allowed the `max + 1` request.

The existing `test_pending_loans_count_against_cap` regression already covers the boundary by setting the cap to 2, opening two pending loans, and expecting the third request to return `MaxLoansReached`.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.