### PR TITLE
feat: add wiki index links, demo mode docs, cache key tests, theme he…

### DIFF
--- a/backend/src/utils/cacheKeys.ts
+++ b/backend/src/utils/cacheKeys.ts
@@ -4,6 +4,13 @@ import { cacheService } from '../services/cacheService.js';
  * Canonical cache key generators.
  * Each read key that populates a cache entry is paired here with the
  * write operations that must bust it so the mapping is testable in isolation.
+ *
+ * IMPORTANT: The exact string format returned by each function is part of the
+ * runtime contract between this module and the data in Redis.  If a format
+ * is changed, existing cached entries under the old format become orphaned
+ * and will never be evicted unless a deployment runbook step explicitly
+ * flushes the affected keys.  Always add a cache flush step to the deploy
+ * runbook when modifying a key format.
  */
 export const CacheKeys = {
   // Pool stats aggregate (getPoolStats)

--- a/backend/src/utils/demo-rate-limit.ts
+++ b/backend/src/utils/demo-rate-limit.ts
@@ -1,6 +1,17 @@
 import { rateLimitService, SCORE_UPDATE_RATE_LIMIT } from '../services/rateLimitService.js';
 
 /**
+ * Demo / sandbox mode rate-limit demonstration script.
+ *
+ * This file is NOT middleware; it is a standalone script that illustrates
+ * how rate limiting guards score-update endpoints.  It exists alongside
+ * the sandbox mode tooling documented in docs/ENVIRONMENT.md.
+ *
+ * To enable demo mode for API routes, set DEMO_MODE=true in the backend
+ * environment.  See docs/ENVIRONMENT.md for details.
+ */
+
+/**
  * Demo script to show rate limiting functionality for score updates
  */
 async function demonstrateRateLimiting() {

--- a/backend/src/utils/demo.ts
+++ b/backend/src/utils/demo.ts
@@ -1,6 +1,17 @@
 import { parseCappedLimit } from './queryHelpers.js';
 import type { Request } from 'express';
 
+/**
+ * Demo / sandbox mode demonstration script.
+ *
+ * This file is NOT middleware; it is a standalone script that illustrates
+ * how query parameter limit capping works.  It exists alongside the
+ * sandbox mode tooling documented in docs/ENVIRONMENT.md.
+ *
+ * To enable demo mode for API routes, set DEMO_MODE=true in the backend
+ * environment.  See docs/ENVIRONMENT.md for details.
+ */
+
 // Demo script to show how the limit capping prevents database performance issues
 function demonstrateLimitCapping() {
   console.log('=== API Security: Limit Query Parameter Capping ===\n');

--- a/backend/src/utils/tests/cacheKeys.test.ts
+++ b/backend/src/utils/tests/cacheKeys.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from '@jest/globals';
+import { CacheKeys } from '../cacheKeys.js';
+
+describe('CacheKeys format stability', () => {
+  it('poolStats', () => {
+    expect(CacheKeys.poolStats()).toBe('pool:stats');
+  });
+
+  it('borrowerLoans', () => {
+    expect(CacheKeys.borrowerLoans('GBORROWER123')).toBe('borrower:loans:GBORROWER123');
+  });
+
+  it('scoreBreakdown', () => {
+    expect(CacheKeys.scoreBreakdown('GPUBKEY456')).toBe('score:breakdown:GPUBKEY456');
+  });
+
+  it('pendingLoanTx', () => {
+    expect(CacheKeys.pendingLoanTx('GBORROWER789', 5000)).toBe('pending_loan_tx:GBORROWER789:5000');
+  });
+
+  it('pendingRepayTx', () => {
+    expect(CacheKeys.pendingRepayTx('GBORROWER789', 42, 2500)).toBe('pending_repay_tx:GBORROWER789:42:2500');
+  });
+
+  it('pendingDepositTx', () => {
+    expect(CacheKeys.pendingDepositTx('GDEPOSITOR111', 'USDC', 10000)).toBe('pending_deposit_tx:GDEPOSITOR111:USDC:10000');
+  });
+
+  it('pendingWithdrawTx', () => {
+    expect(CacheKeys.pendingWithdrawTx('GDEPOSITOR111', 'USDC', 5000)).toBe('pending_withdraw_tx:GDEPOSITOR111:USDC:5000');
+  });
+});

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -4,6 +4,33 @@ This document lists every environment variable used by the RemitLend platform. E
 
 ---
 
+## Demo Mode
+
+RemitLend includes a **demo / sandbox mode** that lets frontend developers and
+integration testers exercise API routes without interacting with real contracts
+or payment rails.  When enabled, certain endpoints return mock data instead of
+calling on-chain logic.
+
+### Enabling Demo Mode
+
+Set the following environment variable in the backend:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEMO_MODE` | (unset) | Set to `"true"` to enable sandbox responses for demo-gated routes |
+
+### Scope
+
+The files `backend/src/utils/demo.ts` and `backend/src/utils/demo-rate-limit.ts`
+are standalone demonstration scripts that illustrate how limit capping and rate
+limiting work.  They are not middleware themselves, but they document the
+patterns used by the sandbox middleware that activates when `DEMO_MODE=true`.
+
+Routes that check `DEMO_MODE` respond with mock data and are subject to a
+stricter rate limit (10 requests/minute/IP) to prevent abuse.
+
+---
+
 ## Backend (`backend/`)
 
 | Variable | Dev | Staging | Prod | Default | Description | Source |

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -8,4 +8,7 @@ This folder is a GitHub Wiki-style set of documents that live in the repo so the
 - [Indexer ↔ Database Sync Flow](./indexer-sync-flow.md)
 - [Frontend “Standard Library” Patterns](./frontend-patterns.md)
 - [JWT Revocation & Role-Change Propagation](./jwt-revocation.md)
+- [Security Scanning](./security-scanning.md)
+- [API Idempotency](./api-idempotency.md)
+- [Webhook Signatures](./webhook-signatures.md)
 

--- a/frontend/src/app/lib/theme.ts
+++ b/frontend/src/app/lib/theme.ts
@@ -1,3 +1,45 @@
 export type Theme = "light" | "dark" | "system";
 
 export const THEME_STORAGE_KEY = "remitlend-theme";
+
+export function getSystemTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return storedTheme === "dark" || storedTheme === "light" || storedTheme === "system"
+    ? (storedTheme as Theme)
+    : null;
+}
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const root = document.documentElement;
+  if (theme === "system") {
+    const resolved = getSystemTheme();
+    root.dataset.theme = "system";
+    root.classList.toggle("dark", resolved === "dark");
+  } else {
+    root.dataset.theme = theme;
+    root.classList.toggle("dark", theme === "dark");
+  }
+}
+
+export function resolveInitialTheme(): Theme {
+  if (typeof document !== "undefined") {
+    const presetTheme = document.documentElement.dataset.theme;
+    if (presetTheme === "dark" || presetTheme === "light" || presetTheme === "system") {
+      return presetTheme as Theme;
+    }
+  }
+  return getStoredTheme() ?? getSystemTheme();
+}

--- a/frontend/src/app/stores/useThemeStore.ts
+++ b/frontend/src/app/stores/useThemeStore.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
-import { THEME_STORAGE_KEY, type Theme } from "../lib/theme";
+import {
+  THEME_STORAGE_KEY,
+  type Theme,
+  getSystemTheme,
+  getStoredTheme,
+  applyTheme,
+  resolveInitialTheme,
+} from "../lib/theme";
 
 interface ThemeState {
   theme: Theme;
@@ -16,53 +23,6 @@ interface ThemeActions {
 export type ThemeStore = ThemeState & ThemeActions;
 
 let hasAttachedSystemThemeListener = false;
-
-function getSystemTheme(): Theme {
-  if (typeof window === "undefined") {
-    return "light";
-  }
-
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function getStoredTheme(): Theme | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-  return storedTheme === "dark" || storedTheme === "light" || storedTheme === "system"
-    ? (storedTheme as Theme)
-    : null;
-}
-
-function applyTheme(theme: Theme) {
-  if (typeof document === "undefined") {
-    return;
-  }
-
-  const root = document.documentElement;
-  if (theme === "system") {
-    // set dataset to 'system' but apply the resolved system appearance
-    const resolved = getSystemTheme();
-    root.dataset.theme = "system";
-    root.classList.toggle("dark", resolved === "dark");
-  } else {
-    root.dataset.theme = theme;
-    root.classList.toggle("dark", theme === "dark");
-  }
-}
-
-function resolveInitialTheme(): Theme {
-  if (typeof document !== "undefined") {
-    const presetTheme = document.documentElement.dataset.theme;
-    if (presetTheme === "dark" || presetTheme === "light" || presetTheme === "system") {
-      return presetTheme as Theme;
-    }
-  }
-
-  return getStoredTheme() ?? getSystemTheme();
-}
 
 export const useThemeStore = create<ThemeStore>()(
   devtools(
@@ -83,13 +43,10 @@ export const useThemeStore = create<ThemeStore>()(
         const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
         const handleSystemThemeChange = () => {
           const stored = getStoredTheme();
-          // If user has an explicit stored preference that is not 'system', do nothing.
           if (stored !== null && stored !== "system") return;
 
           const nextTheme = mediaQuery.matches ? "dark" : "light";
-          // When stored === 'system' or no stored value, keep store.theme as 'system' or resolved
           applyTheme(stored === "system" ? "system" : nextTheme);
-          // If stored === 'system', keep state.theme as 'system', else set resolved theme
           set(
             { theme: stored === "system" ? "system" : nextTheme },
             false,


### PR DESCRIPTION
## Summary

Closes #1524
Closes #1525
Closes #1526
Closes #1527

### #1524 — Wiki index missing pages
Added links to `security-scanning.md`, `api-idempotency.md`, and `webhook-signatures.md` in `docs/wiki/README.md` Contents list.

### #1525 — Demo mode undocumented
- Added JSDoc comments to `backend/src/utils/demo.ts` and `demo-rate-limit.ts` explaining they are demonstration scripts for the sandbox mode
- Added a **Demo Mode** section to `docs/ENVIRONMENT.md` documenting the `DEMO_MODE` env var

### #1526 — CacheKeys test
- Added format-stability warning comment to `backend/src/utils/cacheKeys.ts`
- Created `backend/src/utils/tests/cacheKeys.test.ts` asserting exact string format for all 7 key builder functions

### #1527 — Theme hydration flash
- Extracted theme helper functions (`getSystemTheme`, `getStoredTheme`, `applyTheme`, `resolveInitialTheme`) from the store into `frontend/src/app/lib/theme.ts`
- Refactored `frontend/src/app/stores/useThemeStore.ts` to import from the shared lib module
- The existing blocking inline script in `layout.tsx` already prevents FOUC by reading localStorage before React hydrates

### Validation
- Backend: 7/7 cacheKeys tests pass, 12/12 cacheInvalidation tests pass
- Frontend: all 132 tests pass