### PR TITLE
fix(lending_pool): correct utilization_bps scale in get_pool_stats

### DIFF
--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -670,7 +670,7 @@ impl LendingPool {
         // Utilisation: portion of tracked principal currently out on loan.
         let utilization_bps = if total_deposits > 0 && pool_token_balance < total_deposits {
             let borrowed = total_deposits - pool_token_balance;
-            ((borrowed * 1_000) / total_deposits) as u32
+            ((borrowed * 10_000) / total_deposits) as u32
         } else {
             0
         };


### PR DESCRIPTION
Closes #1298 

Utilization was computed using * 1_000 (1/1000ths) instead of * 10_000 (1/10000ths = basis points). A pool that is 50% utilized reported as 500 bps (5%) instead of 5000 bps (50%) — off by a factor of ten.

Every dashboard, rate curve and risk check that reads utilization was wrong by a factor of 10.

Changed * 1_000 to * 10_000 so utilization_bps uses the correct basis- point scale against the full 10000 denominator.

Fixes #???.

File: contracts/lending_pool/src/lib.rs
Function: get_pool_stats

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
