### PR TITLE
Fix critical backend bugs: rate limiting, remittance ordering, score reconciliation, token revocation

### DIFF
--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -30,7 +30,7 @@ export const challengeRateLimiter = rateLimit({
 });
 
 export const loginRateLimiter = rateLimit({
-  windowMs: 6 * 1000, // 1 minute
+  windowMs: 60 * 1000, // 1 minute
   max: 5,
   keyGenerator: (req) =>
     `${ipKeyGenerator(req.ip ?? 'unknown')}:${req.body?.publicKey ?? 'unknown'}`,

--- a/backend/src/services/remittanceService.ts
+++ b/backend/src/services/remittanceService.ts
@@ -127,8 +127,8 @@ export const remittanceService = {
            RETURNING *`,
           [
             id,
-            payload.recipientAddress,
             payload.senderAddress,
+            payload.recipientAddress,
             payload.amount,
             normalizedFromCurrency,
             normalizedToCurrency,


### PR DESCRIPTION


## Summary

Investigated four critical backend issues. Two were already fixed on `main` by an
earlier commit (`211d6d9`, "Fix logic errors and inverted conditions across auth,
pool, rate limiting, and scores") and needed no further change. The other two were
still present and are fixed here, one commit per file.

closes #1327 
closes #1336 
closes #1328 
closes #1361
## Issues

### #1336 — Login rate-limit window is ten times too short (fixed)
`loginRateLimiter` in `backend/src/middleware/rateLimiter.ts` set `windowMs: 6 * 1000`
while the comment and `max: 5` both intended a 1-minute window. The effective limit
was ~50 attempts/minute instead of 5, making brute-forcing login far easier.

Fix: `windowMs` corrected to `60 * 1000`.

### #1328 — Remittance sender and recipient are stored swapped (fixed)
`createRemittance` in `backend/src/services/remittanceService.ts` bound
`payload.recipientAddress` to the `sender_id` column and `payload.senderAddress` to
`recipient_address` in the INSERT, persisting every remittance with the two parties
reversed.

Fix: swapped the bound values so `sender_id` gets `senderAddress` and
`recipient_address` gets `recipientAddress`.

### #1327 — Score drift between DB and contract is never flagged (already fixed on main)
`reconcileActiveBorrowerScores` in `backend/src/services/scoreReconciliationService.ts`
correctly computes `isDivergent = dbScore === null || dbScore !== contractScore`.
The wrong-operator regression (`===` instead of `!==`) was introduced by
`b1c3fa3` and already reverted by `211d6d9`, which is an ancestor of the current
`main`. No change needed.

### #1361 — Token revocation is a no-op (already fixed on main)
`revokeToken` in `backend/src/services/authService.ts` correctly guards with
`if (ttlSeconds <= 0) return;`, only skipping the blacklist write for
already-expired tokens. The inverted guard (`ttlSeconds >= 0`) was introduced by
`3343268` and already reverted by `211d6d9`, which is an ancestor of the current
`main`. No change needed.

## Commits

- `fix(backend): correct login rate-limit window to one minute` — `backend/src/middleware/rateLimiter.ts`
- `fix(backend): store remittance sender and recipient in correct order` — `backend/src/services/remittanceService.ts`

## Test plan

- [ ] `npm install` in `backend/` (not available in this environment) then `npm run typecheck`
- [ ] `npm test` — in particular `remittanceService.test.ts`
- [ ] Manually verify: 6 failed logins within 60s now trigger the limiter and it does not reset after ~6s
- [ ] Create a remittance from A to B and confirm the stored record has `sender_id = A`, `recipient_address = B`
