### PR TITLE
fix: burn redeemed lending pool shares

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -265,7 +265,7 @@ impl LendingPool {
         }
 
         let cur_shares = Self::read_shares(env, provider, token);
-        if cur_shares <= shares {
+        if cur_shares < shares {
             return Err(PoolError::InsufficientBalance);
         }
 
@@ -290,7 +290,7 @@ impl LendingPool {
 
         let share_key = DataKey::Shares(provider.clone(), token.clone());
         let deposit_key = DataKey::DepositTimestamp(provider.clone(), token.clone());
-        let remaining = cur_shares.checked_add(shares).expect("share underflow");
+        let remaining = cur_shares.checked_sub(shares).expect("share underflow");
         if remaining == 0 {
             env.storage().persistent().remove(&share_key);
             env.storage().persistent().remove(&deposit_key);

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -153,6 +153,35 @@ fn test_withdraw_flow() {
 }
 
 #[test]
+fn test_withdraw_burns_redeemed_shares_and_allows_final_redeem() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&token_admin);
+    pool_client.set_withdrawal_cooldown(&0);
+
+    let provider = Address::generate(&env);
+    stellar_asset_client.mint(&provider, &3000);
+    pool_client.deposit(&provider, &token_id, &3000);
+
+    pool_client.withdraw(&provider, &token_id, &1000);
+    assert_eq!(pool_client.get_shares(&provider, &token_id), 2000);
+    assert_eq!(pool_client.get_total_shares(&token_id), 2000);
+
+    pool_client.withdraw(&provider, &token_id, &2000);
+    assert_eq!(pool_client.get_shares(&provider, &token_id), 0);
+    assert_eq!(pool_client.get_total_shares(&token_id), 0);
+    assert_eq!(pool_client.get_depositor_count(&token_id), 0);
+    assert_eq!(token_client.balance(&provider), 3000);
+    assert_eq!(token_client.balance(&pool_id), 0);
+}
+
+#[test]
 #[should_panic]
 fn test_negative_withdraw_panic() {
     let env = Env::default();


### PR DESCRIPTION
Closes #1355

Summary:
- Burn redeemed LP shares by subtracting from the provider share balance instead of adding the redeemed amount back.
- Allow exact-balance final redemptions while still rejecting attempts to redeem more shares than held.
- Add a regression test covering a partial redeem followed by a final redeem, including provider shares, total shares, depositor count, and token balances.

Validation:
- Static GitHub API/source inspection only; local Soroban/Rust toolchain commands were not run to avoid installing or executing project dependencies in this environment.