### PR TITLE
fix(remittance_nft): transfer must require the owner's auth, not the recipient's

### DIFF
--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -942,7 +942,10 @@ impl RemittanceNFT {
             return Err(NftError::SelfTransfer);
         }
 
-        to.require_auth();
+        // #1358: the current owner must consent to giving up their own asset —
+        // requiring the recipient's auth instead let anyone pull any victim's
+        // NFT (and its score) to themselves.
+        from.require_auth();
         Self::require_admin_or_authorized_minter(&env, minter)?;
 
         let transfer_cooldown_key = DataKey::TransferCooldown(from.clone());

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -993,6 +993,45 @@ fn test_transfer_moves_identity_state_to_new_wallet() {
 }
 
 #[test]
+fn test_transfer_requires_owner_auth_not_recipient() {
+    // Regression test for #1358: transfer required `to.require_auth()`
+    // instead of `from.require_auth()`, so an attacker could pull any
+    // victim's NFT to themselves by only authorizing as the recipient.
+    // Assert the contract actually required the *owner's* (from's)
+    // authorization for this call, not the recipient's.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.mint(
+        &from,
+        &500,
+        &create_test_hash(&env, 99),
+        &create_test_uri(&env),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    client.transfer(&from, &to, &None);
+
+    assert!(
+        env.auths().iter().any(|(address, _)| address == &from),
+        "transfer must require the current owner's (from's) authorization"
+    );
+    assert!(
+        !env.auths().iter().any(|(address, _)| address == &to),
+        "transfer must not require the recipient's authorization"
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_transfer_enforces_cooldown_before_retransfer() {
     let env = Env::default();

--- a/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_active.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_active.1.json
@@ -40,7 +40,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -164,7 +164,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -179,7 +179,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_expired.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_expired.1.json
@@ -40,7 +40,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -163,7 +163,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -178,7 +178,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/contracts/remittance_nft/test_snapshots/test/test_transfer_enforces_cooldown_before_retransfer.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_transfer_enforces_cooldown_before_retransfer.1.json
@@ -40,7 +40,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -163,7 +163,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -178,7 +178,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/contracts/remittance_nft/test_snapshots/test/test_transfer_moves_identity_state_to_new_wallet.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_transfer_moves_identity_state_to_new_wallet.1.json
@@ -86,7 +86,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -283,7 +283,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 4837995959683129791
@@ -298,7 +298,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 4837995959683129791


### PR DESCRIPTION
## Summary
`transfer` (`contracts/remittance_nft/src/lib.rs`) required authorization from the **recipient** (`to`) instead of the **current owner** (`from`), letting anyone steal any account's NFT — and the credit score, history, and default-count state attached to it.

closes #1358

## Root cause
```rust
to.require_auth();
Self::require_admin_or_authorized_minter(&env, minter)?;
```
Since anyone can trivially authorize as themselves, an attacker could call `transfer(victim_address, attacker_address, None)` and the contract would only ever check that the *attacker* (as `to`) authorized — never that the victim (`from`, the actual owner) consented.

## Fix
Swapped to `from.require_auth()`. The existing `require_admin_or_authorized_minter` check is unchanged — a transfer still requires an authorized minter or admin to co-sign, on top of the owner's own consent.

## Test plan
- Added `test_transfer_requires_owner_auth_not_recipient`, which inspects `env.auths()` after a `transfer` call to assert the contract actually required `from`'s authorization and did **not** require `to`'s.
- Verified this test **fails** against the pre-fix `to.require_auth()` (reverted locally, re-ran, confirmed failure) and **passes** against this fix.
- `cargo test -p remittance_nft`: 75 passed, 0 failed.
- `cargo test --workspace` (all 4 contracts): all green.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo build --target wasm32-unknown-unknown --release`: all 4 wasm artifacts well under the 256 KiB CI budget.

Four pre-existing recorded budget-snapshot fixtures (`test_snapshots/test/test_*.1.json`) are regenerated to match the new (correct) auth trace — the transfer-flow assertions in those tests are otherwise unchanged.