### PR TITLE
fix(backend): correct has_next pagination flag; close 3 already-fixed contract issues

### DIFF
--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -110,7 +110,7 @@ export function createPaginatedResponse<T>(
       offset,
       count: currentCount,
       has_previous: offset > 0,
-      has_next: offset + currentCount <= totalCount,
+      has_next: offset + currentCount < totalCount,
     },
   };
 }


### PR DESCRIPTION
closes #1300 - has_next in createPaginatedResponse (backend/src/utils/pagination.ts) used <= instead of < when comparing offset + currentCount against totalCount, so the last page still advertised another page. Changed to strict < so has_next is false once returned rows reach the total count.

closes #1299 - Verified against current main: the quorum check in contracts/multisig_governance/src/lib.rs already requires approval_count >= threshold before finalize (rejects with ThresholdNotMet otherwise). This was fixed by commit c6ac86e "fix(contracts): require full approval threshold before finalize" (2026-07-25), which predates this PR. No quorum bypass exists on main; closing as already resolved.

closes #1315 - Verified against current main: finalize_admin_transfer in contracts/multisig_governance/src/lib.rs already blocks finalization while now < pending.executable_after and only proceeds once the timelock has fully elapsed. This was fixed by commit 50653cf "fix(contracts): fix inverted comparison operators in multisig_governance" (2026-07-24), which predates this PR. The comparison is not inverted on main; closing as already resolved.

closes #1313 - Verified against current main: assert_withdrawal_cooldown_elapsed in contracts/lending_pool/src/lib.rs already panics with withdrawal_cooldown_active while current_ledger < deposit_ledger + cooldown, correctly blocking withdrawals only during the lock window and permitting them after. This was fixed by commit 0ec8d15 "Fix logic errors and inverted conditions in lending pool smart contract" (2026-07-24), which predates this PR. The check is not reversed on main; closing as already resolved.
