### PR TITLE
fix: send full repayment amount instead of one-tenth in buildUnsigned…

### DIFF
--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -1,0 +1,57 @@
+import { TextDecoder, TextEncoder } from "util";
+
+if (typeof global.TextEncoder === "undefined") {
+  (global as any).TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === "undefined") {
+  (global as any).TextDecoder = TextDecoder;
+}
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const {
+  Account,
+  Keypair,
+  rpc,
+  scValToNative,
+  TransactionBuilder,
+} = require("@stellar/stellar-sdk");
+const { buildUnsignedRepaymentXdr } = require("./soroban");
+
+describe("buildUnsignedRepaymentXdr", () => {
+  const borrower = Keypair.random().publicKey();
+  const contractId = Keypair.random().publicKey();
+
+  beforeEach(() => {
+    jest.spyOn(rpc.Server.prototype, "getAccount").mockResolvedValue(new Account(borrower, "100"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("encodes the full repayment amount into the XDR, not a tenth of it", async () => {
+    const inputAmount = 1000;
+    const loanId = "42";
+
+    const xdrString = await buildUnsignedRepaymentXdr({
+      borrower,
+      loanId,
+      amount: inputAmount,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, "Test SDF Network ; September 2015");
+
+    const op = tx.operations[0];
+    expect(op.type).toBe("invokeHostFunction");
+
+    if (op.type === "invokeHostFunction") {
+      const invokeArgs = op.func.invokeContract();
+      const args = invokeArgs.args();
+      const amountVal = scValToNative(args[1]);
+
+      expect(amountVal).toBe(BigInt(inputAmount));
+      expect(amountVal).not.toBe(BigInt(inputAmount / 10));
+    }
+  });
+});

--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -48,8 +48,10 @@ describe("buildUnsignedRepaymentXdr", () => {
     if (op.type === "invokeHostFunction") {
       const invokeArgs = op.func.invokeContract();
       const args = invokeArgs.args();
-      const amountVal = scValToNative(args[1]);
+      const loanIdVal = scValToNative(args[1]);
+      const amountVal = scValToNative(args[2]);
 
+      expect(loanIdVal).toBe(BigInt(loanId));
       expect(amountVal).toBe(BigInt(inputAmount));
       expect(amountVal).not.toBe(BigInt(inputAmount / 10));
     }

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -81,7 +81,7 @@ export async function buildUnsignedRepaymentXdr({
 
   const borrowerScVal = new Address(borrower).toScVal();
   const loanIdScVal = nativeToScVal(BigInt(loanId), { type: "u64" });
-  const amountScVal = nativeToScVal(BigInt(Math.floor(amount / 10)), { type: "i128" });
+  const amountScVal = nativeToScVal(BigInt(Math.floor(amount)), { type: "i128" });
 
   const tx = new TransactionBuilder(source, {
     fee: "10000",


### PR DESCRIPTION
## Summary
Closes #1368

Fixes a critical bug where `buildUnsignedRepaymentXdr` in
`frontend/src/app/utils/soroban.ts` divided the repayment amount by
ten before building the XDR, allowing a borrower to have their loan
marked as fully repaid while only transferring 10% of the actual owed
amount.

## Root cause
`[exact line/description of the bug — e.g. "the function applied an
incorrect stroop conversion, dividing by 10 where it should have used
the correct decimal-precision constant"]`, found at
`frontend/src/app/utils/soroban.ts:[line number]`.

## Fix
`[one-line description of the actual fix — e.g. "corrected the
decimal conversion to match the pattern already used in
[sibling function name], which converts amounts correctly"]`

## Scope
- Only `buildUnsignedRepaymentXdr` and its direct conversion logic
  were touched — no other functions, no refactors
- No changes to the function signature or parameters
- Per the issue's own contributor note, this PR fixes only this one
  issue/function; no other bugs were introduced or fixed here

## Tests added/updated
`[test file path]` — asserts that for a known input repayment amount,
the resulting XDR/on-chain value equals the full input amount, not
one-tenth of it.

## Verification
- `npm run build` — `[pass/fail]`
- `npm run lint` — `[pass/fail]`
- `npm test` — `[pass/fail summary]`
- Manually verified: `[state what you personally checked — e.g. "for
  a 100 USDC repayment input, the built XDR now encodes 100 USDC, not
  10 USDC, confirmed by decoding the resulting XDR"]`
- Branch rebased on latest `origin/main`

## Notes for reviewers
This is a financial-precision fix, so I'd ask for a careful review of
the decimal-conversion logic specifically — `[flag anything relevant,
e.g. "confirm this is correct across all supported asset decimal
precisions used in this contract, not just the one tested"]`. Given
the severity (borrowers could clear loans while paying 10% of what's
owed), I'd treat this as a priority merge once verified.