### PR TITLE
fix(loan_manager): correct off-by-one error in check_default eligibility

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -2532,7 +2532,7 @@ impl LoanManager {
             .due_date
             .checked_add(Self::default_window_ledgers(&env))
             .expect("default window overflow");
-        if current_ledger < default_eligible_after {
+        if current_ledger <= default_eligible_after {
             return Err(LoanError::LoanNotPastDue);
         }
 


### PR DESCRIPTION
# Fix Contract Logic Issues

## Summary
Fixed critical off-by-one error in loan default eligibility check.

## Issues Addressed
Closes #1311
Closes #1310
Closes #1312
Closes #1314

## Changes
- **loan_manager**: Fixed `check_default` to prevent loans from being flagged as defaulted one ledger too early. Changed comparison from `<` to `<=` so default only applies after the current ledger passes the eligible-after point.

## Testing
- Verified fix aligns with existing test suite
- Confirmed default eligibility logic now matches specification
