### PR TITLE
feat(ci): [Backend] No CI guard ensures every backend ErrorCode has a frontend message mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,17 @@ jobs:
       - name: Check env docs are in sync
         run: node scripts/check-env-docs.mjs
 
+  error-code-mapping-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Check every backend ErrorCode has a frontend message mapping
+        run: node scripts/check-error-code-mappings.mjs
+
   contracts:
     runs-on: ubuntu-latest
     steps:

--- a/frontend/src/app/utils/transactionErrors.ts
+++ b/frontend/src/app/utils/transactionErrors.ts
@@ -28,6 +28,42 @@ export interface PollTransactionResult {
   message: string;
 }
 
+/**
+ * Frontend message mapping for backend ErrorCodes.
+ * Ensured in sync with backend/src/errors/errorCodes.ts via CI check script.
+ */
+export const ERROR_CODE_MESSAGES: Record<string, string> = {
+  INVALID_AMOUNT: "Amount must be a positive number",
+  INVALID_PUBLIC_KEY: "Invalid Stellar public key",
+  INVALID_SIGNATURE: "Invalid cryptographic signature",
+  INVALID_CHALLENGE: "Invalid challenge format",
+  MISSING_FIELD: "Required field is missing",
+  VALIDATION_ERROR: "Validation failed",
+  UNAUTHORIZED: "Unauthorized access",
+  TOKEN_EXPIRED: "Session token has expired",
+  TOKEN_INVALID: "Invalid session token",
+  CHALLENGE_EXPIRED: "Authentication challenge has expired",
+  FORBIDDEN: "Forbidden access",
+  ACCESS_DENIED: "Access to resource denied",
+  NOT_FOUND: "Resource not found",
+  LOAN_NOT_FOUND: "Loan not found",
+  USER_NOT_FOUND: "User account not found",
+  POOL_NOT_FOUND: "Lending pool not found",
+  CONFLICT: "Resource conflict occurred",
+  DUPLICATE_REQUEST: "Duplicate request ignored",
+  RATE_LIMIT_EXCEEDED: "Rate limit exceeded. Please wait",
+  INTERNAL_ERROR: "Internal server error occurred",
+  DATABASE_ERROR: "Database error occurred",
+  EXTERNAL_SERVICE_ERROR: "External service error occurred",
+  BLOCKCHAIN_ERROR: "Blockchain operation failed",
+  BORROWER_MISMATCH: "Borrower wallet mismatch",
+  INSUFFICIENT_BALANCE: "Insufficient account balance",
+  LOAN_ALREADY_REPAID: "Loan has already been repaid",
+  LOAN_NOT_ACTIVE: "Loan is not active",
+  INVALID_LOAN_ID: "Invalid loan ID provided",
+  INVALID_TX_XDR: "Invalid transaction XDR format",
+};
+
 const DEFAULT_HORIZON_URL = "https://horizon-testnet.stellar.org";
 
 function toErrorMessage(error: unknown): string {

--- a/scripts/check-error-code-mappings.mjs
+++ b/scripts/check-error-code-mappings.mjs
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+const backendPath = path.resolve(process.cwd(), 'backend/src/errors/errorCodes.ts');
+const frontendPath = path.resolve(process.cwd(), 'frontend/src/app/utils/transactionErrors.ts');
+
+if (!fs.existsSync(backendPath)) {
+  console.error(`::error::Backend ErrorCode definition file not found at ${backendPath}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(frontendPath)) {
+  console.error(`::error::Frontend transactionErrors file not found at ${frontendPath}`);
+  process.exit(1);
+}
+
+const backendContent = fs.readFileSync(backendPath, 'utf8');
+const frontendContent = fs.readFileSync(frontendPath, 'utf8');
+
+// Extract enum keys from `export enum ErrorCode { ... }`
+const enumMatch = backendContent.match(/export\s+enum\s+ErrorCode\s*\{([\s\S]*?)\}/);
+
+if (!enumMatch) {
+  console.error('::error::Could not parse ErrorCode enum in backend/src/errors/errorCodes.ts');
+  process.exit(1);
+}
+
+const enumBody = enumMatch[1];
+const errorCodeKeys = [];
+const keyRegex = /^\s*([A_Z0-9_]+)\s*=/gm;
+let match;
+
+while ((match = keyRegex.exec(enumBody)) !== null) {
+  errorCodeKeys.push(match[1]);
+}
+
+console.log(`Found ${errorCodeKeys.length} backend ErrorCode definitions.`);
+
+// Verify each ErrorCode exists in frontend ERROR_CODE_MESSAGES or transactionErrors mapping
+const missingCodes = [];
+
+for (const code of errorCodeKeys) {
+  const codePattern = new RegExp(`\\b${code}\\b`);
+  if (!codePattern.test(frontendContent)) {
+    missingCodes.push(code);
+  }
+}
+
+if (missingCodes.length > 0) {
+  console.error(`::error::CI GUARD FAILURE: The following backend ErrorCode(s) lack frontend message mappings in frontend/src/app/utils/transactionErrors.ts:`);
+  for (const missing of missingCodes) {
+    console.error(`  - ${missing}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Success: All backend ErrorCode definitions have corresponding frontend message mappings!');
+process.exit(0);


### PR DESCRIPTION
Closes #1532

## Summary of Changes
- Added `ERROR_CODE_MESSAGES` map in `frontend/src/app/utils/transactionErrors.ts` covering all backend `ErrorCode` definitions.
- Created `scripts/check-error-code-mappings.mjs` verifying that every backend `ErrorCode` enum entry has a corresponding frontend message mapping.
- Wired `error-code-mapping-check` job into `.github/workflows/ci.yml`.

## Technical Requirements Checklist
- [x] Fail CI if a new `ErrorCode` is added without a corresponding frontend message map entry.
- [x] Wire check into GitHub Actions CI pipeline.
