### PR TITLE
fix(loan_manager): correct refinance_loan's outstanding-delta sign

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1993,9 +1993,10 @@ impl LoanManager {
             core::cmp::Ordering::Equal => {}
         }
 
-        let outstanding_delta = loan
-            .amount
-            .checked_sub(new_amount)
+        // #1354: delta must be new minus prior, not prior minus new — adjust_total_outstanding
+        // adds the delta to the running total, so borrowing more must produce a positive delta.
+        let outstanding_delta = new_amount
+            .checked_sub(loan.amount)
             .expect("outstanding delta overflow");
         Self::adjust_total_outstanding(&env, &token, outstanding_delta);
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -2945,6 +2945,51 @@ fn test_refinance_loan_increases_principal_draws_from_pool() {
 }
 
 #[test]
+fn test_refinance_loan_increasing_amount_increases_total_outstanding() {
+    // Regression test for #1354: refinancing to a larger amount (borrowing
+    // more) must INCREASE total_outstanding by the borrowed delta, not
+    // decrease it — a flipped sign here would let a borrower's recorded debt
+    // shrink while the pool actually pays them more.
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    stellar_token.mint(&manager.address, &5_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 5_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let total_outstanding_before = manager.get_total_outstanding(&token_id);
+
+    // Refinance from 1_000 to 2_000 — total_outstanding must grow by 1_000.
+    manager.refinance_loan(&loan_id, &2_000, &17_280);
+
+    let total_outstanding_after = manager.get_total_outstanding(&token_id);
+    assert_eq!(total_outstanding_after, total_outstanding_before + 1_000);
+}
+
+#[test]
 fn test_refinance_loan_decreases_principal_returns_excess_to_pool() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();
@@ -2994,6 +3039,50 @@ fn test_refinance_loan_decreases_principal_returns_excess_to_pool() {
         token_client.balance(&pool_client),
         pool_balance_before + 1_000
     );
+}
+
+#[test]
+fn test_refinance_loan_decreasing_amount_decreases_total_outstanding() {
+    // Regression test for #1354: refinancing to a smaller amount (paying
+    // down principal) must DECREASE total_outstanding by the returned delta.
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+    stellar_token.mint(&borrower, &10_000);
+
+    let loan_id = manager.request_loan(&borrower, &2_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    stellar_token.mint(&manager.address, &2_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 2_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let total_outstanding_before = manager.get_total_outstanding(&token_id);
+
+    // Refinance down from 2_000 to 1_000 — total_outstanding must shrink by 1_000.
+    manager.refinance_loan(&loan_id, &1_000, &17_280);
+
+    let total_outstanding_after = manager.get_total_outstanding(&token_id);
+    assert_eq!(total_outstanding_after, total_outstanding_before - 1_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
`refinance_loan` (`contracts/loan_manager/src/lib.rs`) computed the delta passed to `adjust_total_outstanding` in the wrong direction, letting a borrower's recorded debt shrink while the pool actually paid them more on a refinance-up — enabling over-borrow.

closes #1354

## Root cause
```rust
let outstanding_delta = loan.amount.checked_sub(new_amount).expect(...);
Self::adjust_total_outstanding(&env, &token, outstanding_delta);
```
`adjust_total_outstanding` does `current.checked_add(delta)` — a positive delta is supposed to mean "outstanding grew." Computing `loan.amount - new_amount` (prior minus new) produces a **negative** delta whenever `new_amount > loan.amount` (borrowing more), which **decreases** `total_outstanding` exactly when it should increase.

## Fix
Flip the calculation to `new_amount.checked_sub(loan.amount)` (new minus prior), so:
- Refinancing to a **larger** amount → positive delta → `total_outstanding` increases by the additional amount borrowed.
- Refinancing to a **smaller** amount → negative delta → `total_outstanding` decreases by the amount returned.

## Test plan
- Added `test_refinance_loan_increasing_amount_increases_total_outstanding` and `test_refinance_loan_decreasing_amount_decreases_total_outstanding`, asserting `get_total_outstanding` moves by exactly the expected delta in each direction.
- Verified both new tests **fail** against the pre-fix calculation (reverted locally, re-ran, confirmed failure) and **pass** against this fix.
- `cargo test -p loan_manager`: 116 passed, 0 failed.
- `cargo test --workspace` (all 4 contracts): all green.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo build --target wasm32-unknown-unknown --release`: all 4 wasm artifacts well under the 256 KiB CI budget.

## Note on #1353
While investigating this issue I also checked #1353 (`deposit_collateral` paying the borrower instead of taking collateral) — that transfer direction is **already fixed on `main`** (commit `4f0da92`, "fix(loan-manager): correct math, limits, and score drops"). No PR needed for #1353; flagging here in case the tracker wasn't updated.