### PR TITLE
fix(ui): remove unused clsx/twMerge imports from Input and Modal

### DIFF
--- a/frontend/src/app/components/ui/Input.tsx
+++ b/frontend/src/app/components/ui/Input.tsx
@@ -1,9 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
 import { cn } from "@/app/utils/cn";
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/frontend/src/app/components/ui/Modal.tsx
+++ b/frontend/src/app/components/ui/Modal.tsx
@@ -2,8 +2,6 @@
 
 import * as React from "react";
 import { X } from "lucide-react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
 import { motion, AnimatePresence } from "framer-motion";
 import { useModalFocusTrap } from "../../hooks/useModalFocusTrap";
 


### PR DESCRIPTION
## Summary

Completes the DRY cleanup from [#1248](https://github.com/LabsCrypt/remitlend/issues/1248).

Commit  already replaced the local  copies in **Button**, **Card**, and **EmptyState** with the shared import from . However, **Input.tsx** and **Modal.tsx** still carried dead `clsx` and `twMerge` imports — they imported the shared `cn()` but never removed the raw dependencies they no longer use directly.

This PR removes those unused imports so there are no dead symbols in the design-system folder.

### Changes
-  — removed unused `clsx` and `tailwind-merge` imports
-  — removed unused `clsx` and `tailwind-merge` imports

### Verification
- No visual or behavioral change — `cn()` calls remain identical
- `tsc --noEmit` passes (pre-existing errors only, none from these files)
- Lint passes (pre-existing prettier config issue aside)

closes #1248 