### PR TITLE
docs(contributing): [Docs] CONTRIBUTING.md does not mention the contracts fuzzing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,11 @@ cargo clippy
 cargo test
 ```
 
+### Smart Contracts Fuzzing (Soroban)
+For consensus-critical changes to smart contracts, fuzz testing is an expected part of the workflow.
+
+Refer to [`contracts/FUZZING_README.md`](contracts/FUZZING_README.md) for full setup instructions, invariant definitions, and running fuzz campaign scripts (`./fuzz_campaign.sh`).
+
 ## Style Guides
 
 - **TypeScript**: Use functional components and hooks. Prefer `interface` over `type`. Ensure strict typing.


### PR DESCRIPTION
Closes #1534

## Summary of Changes
- Added Smart Contracts Fuzzing section under Testing Requirements in `CONTRIBUTING.md`.
- Linked `contracts/FUZZING_README.md` for invariant testing setup and campaign instructions (`./fuzz_campaign.sh`).

## Technical Requirements Checklist
- [x] Add short contract fuzzing subsection to `CONTRIBUTING.md` linking to `contracts/FUZZING_README.md`.
