### PR TITLE
fix: default only after eligibility boundary

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -2529,7 +2529,7 @@ impl LoanManager {
             .due_date
             .checked_add(Self::default_window_ledgers(&env))
             .expect("default window overflow");
-        if current_ledger < default_eligible_after {
+        if current_ledger <= default_eligible_after {
             return Err(LoanError::LoanNotPastDue);
         }
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1253,7 +1253,7 @@ fn test_check_default_respects_default_window() {
     manager.approve_loan(&loan_id);
 
     let due_date = manager.get_loan(&loan_id).due_date;
-    env.ledger().set_sequence_number(due_date + 9_999);
+    env.ledger().set_sequence_number(due_date + manager.get_default_window_ledgers());
 
     let result = manager.try_check_default(&loan_id);
     assert_eq!(result, Err(Ok(LoanError::LoanNotPastDue)));


### PR DESCRIPTION
Fixes #1311.

This aligns `check_default` with the batch `check_defaults` boundary so a loan is not default-eligible at exactly `due_date + default_window`; it only becomes eligible after that ledger.

I updated the existing default-window regression to assert the exact boundary ledger still returns `LoanNotPastDue`.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.