### PR TITLE
fix: disburse approved loans to borrower

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1185,7 +1185,7 @@ impl LoanManager {
 
         // ── INTERACTIONS (external calls last) ──────────────────────────────
         let token_client = TokenClient::new(&env, &token);
-        token_client.transfer(&borrower, &lending_pool, &transfer_amount);
+        token_client.transfer(&lending_pool, &borrower, &transfer_amount);
 
         events::loan_approved(
             &env,


### PR DESCRIPTION
Fixes #1306.

This corrects `approve_loan` so approval disburses principal from the lending pool to the borrower. The previous transfer arguments moved funds from the borrower into the pool.

Existing `test_approve_loan_flow` already asserts the borrower receives the approved principal after approval.

Validation: static GitHub API/source inspection only; I did not run the contract test suite locally because this environment is avoiding dependency/toolchain execution.