### PR TITLE
fix(lending_pool): adjust_outstanding must add, not subtract, delta

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -770,10 +770,13 @@ impl LendingPool {
             return;
         }
 
+        // #1356: delta must be added, not subtracted — a positive delta means
+        // outstanding debt grew (e.g. a new disbursement), a negative delta
+        // means it shrank (e.g. a repayment). Subtracting inverted both cases.
         let key = DataKey::TotalOutstanding(token.clone());
         let current = Self::read_total_outstanding(&env, &token);
         let updated = current
-            .checked_sub(delta)
+            .checked_add(delta)
             .expect("total outstanding overflow");
 
         if updated < 0 {

--- a/contracts/lending_pool/src/test.rs
+++ b/contracts/lending_pool/src/test.rs
@@ -1556,3 +1556,64 @@ fn test_multiple_depositors_share_yield_proportionally_and_total_shares_track_co
     assert_eq!(token_client.balance(&pool_id), 0);
     assert_eq!(pool_client.get_total_shares(&token_id), 0);
 }
+
+// ── adjust_outstanding tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_adjust_outstanding_positive_delta_increases_total() {
+    // Regression test for #1356: adjust_outstanding subtracted delta instead
+    // of adding it, so a positive delta (e.g. a new disbursement growing the
+    // pool's recorded debt) shrank total_outstanding instead of growing it.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+
+    assert_eq!(pool_client.get_total_outstanding(&token), 0);
+
+    pool_client.adjust_outstanding(&token, &1_500);
+
+    assert_eq!(pool_client.get_total_outstanding(&token), 1_500);
+}
+
+#[test]
+fn test_adjust_outstanding_negative_delta_decreases_total() {
+    // Regression test for #1356: a negative delta (e.g. a repayment shrinking
+    // recorded debt) must decrease total_outstanding.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+
+    pool_client.adjust_outstanding(&token, &2_000);
+    assert_eq!(pool_client.get_total_outstanding(&token), 2_000);
+
+    pool_client.adjust_outstanding(&token, &-800);
+
+    assert_eq!(pool_client.get_total_outstanding(&token), 1_200);
+}
+
+#[test]
+fn test_adjust_outstanding_zero_delta_is_a_no_op() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let pool_id = env.register(LendingPool, ());
+    let pool_client = LendingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin);
+
+    pool_client.adjust_outstanding(&token, &1_000);
+    pool_client.adjust_outstanding(&token, &0);
+
+    assert_eq!(pool_client.get_total_outstanding(&token), 1_000);
+}


### PR DESCRIPTION
## Summary
`adjust_outstanding` (`contracts/lending_pool/src/lib.rs`) applied the caller-supplied delta in the wrong direction, moving total_outstanding — and therefore the pool's share price — the wrong way.

closes #1356

## Root cause
```rust
let updated = current.checked_sub(delta).expect(...);
```
A positive `delta` is meant to represent outstanding debt growing (e.g. a new disbursement); a negative `delta` represents it shrinking (e.g. a repayment). Subtracting instead of adding inverts both cases — a positive delta *decreases* the recorded total, and a negative delta *increases* it.

## Fix
Changed `checked_sub(delta)` to `checked_add(delta)`, matching the sibling implementation in `loan_manager`'s own `adjust_total_outstanding` and the standard meaning of a delta parameter.

## Test plan
- Added `test_adjust_outstanding_positive_delta_increases_total`, `test_adjust_outstanding_negative_delta_decreases_total`, and `test_adjust_outstanding_zero_delta_is_a_no_op`.
- Verified all three **fail** against the pre-fix `checked_sub` (reverted locally: the positive-delta case panics immediately with a total-outstanding underflow, since `current` starts at 0 and `0 - 1500 < 0`) and **pass** against this fix.
- `cargo test -p lending_pool`: 58 passed, 0 failed.
- `cargo test --workspace` (all 4 contracts): all green.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo build --target wasm32-unknown-unknown --release`: all 4 wasm artifacts well under the 256 KiB CI budget.