### PR TITLE
Fix stale docs, add stepper keyboard nav, scrub PII from Sentry events

### DIFF
--- a/backend/src/config/__tests__/sentry.test.ts
+++ b/backend/src/config/__tests__/sentry.test.ts
@@ -1,0 +1,71 @@
+import type { ErrorEvent } from '@sentry/node';
+import { scrubEvent } from '../sentry.js';
+
+describe('scrubEvent', () => {
+  it('redacts Authorization headers and cookies from request context', () => {
+    const event = {
+      request: {
+        headers: {
+          Authorization: 'Bearer fake.jwt.token',
+          'x-api-key': 'super-secret-key',
+          'user-agent': 'jest-test',
+        },
+        cookies: {
+          session: 'fake-session-jwt',
+        },
+        data: {
+          password: 'hunter2',
+          publicKey: 'GABCDEF1234567890',
+          amount: 100,
+        },
+      },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+
+    expect(scrubbed.request?.headers?.Authorization).toBe('[REDACTED]');
+    expect(scrubbed.request?.headers?.['x-api-key']).toBe('[REDACTED]');
+    expect(scrubbed.request?.headers?.['user-agent']).toBe('jest-test');
+    expect((scrubbed.request?.cookies as Record<string, string>).session).toBe('[REDACTED]');
+    expect((scrubbed.request?.data as Record<string, unknown>).password).toBe('[REDACTED]');
+    expect((scrubbed.request?.data as Record<string, unknown>).publicKey).toBe('[REDACTED]');
+    expect((scrubbed.request?.data as Record<string, unknown>).amount).toBe(100);
+  });
+
+  it('redacts PII fields nested in user and extra context', () => {
+    const event = {
+      user: {
+        id: 'user-1',
+        walletAddress: 'GABC...XYZ',
+      },
+      extra: {
+        nested: {
+          jwt: 'fake.jwt.value',
+          note: 'not sensitive',
+        },
+      },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+
+    expect((scrubbed.user as Record<string, unknown>).walletAddress).toBe('[REDACTED]');
+    expect((scrubbed.user as Record<string, unknown>).id).toBe('user-1');
+    const extra = scrubbed.extra as { nested: Record<string, unknown> };
+    expect(extra.nested.jwt).toBe('[REDACTED]');
+    expect(extra.nested.note).toBe('not sensitive');
+  });
+
+  it('is a no-op when no sensitive data is present', () => {
+    const event = {
+      request: {
+        headers: { 'content-type': 'application/json' },
+      },
+      message: 'Something broke',
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+
+    expect(scrubbed.request?.headers?.['content-type']).toBe('application/json');
+    expect(scrubbed.message).toBe('Something broke');
+  });
+});

--- a/backend/src/config/sentry.ts
+++ b/backend/src/config/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import type { ErrorEvent, EventHint } from '@sentry/node';
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
 const NODE_ENV = process.env.NODE_ENV || 'development';
@@ -9,6 +10,80 @@ const ENVIRONMENT_MAP: Record<string, string> = {
   development: 'development',
   test: 'test',
 };
+
+const SENSITIVE_HEADERS = ['authorization', 'cookie', 'x-api-key'];
+
+const SENSITIVE_FIELDS = [
+  'secret',
+  'apiKey',
+  'password',
+  'token',
+  'jwt',
+  'signedTx',
+  'signedTxXdr',
+  'publicKey',
+  'privateKey',
+  'walletAddress',
+  'borrowerPublicKey',
+];
+
+function scrubValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (!value || typeof value !== 'object') return value;
+
+  if (seen.has(value as object)) return value;
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubValue(item, seen));
+  }
+
+  const scrubbed = { ...(value as Record<string, unknown>) };
+  for (const key of Object.keys(scrubbed)) {
+    if (SENSITIVE_FIELDS.includes(key) || SENSITIVE_HEADERS.includes(key.toLowerCase())) {
+      scrubbed[key] = '[REDACTED]';
+    } else if (typeof scrubbed[key] === 'object' && scrubbed[key] !== null) {
+      scrubbed[key] = scrubValue(scrubbed[key], seen);
+    }
+  }
+
+  return scrubbed;
+}
+
+/**
+ * Strips Authorization headers, JWT/session cookies, and known PII field
+ * names from an event before it is sent to Sentry.
+ */
+export function scrubEvent(event: ErrorEvent): ErrorEvent {
+  if (event.request) {
+    if (event.request.headers) {
+      event.request.headers = scrubValue(event.request.headers) as Record<string, string>;
+    }
+    if (event.request.cookies) {
+      // Cookies may carry session/JWT values under arbitrary names, so redact
+      // every cookie wholesale rather than matching against a field-name list.
+      event.request.cookies = Object.fromEntries(
+        Object.keys(event.request.cookies).map((name) => [name, '[REDACTED]']),
+      );
+    }
+    if (event.request.data) {
+      event.request.data = scrubValue(event.request.data);
+    }
+  }
+
+  if (event.user) {
+    event.user = scrubValue(event.user) as Sentry.User;
+  }
+
+  if (event.extra) {
+    event.extra = scrubValue(event.extra) as Record<string, unknown>;
+  }
+
+  if (event.contexts) {
+    event.contexts = scrubValue(event.contexts) as Record<string, Record<string, unknown>>;
+  }
+
+  return event;
+}
 
 export function initSentry(): void {
   if (!SENTRY_DSN) {
@@ -22,6 +97,9 @@ export function initSentry(): void {
     tracesSampleRate: NODE_ENV === 'production' ? 0.2 : 1.0,
     // Disable Sentry in test environment to avoid noise
     enabled: NODE_ENV !== 'test',
+    beforeSend(event: ErrorEvent, _hint: EventHint) {
+      return scrubEvent(event);
+    },
   });
 }
 

