### PR TITLE
fix: block full 172 private host range

### DIFF
--- a/backend/src/__tests__/indexerPrivateHost.test.ts
+++ b/backend/src/__tests__/indexerPrivateHost.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { isPrivateHost } from '../controllers/indexerController.js';
+
+describe('isPrivateHost', () => {
+  it('blocks the full 172.16.0.0/12 private range', () => {
+    expect(isPrivateHost('172.16.0.1')).toBe(true);
+    expect(isPrivateHost('172.16.255.254')).toBe(true);
+    expect(isPrivateHost('172.31.255.254')).toBe(true);
+  });
+
+  it('does not classify neighboring public 172 ranges as private', () => {
+    expect(isPrivateHost('172.15.255.254')).toBe(false);
+    expect(isPrivateHost('172.32.0.1')).toBe(false);
+  });
+});

--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -20,7 +20,7 @@ import logger from '../utils/logger.js';
  * Returns true if the hostname resolves to a private, loopback, or link-local
  * address that should never receive outbound webhook deliveries (SSRF guard).
  */
-function isPrivateHost(hostname: string): boolean {
+export function isPrivateHost(hostname: string): boolean {
   // Strip IPv6 brackets
   const host = hostname.replace(/^\[|\]$/g, '');
 
@@ -34,7 +34,7 @@ function isPrivateHost(hostname: string): boolean {
 
   // Private IPv4 ranges (RFC 1918)
   if (/^10\./.test(host)) return true;
-  if (/^172\.(1[7-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
   if (/^192\.168\./.test(host)) return true;
 
   // AWS / GCP metadata endpoints


### PR DESCRIPTION
Closes #1339

Summary:
- Expand the private-host guard to cover the full RFC1918 172.16.0.0/12 range, including 172.16.x.x.
- Export the helper so the boundary logic can be tested directly.
- Add regression coverage for 172.16/172.31 being blocked and neighboring public 172.15/172.32 ranges remaining allowed.

Validation:
- Static GitHub API/source inspection only; local backend dependency or test commands were not run to avoid installing or executing project dependencies in this environment.