### PR TITLE
fix: correct JWT expiry operator, repayment XDR arg order, and SSRF 172.16 gap

### DIFF
--- a/backend/src/controllers/indexerController.ts
+++ b/backend/src/controllers/indexerController.ts
@@ -40,7 +40,7 @@ function isPrivateHost(hostname: string): boolean {
 
   // Private IPv4 ranges (RFC 1918)
   if (/^10\./.test(host)) return true;
-  if (/^172\.(1[7-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
   if (/^192\.168\./.test(host)) return true;
 
   // AWS / GCP metadata endpoints

--- a/frontend/src/app/lib/session.ts
+++ b/frontend/src/app/lib/session.ts
@@ -34,7 +34,7 @@ export function isJwtExpired(token: string): boolean {
   const payload = decodeJwtPayload(token);
   const exp = payload?.exp;
 
-  return typeof exp === "number" && exp * 1000 >= Date.now();
+  return typeof exp === "number" && exp * 1000 <= Date.now();
 }
 
 export function clearSessionState() {

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -93,7 +93,7 @@ export async function buildUnsignedRepaymentXdr({
           new xdr.InvokeContractArgs({
             contractAddress: Address.fromString(contractId).toScAddress(),
             functionName: "repay",
-            args: [borrowerScVal, amountScVal, loanIdScVal],
+            args: [borrowerScVal, loanIdScVal, amountScVal],
           }),
         ),
         auth: [],


### PR DESCRIPTION
Closes #1339
Closes #1340
Closes #1341
Closes #1342

## Summary

Three one-line logic fixes across the frontend and backend.

## Changes

### #1340 — JWT expiry check inverted (`frontend/src/app/lib/session.ts`)

`isJwtExpired` compared the expiry with `>=` instead of `<=`, causing valid tokens to appear expired and expired tokens to appear valid.

```ts
// Before (wrong)
return typeof exp === "number" && exp * 1000 >= Date.now();

// After (correct)
return typeof exp === "number" && exp * 1000 <= Date.now();
```

A token is expired when `exp * 1000` is **in the past** (≤ now), not the future.

---

### #1341 — Repayment XDR argument order (`frontend/src/app/utils/soroban.ts`)

`buildUnsignedRepaymentXdr` passed `[borrowerScVal, amountScVal, loanIdScVal]` to the contract's `repay` function, but the contract signature expects `(borrower, loan_id, amount)`.

```ts
// Before (wrong order)
args: [borrowerScVal, amountScVal, loanIdScVal],

// After (correct order)
args: [borrowerScVal, loanIdScVal, amountScVal],
```

---

### #1339 — SSRF guard misses 172.16.x (`backend/src/controllers/indexerController.ts`)

The `isPrivateHost` regex used `1[7-9]` for the second octet of the `172.x` range, covering only `172.17–172.31`. The full RFC 1918 `172.16.0.0/12` block starts at `172.16`, so `172.16.x` addresses were incorrectly treated as public.

```ts
// Before (misses 172.16.x)
if (/^172\.(1[7-9]|2\d|3[01])\./.test(host)) return true;

// After (covers full 172.16.0.0/12)
if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
```