--- a/backend/src/middleware/README.md
+++ b/backend/src/middleware/README.md
@@ -1,18 +1,55 @@
-# Validation Middleware
+# Middleware
 
-This directory contains middleware for validating incoming requests using Zod.
+This directory contains all Express middleware used by the backend.
+
+## Middleware chain order (`app.ts`)
+
+Applied in this order for every request:
+
+1. `helmet` (third-party) — security headers, CSP.
+2. `cors` (third-party) — origin allowlist enforcement.
+3. `compression` (third-party) — response gzip/deflate.
+4. `express.json` (third-party) — JSON body parsing, capped at 100kb.
+5. **`globalRateLimiter`** (`rateLimiter.ts`) — global per-IP request rate limit.
+6. **`requestIdMiddleware`** (`requestId.ts`) — assigns/propagates `x-request-id`.
+7. **`requestLogger`** (`requestLogger.ts`) — structured request/response logging.
+8. **`metricsMiddleware`** (`metrics.ts`) — records Prometheus HTTP metrics.
+9. **`pauseGuard`** (`pauseGuard.ts`) — rejects state-mutating requests while contracts are paused.
+10. _(routes mounted here)_
+11. **`Sentry.setupExpressErrorHandler`** — captures forwarded errors for Sentry.
+12. **`errorHandler`** (`errorHandler.ts`) — final centralized error handler, must stay last.
+
+Additional middleware below are applied per-route (not globally in `app.ts`) via individual router files.
+
+## Middleware reference
+
+| File                     | Description                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `auditLog.ts`            | Sanitizes and logs mutating requests for the audit trail, stripping sensitive fields from the body before persisting. |
+| `auth.ts`                | `requireApiKey` — validates admin API keys and enforces scope-based access for internal/admin routes.                 |
+| `errorHandler.ts`        | Centralized Express error handler; formats and returns all forwarded errors. Must be registered last.                 |
+| `idempotency.ts`         | Handles `Idempotency-Key` headers, returning a cached response when a key has already been processed.                 |
+| `jwtAuth.ts`             | `requireJwtAuth` — validates JWTs and caps embedded scopes to the wallet's current on-chain role.                     |
+| `loanAccess.ts`          | Used after `requireJwtAuth`; ensures `req.params.loanId` belongs to the authenticated borrower.                       |
+| `metrics.ts`             | `metricsMiddleware`/`metricsHandler` — records and exposes Prometheus HTTP metrics.                                   |
+| `pauseGuard.ts`          | Blocks state-mutating requests when the relevant on-chain contract is paused.                                         |
+| `rateLimiter.ts`         | `globalRateLimiter`/`strictRateLimiter` — general-purpose per-IP rate limiting used in `app.ts`.                      |
+| `rateLimitMiddleware.ts` | Configurable rate limiting middleware for specific routes, with pluggable request-identifier extraction.              |
+| `requestId.ts`           | Assigns/propagates a unique `x-request-id` per request for tracing.                                                   |
+| `requestLogger.ts`       | Logs structured HTTP request fields (method, url, statusCode, durationMs).                                            |
+| `validation.ts`          | `validateBody`/`validateQuery`/`validateParams` — validates request data against Zod schemas.                         |
 
 ## Usage
 
-The `validate` middleware function accepts a Zod schema and validates the request against it.
+The `validate*` middleware functions accept a Zod schema and validate the corresponding part of the request against it.
 
 ### Example
 
 ```typescript
-import { validate } from '../middleware/validation.js';
+import { validateBody } from '../middleware/validation.js';
 import { mySchema } from '../schemas/mySchemas.js';
 
-router.post('/endpoint', validate(mySchema), myController);
+router.post('/endpoint', validateBody(mySchema), myController);
 ```
 
 ## Schema Structure

