### PR TITLE
Feat loan repayment is displayed as a credit

### DIFF
--- a/frontend/src/app/stores/useGamificationStore.ts
+++ b/frontend/src/app/stores/useGamificationStore.ts
@@ -236,6 +236,7 @@ export const useGamificationStore = create<GamificationStore>()(
           const { xp, level } = get();
           const newLevel = calculateLevel(xp);
 
+          // Only trigger level-up celebration when new level strictly exceeds current level
           if (newLevel > level) {
             const levelUpReward = LEVEL_THRESHOLDS.find((t) => t.level === newLevel);
             if (levelUpReward) {

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -55,7 +55,7 @@ export async function buildUnsignedLoanRequestXdr({
           new xdr.InvokeContractArgs({
             contractAddress: Address.fromString(contractId).toScAddress(),
             functionName: "request_loan",
-            args: [borrowerScVal, termScVal, amountScVal],
+            args: [borrowerScVal, amountScVal, termScVal],
           }),
         ),
         auth: [],

--- a/frontend/src/app/utils/transactionErrors.ts
+++ b/frontend/src/app/utils/transactionErrors.ts
@@ -150,7 +150,7 @@ async function fetchTransactionStatus(
 ): Promise<"pending" | "success" | "failed"> {
   const response = await fetch(`${horizonUrl}/transactions/${txHash}`);
 
-  if (response.status === 400) {
+  if (response.status === 404) {
     return "pending";
   }
 

--- a/frontend/src/app/utils/transactionFormatter.ts
+++ b/frontend/src/app/utils/transactionFormatter.ts
@@ -87,7 +87,7 @@ export function formatLoanRepayment(params: LoanRepaymentParams): TransactionPre
     {
       token: "USDC",
       change: `-${params.amount}`,
-      isPositive: true,
+      isPositive: false,
     },
   ];
 


### PR DESCRIPTION
Closes #1349	transactionErrors.ts → fetchTransactionStatus	Changed response.status === 400 → 404. HTTP 404 = "not found" = transaction still pending on Horizon, not a bad request.	d2e9085

Closes #1350	soroban.ts → buildUnsignedLoanRequestXdr	Reordered XDR args from [borrower, term, amount] → [borrower, amount, term] to match the contract's request_loan(borrower, amount, term) signature.	86ca5d7

Closes #1348	useGamificationStore.ts → checkLevelUp	Confirmed strict > comparison is in place (with an added clarifying comment). The >= bug allowed level-up modal to fire even when level stayed the same.	c548673

Closes #1347	transactionFormatter.ts → formatLoanRepayment	Changed isPositive: true → isPositive: false. The change string was already negative (-${amount}), but the positive flag was causing it to render as a credit instead of a debit.	3256566
