### PR TITLE
fix(loan-manager): retire outstanding debt on liquidation

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1637,15 +1637,17 @@ impl LoanManager {
         Self::apply_debt_recovery(&mut loan, debt_repaid);
         loan.status = LoanStatus::Liquidated;
         loan.collateral_amount = 0;
-        env.storage().persistent().set(&loan_key, &loan);
-        Self::bump_persistent_ttl(&env, &loan_key);
-        Self::decrement_borrower_loan_count(&env, &loan.borrower);
 
         let token: Address = env
             .storage()
             .instance()
             .get(&DataKey::Token)
             .expect("token not set");
+        Self::adjust_total_outstanding(&env, &token, -loan.amount);
+
+        env.storage().persistent().set(&loan_key, &loan);
+        Self::bump_persistent_ttl(&env, &loan_key);
+        Self::decrement_borrower_loan_count(&env, &loan.borrower);
         let lending_pool: Address = env
             .storage()
             .instance()


### PR DESCRIPTION
## Summary
`liquidate()` in `contracts/loan_manager/src/lib.rs` never called `adjust_total_outstanding`, unlike `repay`, `check_default`, and `check_defaults`, which all decrement `TotalOutstanding` on their terminal loan transition. Without it, `TotalOutstanding` stays inflated by the full loan amount after every liquidation, which wrongly shrinks `available_liquidity` in `approve_loan` and can eventually block new lending even though the pool is solvent.

Fix: call `Self::adjust_total_outstanding(&env, &token, -loan.amount)` in `liquidate`, mirroring the existing pattern in the other terminal paths.

Closes  #1355, 
Closes  #1364,
Closes  #1352, 
Closes  #1351, 
## Test plan
- [ ] `cargo test -p loan_manager` covering `liquidate`
- [ ] Add/verify a regression test asserting `get_total_outstanding` decreases after `liquidate`, matching the existing `test_get_total_outstanding_decreases_on_check_default` pattern