### PR TITLE
fix(frontend): correct off-by-one in truncateDecimals and add precision tests

### DIFF
--- a/frontend/src/app/utils/precision.test.ts
+++ b/frontend/src/app/utils/precision.test.ts
@@ -1,0 +1,46 @@
+import { truncateDecimals, getAssetPrecision } from "./precision";
+
+describe("truncateDecimals (#1304)", () => {
+  it("keeps exactly N decimals when the input has more", () => {
+    // Off-by-one bug: used slice(0, decimals + 1) instead of slice(0, decimals).
+    expect(truncateDecimals("1.12345", 2)).toBe("1.12");
+    expect(truncateDecimals("9.9999999", 7)).toBe("9.9999999");
+    expect(truncateDecimals("0.123456789", 7)).toBe("0.1234567");
+  });
+
+  it("does not modify values already within precision", () => {
+    expect(truncateDecimals("1.5", 7)).toBe("1.5");
+    expect(truncateDecimals("1.12", 2)).toBe("1.12");
+    expect(truncateDecimals("42", 7)).toBe("42");
+  });
+
+  it("handles an empty string", () => {
+    expect(truncateDecimals("", 7)).toBe("");
+  });
+
+  it("handles multiple decimal points by keeping only the first fractional part", () => {
+    expect(truncateDecimals("1.2.3", 2)).toBe("1.2");
+    expect(truncateDecimals("1.234.5", 1)).toBe("1.2");
+  });
+});
+
+describe("getAssetPrecision", () => {
+  it("returns 7 for XLM", () => {
+    expect(getAssetPrecision("XLM")).toBe(7);
+  });
+
+  it("returns 2 for stablecoins", () => {
+    expect(getAssetPrecision("USDC")).toBe(2);
+    expect(getAssetPrecision("EURC")).toBe(2);
+    expect(getAssetPrecision("PHP")).toBe(2);
+  });
+
+  it("is case-insensitive", () => {
+    expect(getAssetPrecision("xlm")).toBe(7);
+    expect(getAssetPrecision("usdc")).toBe(2);
+  });
+
+  it("falls back to 7 for unknown assets", () => {
+    expect(getAssetPrecision("UNKNOWN")).toBe(7);
+  });
+});

--- a/frontend/src/app/utils/precision.ts
+++ b/frontend/src/app/utils/precision.ts
@@ -17,7 +17,7 @@ export function truncateDecimals(value: string, decimals: number): string {
   }
 
   if (parts.length === 2 && parts[1].length > decimals) {
-    return `${parts[0]}.${parts[1].slice(0, decimals + 1)}`;
+    return `${parts[0]}.${parts[1].slice(0, decimals)}`;
   }
 
   return value;


### PR DESCRIPTION
Closes #1303
Closes #1304
Closes #1305
Closes #1306

## Changes

**#1304 — `truncateDecimals` keeps one extra decimal (fixed)**

`frontend/src/app/utils/precision.ts`: changed `slice(0, decimals + 1)` to `slice(0, decimals)`. The off-by-one meant a value like `"1.123"` truncated to 2 decimals returned `"1.123"` (3 digits) instead of `"1.12"`.

**#1303, #1305, #1306 — verified fixed by prior merge**

The `toStroops` padding direction (#1303), `escapeCsvValue` global-replace (#1305), and `approve_loan` transfer direction (#1306) were corrected in the preceding merge. Existing tests in `amount.test.ts` and `csv.test.ts` already cover those cases.

**New test file**

Added `frontend/src/app/utils/precision.test.ts` covering `truncateDecimals` (the off-by-one regression, within-precision passthrough, empty input, multiple-dot input) and `getAssetPrecision` (all known assets, case-insensitivity, unknown fallback).