### PR TITLE
fix: enforce borrower SSE stream ownership

### DIFF
--- a/backend/src/controllers/eventStreamController.ts
+++ b/backend/src/controllers/eventStreamController.ts
@@ -52,7 +52,7 @@ export const streamEvents = asyncHandler(async (req: Request, res: Response) => 
 
   const isAdmin = role === 'admin';
 
-  if (isAdmin && requestedBorrower && requestedBorrower !== userKey) {
+  if (!isAdmin && requestedBorrower && requestedBorrower !== userKey) {
     throw AppError.forbidden('Borrowers can only subscribe to their own events');
   }
 


### PR DESCRIPTION
Fixes #1332.

This PR corrects the ownership guard in ackend/src/controllers/eventStreamController.ts::streamEvents. Non-admin users are now blocked when they request a borrower stream for a wallet other than their authenticated public key, while admins can still request a specific borrower feed.

The existing eventStream test suite already includes the regression expectation: a borrower token requesting ?borrower=GOTHERWALLET must receive 403.

Validation: static GitHub API/source inspection only; local backend tests were not run in this environment to avoid installing or executing additional toolchains.