### PR TITLE
fix: correct cancellable loan statuses

### DIFF
--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -63,7 +63,7 @@ export const buildCancelLoanTx = async (req: Request, res: Response, next: NextF
       });
     }
 
-    if (!['PENDING', 'DEFAULTED'].includes(loan.status as string)) {
+    if (!['PENDING', 'OPEN'].includes(loan.status as string)) {
       return res.status(400).json({
         message: 'Loan cannot be cancelled',
       });

--- a/backend/src/services/__tests__/loanEndpoints.test.ts
+++ b/backend/src/services/__tests__/loanEndpoints.test.ts
@@ -15,6 +15,8 @@ process.env.ADMIN_WALLETS = ADMIN;
 // both the cancel (PENDING|OPEN) and reject (PENDING) guards.
 const loans: Record<string, { status: string; address: string }> = {
   'loan-123': { status: 'PENDING', address: BORROWER },
+  'open-loan': { status: 'OPEN', address: BORROWER },
+  'defaulted-loan': { status: 'DEFAULTED', address: BORROWER },
   'completed-loan': { status: 'COMPLETED', address: BORROWER },
   'loan-1': { status: 'PENDING', address: BORROWER },
 };
@@ -98,6 +100,24 @@ describe('POST /api/loans/:loanId/build-cancel', () => {
       .set('Authorization', borrowerAuth);
 
     expect(response.status).toBe(400);
+  });
+
+  it('should allow an OPEN loan to be cancelled', async () => {
+    const response = await request(app)
+      .post('/api/loans/open-loan/build-cancel')
+      .set('Authorization', borrowerAuth);
+
+    expect(response.status).toBe(200);
+    expect(mockBuildCancelLoanTx).toHaveBeenCalledWith(BORROWER, 'open-loan');
+  });
+
+  it('should reject a DEFAULTED loan', async () => {
+    const response = await request(app)
+      .post('/api/loans/defaulted-loan/build-cancel')
+      .set('Authorization', borrowerAuth);
+
+    expect(response.status).toBe(400);
+    expect(mockBuildCancelLoanTx).not.toHaveBeenCalledWith(BORROWER, 'defaulted-loan');
   });
 });
 


### PR DESCRIPTION
## Summary

`buildCancelLoanTx` incorrectly treated `DEFAULTED` as cancellable and rejected `OPEN`. The guard now permits only `PENDING` and `OPEN`, with endpoint regression coverage for both OPEN success and DEFAULTED rejection.

## Validation

- `npm test -- --runInBand src/services/__tests__/loanEndpoints.test.ts --forceExit` — 6 tests passed
- `git diff --check`

Closes #1331