--- a/backend/src/services/README.md
+++ b/backend/src/services/README.md
@@ -58,6 +58,18 @@ Services read configuration from `.env`. Key variables:
 
 Refer to `backend/.env.example` for the full list.
 
+### jobMetricsService
+
+Tracks per-background-job health: `lastRunAt`, `lastSuccessAt`, `lastError`, `runsTotal`, `failuresTotal`, and `durationMs`, keyed by job name. Jobs call `recordSuccess()`/`recordFailure()` after each run; metrics are read back via `getJobMetrics()`/`getAllMetrics()` for status endpoints and dashboards.
+
+**Consumers**: `defaultChecker.ts`, `scoreReconciliationService.ts`, `webhookRetryProcessor.ts`, `cron/scoreDecayJob.ts`, `cron/loanCheckCron.ts`.
+
+### rateLimitService
+
+Redis-backed fixed-window rate limiter using atomic `INCR`+`EXPIRE` via a Lua script, keyed by an arbitrary identifier (user ID, IP, etc.). `checkRateLimit()` increments and evaluates the window; `getRateLimitStatus()` reads without incrementing; `resetRateLimit()` clears a key. Fails open (allows the request) if Redis is unreachable, so an outage never blocks traffic outright.
+
+**Consumers**: `middleware/rateLimitMiddleware.ts` (per-route rate limiting), score update endpoints via the exported `SCORE_UPDATE_RATE_LIMIT` config.
+
 ### Testing
 
 Most services have corresponding test files in `services/__tests__/`. Tests use Jest and mock external dependencies (database, Redis, Stellar RPC). Run:

