### PR TITLE
feat: emit distinct emergency withdraw event

### DIFF
--- a/contracts/lending_pool/src/events.rs
+++ b/contracts/lending_pool/src/events.rs
@@ -11,6 +11,11 @@ pub fn withdraw(env: &Env, provider: Address, token: Address, amount: i128, shar
     env.events().publish(topics, (amount, shares_burned));
 }
 
+pub fn emergency_withdraw(env: &Env, provider: Address, token: Address, shares_burned: i128) {
+    let topics = (Symbol::new(env, "EmergencyWithdraw"), provider, token);
+    env.events().publish(topics, shares_burned);
+}
+
 #[allow(dead_code)]
 pub fn yield_distributed(env: &Env, token: Address, amount: i128) {
     if amount > 0 {

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -620,7 +620,9 @@ impl LendingPool {
         shares: i128,
     ) -> Result<(), PoolError> {
         provider.require_auth();
-        Self::redeem_shares(&env, &provider, &token, shares)
+        Self::redeem_shares(&env, &provider, &token, shares)?;
+        events::emergency_withdraw(&env, provider, token, shares);
+        Ok(())
     }
 
     // ── Cooldown views ────────────────────────────────────────────────────

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -396,6 +396,35 @@ fn test_emergency_withdraw_bypasses_pause_and_cooldown() {
     assert_eq!(token_client.balance(&pool_id), 0);
 }
 
+#[test]
+fn test_emergency_withdraw_emits_distinct_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, _token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&100);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &5_000);
+    pool_client.deposit(&provider, &token_id, &1_500);
+
+    pool_client.pause();
+    pool_client.emergency_withdraw(&provider, &token_id, &500);
+
+    let events = env.events().all();
+    let has_emergency_event = events.iter().any(|event| {
+        let first_topic = event.1.get(0).unwrap();
+        soroban_sdk::Symbol::from_val(&env, &first_topic)
+            == soroban_sdk::Symbol::new(&env, "EmergencyWithdraw")
+    });
+
+    assert!(has_emergency_event);
+}
 // ── Deposit / Withdraw invariants ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Fixes #1140.

This PR adds a machine-distinguishable EmergencyWithdraw event for the contracts/lending_pool/src/lib.rs::emergency_withdraw path while leaving normal Withdraw emission and fund-movement mechanics unchanged.

Changes:
- defines events::emergency_withdraw in contracts/lending_pool/src/events.rs
- emits it only after a successful emergency redemption
- adds a focused test that verifies the emergency path publishes the distinct event

Validation: static GitHub API/source inspection only; local Soroban/Rust tests were not run in this environment to avoid installing or executing additional toolchains.