### PR TITLE
fix(docs,infra,test): date storage audit, pin docker tags, add e2e README

### DIFF
--- a/contracts/STORAGE_AUDIT.md
+++ b/contracts/STORAGE_AUDIT.md
@@ -1,11 +1,19 @@
 # Storage Audit
 
+> **Audit date:** 2026-03-25
+> **Pinned commit:** [`079dccf`](https://github.com/LabsCrypt/remitlend/commit/079dccf6b09f7a87ad61c790d923220d3da44317)
+>
+> This document may drift as storage keys are added or removed.
+> Re-validate whenever contract storage changes land and update the date and
+> commit reference above.
+
 ## Summary
 
 This audit reviewed all current Soroban storage usage across:
 
 - `contracts/lending_pool`
 - `contracts/loan_manager`
+- `contracts/multisig_governance`
 - `contracts/remittance_nft`
 
 The current protocol stores only long-lived state:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:16.9-alpine
     environment:
       POSTGRES_DB: remitlend
       POSTGRES_USER: postgres
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:alpine
+    image: redis:7.4-alpine
     restart: unless-stopped
 
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:16.9-alpine
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:alpine
+    image: redis:7.4-alpine
     restart: always
     ports:
       - "6380:6379"

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -99,6 +99,21 @@ This document lists every environment variable used by the RemitLend platform. E
 
 ---
 
+## Pinned Infrastructure Image Versions
+
+The `docker-compose.yml` and `docker-compose.staging.yml` files pin dependency
+images to specific minor versions to prevent silent environment drift.
+
+| Service  | Image                  | Used in                                               |
+| -------- | ---------------------- | ----------------------------------------------------- |
+| Postgres | `postgres:16.9-alpine` | `docker-compose.yml`, `docker-compose.staging.yml`    |
+| Redis    | `redis:7.4-alpine`     | `docker-compose.yml`, `docker-compose.staging.yml`    |
+
+When upgrading either dependency, update **both** compose files and this table
+in the same PR.
+
+---
+
 ## `.env.example` vs `ENVIRONMENT.md` Drift
 
 A CI job (`env-docs-check`) runs on every PR to ensure the keys listed in `.env.example` files are present in this document. The check performs a sorted diff and fails if any key is missing from either side.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,42 @@
+# End-to-End Test Suite
+
+This directory contains Playwright e2e specs for RemitLend. Each spec file owns
+a single user flow so that mock shapes stay consistent and coverage gaps are
+easy to spot.
+
+## Spec Responsibilities
+
+| Spec file                      | Unique responsibility                                                    |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `admin-governance.spec.ts`     | Admin views and votes on governance proposals                            |
+| `borrower-loan-flow.spec.ts`   | Full borrower loan-request lifecycle (wallet, score, apply, approve)     |
+| `borrower-repay-flow.spec.ts`  | Borrower repays an active loan and confirms balance update               |
+| `criticalFlows.spec.ts`        | Lending-pool deposit, remittance history, and settings/logout flows      |
+| `landing-page.spec.ts`         | Landing page load, wallet prompt, and basic navigation                   |
+| `lender-withdraw-flow.spec.ts` | Lender withdraws deposited liquidity from the pool                       |
+| `notifications-inbox.spec.ts`  | Notification badge, inbox drawer, and mark-as-read                       |
+| `recent-transactions.spec.ts`  | Recent transactions drawer with copied hashes                            |
+| `remittance-nft-viewer.spec.ts`| Viewing and inspecting minted remittance NFTs                            |
+| `send-remittance.spec.ts`      | Sending a remittance to a recipient address                              |
+
+## Adding a New Spec
+
+Before creating a new spec file, check the table above:
+
+- [ ] **No existing spec already covers the flow.** If one does, extend it
+      rather than creating a new file with overlapping route mocks.
+- [ ] **The new spec owns exactly one user flow.** Each file should test a
+      distinct area of the app so that failures pinpoint the broken feature.
+- [ ] **Update this table.** Add a row describing the new spec's unique
+      responsibility.
+
+## PR Checklist
+
+When opening a PR that adds or modifies e2e specs:
+
+- [ ] Verified that no other spec file already covers the same flow
+- [ ] Each spec file uses a self-contained set of route mocks (no cross-file
+      mock dependencies)
+- [ ] Updated the responsibility table in this README if a spec was added,
+      removed, or re-scoped
+- [ ] Tests pass locally with `npx playwright test --project=chromium`

--- a/frontend/e2e/criticalFlows.spec.ts
+++ b/frontend/e2e/criticalFlows.spec.ts
@@ -1,4 +1,13 @@
 // e2e coverage temporarily skipped: assertions rely on product wiring (wallet-connect state, /api/* mock paths, Zustand hydration) that has drifted from the current app. Restore file-by-file once the flows are re-aligned with the mocks.
+//
+// Scope after consolidation (see frontend/e2e/README.md):
+//   - Lending-pool deposit flow
+//   - Remittance history view
+//   - Settings update & logout
+//
+// Loan-request and repay flows were removed; they are covered by
+// borrower-loan-flow.spec.ts and borrower-repay-flow.spec.ts with a single
+// consistent set of route mocks.
 import { test, expect, type Page, type Route } from "@playwright/test";
 
 // Mock wallet address for all tests


### PR DESCRIPTION
## Summary

- **[Contracts]** Pin `contracts/STORAGE_AUDIT.md` to commit `079dccf` (2026-03-25) and add a staleness notice so readers know when the audit was last validated. Also adds the missing `multisig_governance` contract to the reviewed list.
- **[Infra]** Pin `postgres` to `16.9-alpine` and `redis` to `7.4-alpine` in both `docker-compose.yml` and `docker-compose.staging.yml` to prevent silent environment drift from untagged image updates. Document the pinned versions in `docs/ENVIRONMENT.md`.
- **[Testing]** Clarify the remaining scope of `criticalFlows.spec.ts` after the loan-request and repay flows were consolidated into their dedicated specs. Add `frontend/e2e/README.md` with a spec responsibility table and a PR checklist that reminds authors to check for overlapping coverage before adding a new spec.

## Files Changed

| File | Change |
|---|---|
| `contracts/STORAGE_AUDIT.md` | Added audit date, pinned commit reference, staleness notice, and missing contract |
| `docker-compose.yml` | Pinned `postgres:16.9-alpine` and `redis:7.4-alpine` |
| `docker-compose.staging.yml` | Pinned `postgres:16.9-alpine` and `redis:7.4-alpine` |
| `docs/ENVIRONMENT.md` | Added "Pinned Infrastructure Image Versions" section |
| `frontend/e2e/criticalFlows.spec.ts` | Added scope header comment documenting consolidation |
| `frontend/e2e/README.md` | New — spec responsibility table and PR overlap checklist |

## Test Plan

- [x] No runtime code changed — documentation and configuration only
- [x] `docker-compose.yml` and `docker-compose.staging.yml` remain valid YAML (services parse correctly)
- [x] `docs/ENVIRONMENT.md` new section does not conflict with the `env-docs-check` CI job (no `.env.example` keys added or removed)
- [x] `criticalFlows.spec.ts` compiles unchanged (only comment block added)
- [x] `frontend/e2e/README.md` responsibility table matches the current spec file list

Closes #1513
Closes #1514
Closes #1515