--- a/frontend/src/app/components/loan-wizard/WizardStepper.tsx
+++ b/frontend/src/app/components/loan-wizard/WizardStepper.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRef } from "react";
+import type { KeyboardEvent } from "react";
 import { Check } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -17,9 +19,40 @@ export interface WizardStep {
 interface WizardStepperProps {
   steps: WizardStep[];
   currentStep: number;
+  onStepSelect?: (stepId: number) => void;
 }
 
-export function WizardStepper({ steps, currentStep }: WizardStepperProps) {
+export function WizardStepper({ steps, currentStep, onStepSelect }: WizardStepperProps) {
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const isReachable = (step: WizardStep) => step.id <= currentStep;
+
+  const focusReachableStepAt = (index: number) => {
+    const step = steps[index];
+    if (!step || !isReachable(step)) return;
+    buttonRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      focusReachableStepAt(index + 1);
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      focusReachableStepAt(index - 1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusReachableStepAt(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      const lastReachableIndex = steps.reduce(
+        (lastIndex, step, i) => (isReachable(step) ? i : lastIndex),
+        index,
+      );
+      focusReachableStepAt(lastReachableIndex);
+    }
+  };
+
   return (
     <nav aria-label="Loan application progress" className="w-full">
       <ol className="flex items-center">
@@ -27,14 +60,27 @@ export function WizardStepper({ steps, currentStep }: WizardStepperProps) {
           const isCompleted = step.id < currentStep;
           const isCurrent = step.id === currentStep;
           const isLast = index === steps.length - 1;
+          const reachable = isReachable(step);
 
           return (
             <li key={step.id} className={cn("flex items-center", !isLast && "flex-1")}>
               {/* Step circle + label */}
               <div className="flex flex-col items-center gap-1.5 min-w-0">
-                <div
+                <button
+                  ref={(el) => {
+                    buttonRefs.current[index] = el;
+                  }}
+                  type="button"
+                  disabled={!reachable}
+                  tabIndex={isCurrent ? 0 : -1}
+                  aria-current={isCurrent ? "step" : undefined}
+                  aria-label={`Step ${step.id}: ${step.label}`}
+                  onClick={() => reachable && onStepSelect?.(step.id)}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
                   className={cn(
                     "flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 text-sm font-semibold transition-all",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
+                    !reachable && "cursor-not-allowed",
                     isCompleted && "border-indigo-600 bg-indigo-600 text-white",
                     isCurrent &&
                       "border-indigo-600 bg-white text-indigo-600 dark:bg-zinc-950 dark:text-indigo-400 shadow-sm",
@@ -42,10 +88,9 @@ export function WizardStepper({ steps, currentStep }: WizardStepperProps) {
                       !isCurrent &&
                       "border-zinc-300 bg-white text-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-500",
                   )}
-                  aria-current={isCurrent ? "step" : undefined}
                 >
                   {isCompleted ? <Check className="h-4 w-4" /> : <span>{step.id}</span>}
-                </div>
+                </button>
                 <div className="hidden sm:block text-center">
                   <p
                     className={cn(

--- a/frontend/src/app/components/loan-wizard/__tests__/WizardStepper.test.tsx
+++ b/frontend/src/app/components/loan-wizard/__tests__/WizardStepper.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WizardStepper, type WizardStep } from "../WizardStepper";
+
+const steps: WizardStep[] = [
+  { id: 1, label: "Amount", description: "Choose amount" },
+  { id: 2, label: "Collateral", description: "Select NFT" },
+  { id: 3, label: "Schedule", description: "Repayment plan" },
+  { id: 4, label: "Sign", description: "Final signature" },
+];
+
+function getStepButton(stepId: number) {
+  return screen.getByRole("button", { name: new RegExp(`Step ${stepId}:`) });
+}
+
+describe("WizardStepper keyboard navigation", () => {
+  it("marks the current step with aria-current", () => {
+    render(<WizardStepper steps={steps} currentStep={2} />);
+
+    expect(getStepButton(2)).toHaveAttribute("aria-current", "step");
+    expect(getStepButton(1)).not.toHaveAttribute("aria-current");
+    expect(getStepButton(3)).not.toHaveAttribute("aria-current");
+  });
+
+  it("allows moving focus between reachable steps with arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<WizardStepper steps={steps} currentStep={3} />);
+
+    getStepButton(3).focus();
+    expect(getStepButton(3)).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(getStepButton(2)).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(getStepButton(1)).toHaveFocus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(getStepButton(2)).toHaveFocus();
+  });
+
+  it("supports Home and End to jump to reachable boundary steps", async () => {
+    const user = userEvent.setup();
+    render(<WizardStepper steps={steps} currentStep={3} />);
+
+    getStepButton(2).focus();
+    await user.keyboard("{Home}");
+    expect(getStepButton(1)).toHaveFocus();
+
+    await user.keyboard("{End}");
+    expect(getStepButton(3)).toHaveFocus();
+  });
+
+  it("does not move focus past the last reachable step", async () => {
+    const user = userEvent.setup();
+    render(<WizardStepper steps={steps} currentStep={2} />);
+
+    getStepButton(2).focus();
+    await user.keyboard("{ArrowRight}");
+    expect(getStepButton(2)).toHaveFocus();
+  });
+
+  it("disables and removes future steps from the tab order", () => {
+    render(<WizardStepper steps={steps} currentStep={2} />);
+
+    const futureStep = getStepButton(3);
+    expect(futureStep).toBeDisabled();
+    expect(futureStep).toHaveAttribute("tabIndex", "-1");
+
+    const anotherFutureStep = getStepButton(4);
+    expect(anotherFutureStep).toBeDisabled();
+    expect(anotherFutureStep).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("keeps completed and current steps enabled and reachable", () => {
+    render(<WizardStepper steps={steps} currentStep={2} />);
+
+    expect(getStepButton(1)).not.toBeDisabled();
+    expect(getStepButton(2)).not.toBeDisabled();
+  });
+
+  it("invokes onStepSelect when a reachable step is activated via keyboard", async () => {
+    const user = userEvent.setup();
+    const onStepSelect = jest.fn();
+    render(<WizardStepper steps={steps} currentStep={3} onStepSelect={onStepSelect} />);
+
+    getStepButton(1).focus();
+    await user.keyboard("{Enter}");
+
+    expect(onStepSelect).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Audits `backend/src/middleware/README.md` against every file in `backend/src/middleware` and documents the full middleware chain order from `app.ts`, plus a reference table for all 13 middleware files.
- Expands `backend/src/services/README.md` with dedicated paragraph descriptions and consumer lists for `jobMetricsService` and `rateLimitService`.
- Adds keyboard navigation (arrow keys, Home/End, roving tabindex) to `WizardStepper.tsx` so steps are keyboard-reachable, marks the current step with `aria-current="step"`, and makes disabled/future steps non-focusable. Adds a test suite covering all of this.
- Adds a `beforeSend` hook to `backend/src/config/sentry.ts` that strips Authorization headers, cookies (session/JWT), and known PII field names (password, token, jwt, publicKey, walletAddress, etc.) from captured events before they reach Sentry, with test coverage.

Closes #1536
Closes #1537
Closes #1538
Closes #1539

## Test plan
- [x] `npx jest src/config/__tests__/sentry.test.ts` — 3/3 passing
- [x] `npx jest src/app/components/loan-wizard/__tests__/WizardStepper.test.tsx` — 7/7 passing
- [x] `npx tsc --noEmit` clean on frontend; backend has one pre-existing unrelated syntax error in `defaultChecker.ts` (not touched by this PR)
- [x] `prettier --check` clean on all changed files