### PR TITLE
fix: amount-range inversion, and verify loan cap/interest/limit fixes

### DIFF
--- a/backend/src/utils/__tests__/pagination.test.ts
+++ b/backend/src/utils/__tests__/pagination.test.ts
@@ -1,0 +1,28 @@
+import { parseQueryParams } from '../pagination.js';
+import type { Request } from 'express';
+
+describe('parseQueryParams amountRange', () => {
+  const mockRequest = (amountRange: string | undefined): Partial<Request> => ({
+    query: { amount_range: amountRange },
+  });
+
+  it('should leave a well-ordered min,max pair unchanged', () => {
+    const req = mockRequest('10,100') as Request;
+    expect(parseQueryParams(req).amountRange).toEqual({ min: 10, max: 100 });
+  });
+
+  it('should swap an out-of-order min,max pair', () => {
+    const req = mockRequest('100,10') as Request;
+    expect(parseQueryParams(req).amountRange).toEqual({ min: 10, max: 100 });
+  });
+
+  it('should return the same value for equal min and max', () => {
+    const req = mockRequest('50,50') as Request;
+    expect(parseQueryParams(req).amountRange).toEqual({ min: 50, max: 50 });
+  });
+
+  it('should return null when amount_range is not provided', () => {
+    const req = mockRequest(undefined) as Request;
+    expect(parseQueryParams(req).amountRange).toBeNull();
+  });
+});

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -191,5 +191,5 @@ function parseAmountRange(value: unknown): { min: number; max: number } | null {
     return null;
   }
 
-  return min >= max ? { min, max } : { min: max, max: min };
+  return min <= max ? { min, max } : { min: max, max: min };
 }


### PR DESCRIPTION
## Summary

- **#1301** — `parseAmountRange` in `backend/src/utils/pagination.ts` had its ordering check inverted (`min >= max ? unchanged : swapped`), so a normal, well-ordered `min,max` pair was being swapped and an actually out-of-order pair was passed through unchanged. Fixed to `min <= max ? unchanged : swapped`. Added `backend/src/utils/__tests__/pagination.test.ts` covering well-ordered, out-of-order, equal, and absent ranges.

- **#1302, #1307, #1308** — Verified these are already fixed on `main` by an earlier, unrelated merge (`4f0da92`, "fix(loan-manager): correct math, limits, and score drops" / "Fix logic errors and inverted conditions across auth, pool, rate limiting, and scores") that never referenced the issue numbers, which is why they stayed open:
  - `#1302`: `parseCappedLimit` in `backend/src/utils/queryHelpers.ts` already rejects `rawLimit <= 0` (not `< 0`), covered by `backend/src/utils/__tests__/queryHelpers.test.ts`.
  - `#1307`: `accrue_interest` in `contracts/loan_manager/src/lib.rs` already divides by `10_000 * DEFAULT_TERM_LEDGERS` (not `100_000 * ...`), covered by existing numeric assertions (e.g. `test_overdue_repayment_charges_late_fee`).
  - `#1308`: `request_loan`'s active-loan-count guard already uses `active_loan_count >= max_loans_per_borrower` (not `>`), covered by `test_borrower_max_active_loans_blocks_new_requests`.

No code changes were needed for these three; including them here so the issues get closed and the fix is documented in one place, per the assignment.

## Test plan

- [x] `cd contracts/loan_manager && cargo test --lib` — 117 passed, 0 failed (confirms #1307 and #1308 behavior)
- [x] `cd backend && node --experimental-vm-modules node_modules/jest/bin/jest.js src/utils/__tests__/pagination.test.ts src/utils/__tests__/queryHelpers.test.ts` — 12 passed, 0 failed (confirms #1301 fix and #1302 behavior)
- [x] `npm run typecheck` in `backend` shows no new errors introduced (pre-existing unrelated errors confirmed via stash diff)

Closes #1301
Closes #1302
Closes #1307
Closes #1308