### PR TITLE
fix: correct amortization basis-point conversion

### DIFF
--- a/backend/src/__tests__/loanEndpoints.test.ts
+++ b/backend/src/__tests__/loanEndpoints.test.ts
@@ -382,6 +382,8 @@ describe('GET /api/loans/:loanId/amortization-schedule', () => {
       principal: 1000,
       interestRateBps: 1200,
       termLedgers: 518400,
+      totalInterest: 120,
+      totalDue: 1120,
     });
     expect(Array.isArray(response.body.amortization.schedule)).toBe(true);
     expect(response.body.amortization.schedule.length).toBeGreaterThan(0);
@@ -457,9 +459,17 @@ describe('POST /api/loans/amortization-preview', () => {
       principal: 1000,
       interestRateBps: 1200,
       termLedgers: 1036800,
+      totalInterest: 120,
+      totalDue: 1120,
     });
     expect(Array.isArray(response.body.amortization.schedule)).toBe(true);
     expect(response.body.amortization.schedule.length).toBe(2);
+    expect(
+      response.body.amortization.schedule.reduce(
+        (sum: number, period: { interestPortion: number }) => sum + period.interestPortion,
+        0,
+      ),
+    ).toBe(120);
   });
 
   it('should reject invalid termDays', async () => {

--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -239,8 +239,8 @@ const buildAmortizationSchedule = (
   termLedgers: number,
   startDate: Date,
 ) => {
-  const totalInterest = principal * (interestRateBps / 1000);
-  const totalDue = principal - totalInterest;
+  const totalInterest = principal * (interestRateBps / 10_000);
+  const totalDue = principal + totalInterest;
 
   const LEDGER_DAY = 17280; // 1 day in ledgers
   const termDays = termLedgers / LEDGER_DAY;


### PR DESCRIPTION
## Summary

`buildAmortizationSchedule` converted basis points with `/ 1000`, making a 1200 bps rate equal 120% instead of 12%. This changes the conversion to `/ 10000`, fixes `totalDue` to add interest to principal, and asserts both aggregate and per-period interest totals.

## Validation

- `npm test -- --runInBand src/__tests__/loanEndpoints.test.ts` was started but the broader endpoint suite did not exit within the command timeout
- the focused backend dependencies installed successfully
- `git diff --check`

Closes #1330