### PR TITLE
Fix four SSE/notification/score reliability bugs

### DIFF
--- a/backend/src/controllers/scoreController.ts
+++ b/backend/src/controllers/scoreController.ts
@@ -207,7 +207,7 @@ export const getScoreBreakdown = asyncHandler(async (req: Request, res: Response
            r.loan_id,
            r.repaid_ledger,
            r.repaid_at,
-           CASE WHEN r.repaid_ledger <= a.approved_ledger - a.term_ledgers
+           CASE WHEN r.repaid_ledger <= a.approved_ledger + a.term_ledgers
                 THEN true ELSE false END AS on_time,
            (r.repaid_ledger - a.approved_ledger) AS repayment_ledgers
          FROM repaid_loans r

--- a/frontend/src/app/hooks/useLoanStream.ts
+++ b/frontend/src/app/hooks/useLoanStream.ts
@@ -60,7 +60,7 @@ export function useLoanStream(loanId: string | undefined): RealtimeStatus {
     onMessage: (payload) => {
       if (payload.type === "init") return;
       if (!payload.eventType || !LOAN_REFRESH_EVENTS.has(payload.eventType)) return;
-      if (String(payload.loanId ?? "") === loanId) return;
+      if (String(payload.loanId ?? "") !== loanId) return;
       invalidateLoanQueries();
     },
     onFallbackPoll: invalidateLoanQueries,

--- a/frontend/src/app/hooks/useNotificationStream.ts
+++ b/frontend/src/app/hooks/useNotificationStream.ts
@@ -89,7 +89,7 @@ export function useNotificationStream() {
                     if ("type" in payload && payload.type === "init") {
                       const ids = new Set(existing.notifications.map((n) => n.id));
                       const merged = [
-                        ...payload.notifications.filter((n) => ids.has(n.id)),
+                        ...payload.notifications.filter((n) => !ids.has(n.id)),
                         ...existing.notifications,
                       ].sort(
                         (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),

--- a/frontend/src/app/hooks/useSSE.ts
+++ b/frontend/src/app/hooks/useSSE.ts
@@ -150,7 +150,7 @@ export function useSSE<T = unknown>({
           return;
         }
 
-        reconnectAttempts.current -= 1;
+        reconnectAttempts.current += 1;
         onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
 
         if (reconnectAttempts.current >= maxReconnectAttempts) {


### PR DESCRIPTION


## Summary

closes #1344
closes #1334 
closes #1345 
closes #1346  

- **#1344** `useSSE`: reconnect attempt counter was decremented on failure instead of incremented, so it never reached `maxReconnectAttempts` and the client kept retrying indefinitely instead of falling back to polling. Changed `reconnectAttempts.current -= 1` to `+= 1`.
- **#1334** `getScoreBreakdown`: the on-time repayment check compared `repaid_ledger <= approved_ledger - term_ledgers`, a threshold earlier than the loan's own approval ledger, so virtually every repayment was classified as late. Changed the comparison to `approved_ledger + term_ledgers` (the actual due ledger).
- **#1345** `useNotificationStream`: the `init` merge kept only notifications whose id was already in the existing cache (`ids.has(n.id)`), discarding genuinely new notifications. Inverted the filter to `!ids.has(n.id)` so new notifications are added instead of dropped.
- **#1346** `useLoanStream`: `onMessage` returned early when the incoming event's `loanId` matched the loan currently being viewed, skipping the exact updates the viewer needed while unrelated loans still triggered a refresh. Inverted the comparison so updates are skipped only when the event is for a different loan.

## Test plan

- [ ] Force repeated SSE connection failures and confirm the reconnect attempt count increments and the client falls back to polling after `maxReconnectAttempts`.
- [ ] Request `/api/score/:userId/breakdown` for a borrower with on-time repayments and confirm they are counted under `repaidOnTime`, not `repaidLate`.
- [ ] Push a new notification over the SSE stream and confirm it appears in the notification list.
- [ ] Open a loan detail page and push a stream event for that same loan; confirm the view refreshes. Push an event for a different loan and confirm it doesn't trigger an unnecessary refresh of the viewed loan (rate limiting still applies).
