### PR TITLE
fix: accrue interest with bps denominator

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -356,7 +356,7 @@ impl LoanManager {
             .and_then(|v| v.checked_mul(PRECISION))
             .ok_or(LoanError::AmountTooLarge)?;
 
-        let denominator = 100_000i128
+        let denominator = 10_000i128
             .checked_mul(Self::DEFAULT_TERM_LEDGERS as i128)
             .ok_or(LoanError::AmountTooLarge)?;
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1781,6 +1781,38 @@ fn test_deposit_collateral_rejects_non_active_loan() {
 }
 
 #[test]
+fn test_interest_accrual_matches_bps_over_full_term() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_address, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &600,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_address, &20_000);
+
+    manager.set_interest_rate(&1_200);
+    let loan_id = manager.request_loan(&borrower, &10_000, &17280);
+    manager.approve_loan(&loan_id);
+
+    let approved = manager.get_loan(&loan_id);
+    env.ledger()
+        .set_sequence_number(approved.last_interest_ledger + 17_280);
+
+    let accrued = manager.get_loan(&loan_id);
+    assert_eq!(accrued.accrued_interest, 1_200);
+    assert_eq!(accrued.interest_residual, 0);
+}
+#[test]
 fn test_small_loan_interest_accrual_precision() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
Closes #1307

Summary:
- Use the standard 10,000 basis-point denominator for interest accrual instead of 100,000.
- Add a regression test for a 10,000 principal loan at 1,200 bps over one full default term, expecting 1,200 accrued interest.

Validation:
- Static GitHub API/source inspection only; local Soroban/Rust toolchain commands were not run to avoid installing or executing project dependencies in this environment.