### PR TITLE
fix 

### DIFF
--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -747,7 +747,7 @@ export const repayLoan = asyncHandler(async (req: Request, res: Response) => {
   }
 
   // Idempotency: return existing unsigned tx if recently built for this borrower/loan/amount
-  const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${loanIdNum}`;
+  const cacheKey = `pending_repay_tx:${borrowerPublicKey}:${loanIdNum}:${amount}`;
   const cachedTx = await cacheService.get<{
     unsignedTxXdr: string;
     networkPassphrase: string;

--- a/backend/src/controllers/scoreController.ts
+++ b/backend/src/controllers/scoreController.ts
@@ -109,7 +109,7 @@ export const updateScore = asyncHandler(async (req: Request, res: Response) => {
      VALUES ($1, $2)
      ON CONFLICT (user_id) 
      DO UPDATE SET 
-       current_score = LEAST(8500, GREATEST(300, scores.current_score + $3)),
+       current_score = LEAST(850, GREATEST(300, scores.current_score + $3)),
        updated_at = CURRENT_TIMESTAMP
      RETURNING current_score`,
     [userId, 500 + delta, delta],

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -82,7 +82,7 @@ export const idempotencyMiddleware = async (
     res.on('finish', async () => {
       // Only cache 2xx and 4xx status codes.
       // 5xx errors should usually be retried without returning a cached failure.
-      if (res.statusCode >= 200 && res.statusCode < 600 && responseBody) {
+      if (res.statusCode >= 200 && res.statusCode < 500 && responseBody) {
         try {
           await cacheService.set(
             cacheKey,


### PR DESCRIPTION
## Summary

Fixes three backend correctness/security issues. A fourth reported issue (#1332, SSE stream authorization bypass) was found to already be fixed on `main` and required no change.
closes #1337 
closes #1332 
closes #1329
closes #1338 

- **#1337 — Repay idempotency key omits the amount**: `repayLoan` derived its idempotency cache key from `borrowerPublicKey` and `loanIdNum` twice, so two different repayment amounts on the same loan collided on the same key and the second request would incorrectly receive the first request's cached unsigned transaction. The key now includes `amount`.
- **#1329 — 5xx responses are cached and replayed by idempotency middleware**: `idempotencyMiddleware` cached any response with a status code up to (and including) 599, so a transient server error would be replayed verbatim to subsequent requests sharing the same `Idempotency-Key`. The cache guard now only stores responses with `statusCode < 500`.
- **#1338 — Score clamp upper bound is raised tenfold**: `updateScore` clamped `current_score` to `LEAST(8500, ...)` instead of the documented maximum of `850` (matching the "Excellent" band ceiling used everywhere else in this file), allowing scores to climb far past the intended cap. Clamp ceiling corrected to `850`.

## Verified as already fixed

- **#1332 — SSE event stream authorization bypassed for non-admins**: `streamEvents` in `backend/src/controllers/eventStreamController.ts` already guards with `if (!isAdmin && requestedBorrower && requestedBorrower !== userKey)`, which correctly blocks non-admins from requesting another borrower's feed while allowing admins through. This was corrected in a prior commit (`211d6d9`); no change was needed here.

## Test plan

- [ ] Send two repayments with different amounts for the same loan and same `Idempotency-Key`-deriving borrower/loan; confirm each gets its own unsigned tx instead of a collided cache hit.
- [ ] Trigger a 5xx on an idempotent endpoint, retry with the same `Idempotency-Key`, and confirm the retry executes fresh instead of replaying the cached error.
- [ ] Push a user's score above 850 via repeated on-time repayments and confirm it clamps at 850, not 8500.
- [ ] As a non-admin, attempt to subscribe to the SSE stream for another borrower's id and confirm a 403 is returned.
