### PR TITLE
fix(loan_manager): correct oracle rate sanity check condition in comp…

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -255,7 +255,7 @@ impl LoanManager {
             let min_rate = Self::min_rate_bps(env);
             let max_rate = Self::max_rate_bps(env);
 
-            if oracle_rate < min_rate && oracle_rate > max_rate {
+            if oracle_rate < min_rate || oracle_rate > max_rate {
                 Self::read_interest_rate(env)
             } else {
                 oracle_rate


### PR DESCRIPTION
Closes #1297 

…ute_interest_rate

The sanity check meant to reject an oracle rate that falls outside the min/max band could never trigger because && was used instead of ||. A u32 value cannot be simultaneously less than min_rate AND greater than max_rate, so the condition was always false and the intended fallback branch was dead code.

A stale or compromised oracle could push the rate to zero (free loans) or to an extreme value without being caught.

Changed && to || so the check correctly triggers when the oracle rate is below the minimum OR above the maximum band.

Fixes #631.

File: contracts/loan_manager/src/lib.rs
Function: compute_interest_rate

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
