### PR TITLE
test: verify optimistic withdrawals decrease deposits

### DIFF
--- a/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
+++ b/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
@@ -207,6 +207,32 @@ describe("useWithdrawFromPool optimistic rollback", () => {
     return { poolStats, depositor };
   }
 
+  it("onMutate subtracts a normal withdrawal from pool and depositor totals", async () => {
+    global.fetch = mockFetchSuccess({
+      unsignedTxXdr: "xdr",
+      networkPassphrase: "pass",
+    }) as unknown as typeof fetch;
+    const { queryClient, wrapper } = createTestHarness();
+    seedWithdrawCache(queryClient);
+
+    const { result } = renderHook(() => useWithdrawFromPool(), { wrapper });
+
+    result.current.mutate({
+      amount: 50,
+      depositorAddress: DEPOSITOR,
+      token: "USDC",
+    });
+
+    await waitFor(() => {
+      const cachedStats = queryClient.getQueryData<PoolStats>(queryKeys.pool.stats());
+      const cachedDepositor = queryClient.getQueryData<DepositorPortfolio>(
+        queryKeys.pool.depositor(DEPOSITOR),
+      );
+      expect(cachedStats?.totalDeposits).toBe(9950);
+      expect(cachedDepositor?.depositAmount).toBe(450);
+    });
+  });
+
   it("onMutate clamps depositAmount and totalDeposits at 0 when withdrawal exceeds balance", async () => {
     global.fetch = mockFetchSuccess({
       unsignedTxXdr: "xdr",


### PR DESCRIPTION
## Summary

Current `main` already subtracts withdrawals in `useWithdrawFromPool`. This PR adds a normal-range regression test proving that withdrawing 50 decreases cached pool deposits from 10,000 to 9,950 and the depositor balance from 500 to 450, complementing the existing over-withdrawal clamp test.

## Validation

- `npm test -- --runInBand src/app/hooks/useApi.optimisticRollback.test.tsx --forceExit` — 10 tests passed
- `git diff --check`

Closes #1343