### PR TITLE
fix(backend): detect ledger gaps via a contiguous-cursor checkpoint table

### DIFF
--- a/backend/migrations/1801000000000_create-pause-state-table.js
+++ b/backend/migrations/1801000000000_create-pause-state-table.js
@@ -9,9 +9,17 @@
  * Related to Issue #1381: Cross-Layer Emergency Pause Propagation
  */
 
-exports.up = async (db) => {
-  await db.none(
-    `
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const up = (pgm) => {
+  pgm.sql(`
     CREATE TABLE IF NOT EXISTS pause_state (
       -- Single row table, ID is always 1
       id BIGINT PRIMARY KEY,
@@ -31,19 +39,20 @@ exports.up = async (db) => {
       -- Timestamp of last update
       updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
     )
-    `,
-  );
+  `);
 
   // Ensure exactly one row exists
-  await db.none(
-    `
+  pgm.sql(`
     INSERT INTO pause_state (id, is_paused, paused_at, reason, contracts, updated_at)
     VALUES (1, false, NULL, NULL, '{}', NOW())
     ON CONFLICT (id) DO NOTHING
-    `,
-  );
+  `);
 };
 
-exports.down = async (db) => {
-  await db.none('DROP TABLE IF EXISTS pause_state');
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const down = (pgm) => {
+  pgm.sql('DROP TABLE IF EXISTS pause_state');
 };

--- a/backend/migrations/1802000000000_create-ledger-checkpoints.js
+++ b/backend/migrations/1802000000000_create-ledger-checkpoints.js
@@ -1,0 +1,66 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * ledger_checkpoints — per-contract record of ledger ranges the indexer has
+ * requested from the Soroban RPC, and whether that range's contiguity with
+ * the previously-verified range has been confirmed (issue #1376, Phase 2).
+ *
+ * `status`:
+ *   - 'verified': range_start immediately follows the prior verified
+ *     range's range_end (no gap detected).
+ *   - 'suspect': range_start does NOT immediately follow the prior verified
+ *     range's range_end — a ledger range between them was never scanned by
+ *     this indexer (see eventIndexer.ts's recordCheckpoint / getSuspectRanges,
+ *     and ledgerCheckpoints.ts's hasUnresolvedLedgerGaps).
+ *
+ * Scoped to gap detection only — this migration does not implement reorg
+ * detection (`range_digest` comparison) or backfill, which the full issue
+ * spec also calls for; see the PR description for why those are out of
+ * scope for this change.
+ *
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const up = (pgm) => {
+  pgm.createTable('ledger_checkpoints', {
+    id: 'id',
+    contract: { type: 'text', notNull: true },
+    range_start: { type: 'bigint', notNull: true },
+    range_end: { type: 'bigint', notNull: true },
+    status: { type: 'text', notNull: true, default: 'verified' },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('CURRENT_TIMESTAMP'),
+    },
+  });
+
+  pgm.addConstraint('ledger_checkpoints', 'ledger_checkpoints_status_check', {
+    check: "status IN ('verified', 'suspect')",
+  });
+
+  pgm.addConstraint('ledger_checkpoints', 'ledger_checkpoints_range_check', {
+    check: 'range_end >= range_start',
+  });
+
+  // Every lookup is "give me the most recent range for this contract" or
+  // "give me the suspect ranges for this contract" — index both.
+  pgm.createIndex('ledger_checkpoints', ['contract', 'range_end'], {
+    name: 'idx_ledger_checkpoints_contract_range_end',
+  });
+  pgm.createIndex('ledger_checkpoints', ['contract', 'status'], {
+    name: 'idx_ledger_checkpoints_contract_status',
+    where: "status = 'suspect'",
+  });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {void}
+ */
+export const down = (pgm) => {
+  pgm.dropTable('ledger_checkpoints');
+};

--- a/backend/src/__tests__/defaultChecker.test.ts
+++ b/backend/src/__tests__/defaultChecker.test.ts
@@ -31,6 +31,9 @@ describe('DefaultChecker', () => {
 
     (checker as unknown as Record<string, unknown>).acquireLock = async () => true;
     (checker as unknown as Record<string, unknown>).releaseLock = async () => undefined;
+    // Stubbed so this test doesn't hit the real (unmocked) db/connection.js —
+    // see hasSuspectLedgerRanges in defaultChecker.ts, added for issue #1376.
+    (checker as unknown as Record<string, unknown>).hasSuspectLedgerRanges = async () => false;
     (checker as unknown as Record<string, unknown>).assertConfigured = () => ({
       signer: {},
       server: {

--- a/backend/src/services/__tests__/defaultChecker.test.ts
+++ b/backend/src/services/__tests__/defaultChecker.test.ts
@@ -82,6 +82,44 @@ describe('DefaultChecker', () => {
     );
   });
 
+  describe('suspect ledger range gate (#1376)', () => {
+    it('skips the run without submitting when the indexer has an unresolved ledger gap', async () => {
+      mockSetNotExists.mockResolvedValue(true);
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes('has_suspect')) {
+          return { rows: [{ has_suspect: true }], rowCount: 1 };
+        }
+        return overdueStatsRow();
+      });
+
+      const checker = new DefaultChecker();
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result).not.toBeNull();
+      expect(result!.skipped).toBe(true);
+      expect(result!.skippedReason).toBe('unresolved_ledger_gap');
+      expect(result!.loansChecked).toBe(0);
+      expect(fakeServer.getLatestLedger).not.toHaveBeenCalled();
+      expect(fakeServer.prepareTransaction).not.toHaveBeenCalled();
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockRecordSuccess).toHaveBeenCalledWith('defaultChecker', expect.any(Number));
+    });
+
+    it('proceeds normally when there is no unresolved ledger gap', async () => {
+      mockSetNotExists.mockResolvedValue(true);
+      fakeServer.prepareTransaction.mockImplementation(async (tx: unknown) => tx);
+      fakeServer.sendTransaction.mockResolvedValue({ hash: 'abc', status: 'PENDING' });
+      fakeServer.pollTransaction.mockResolvedValue({ status: 'SUCCESS' });
+      // mockQuery already resolves has_suspect-less overdueStatsRow() by default.
+
+      const checker = new DefaultChecker();
+      const result = await checker.checkOverdueLoans([1, 2]);
+
+      expect(result!.skipped).toBeUndefined();
+      expect(fakeServer.getLatestLedger).toHaveBeenCalled();
+    });
+  });
+
   describe('acquireLock', () => {
     it('returns null without submitting when the lock is not acquired', async () => {
       mockSetNotExists.mockResolvedValue(false);

--- a/backend/src/services/__tests__/eventIndexerCheckpoints.test.ts
+++ b/backend/src/services/__tests__/eventIndexerCheckpoints.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the contiguous-cursor invariant / gap detection added for
+ * issue #1376: EventIndexer.recordCheckpoint (called from pollOnce) and
+ * EventIndexer.getSuspectRanges.
+ *
+ * Mocking pattern mirrors eventIndexer.test.ts's ESM module mocks — this
+ * suite needs `node --experimental-vm-modules` (the project's `npm test`
+ * script already passes it; a bare `npx jest` invocation will not).
+ */
+import { jest, describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
+
+let mockQuery: jest.Mock<(...args: unknown[]) => Promise<{ rows: unknown[]; rowCount: number }>>;
+let EventIndexer: new (config: { rpcUrl: string; contractIds?: string[] }) => {
+  getSuspectRanges: () => Promise<Array<{ rangeStart: number; rangeEnd: number }>>;
+  pollOnce: () => Promise<void>;
+  running: boolean;
+  rpc: { getEvents: unknown; getLatestLedger: unknown };
+};
+let hasUnresolvedLedgerGaps: (contract: string) => Promise<boolean>;
+
+beforeAll(async () => {
+  mockQuery = jest
+    .fn<(...args: unknown[]) => Promise<{ rows: unknown[]; rowCount: number }>>()
+    .mockResolvedValue({ rows: [], rowCount: 0 } as never);
+
+  jest.unstable_mockModule('../../db/connection.js', () => ({
+    query: mockQuery,
+    getClient: jest.fn(),
+    withTransaction: jest.fn(),
+    TRANSIENT_ERROR_CODES: new Set(['08006', '57P01', '40001']),
+  }));
+
+  jest.unstable_mockModule('../scoresService.js', () => ({
+    updateUserScoresBulk: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  }));
+
+  jest.unstable_mockModule('../sorobanService.js', () => ({
+    sorobanService: {
+      getScoreConfig: jest
+        .fn<() => { repaymentDelta: number; defaultPenalty: number }>()
+        .mockReturnValue({ repaymentDelta: 10, defaultPenalty: 20 }),
+    },
+  }));
+
+  jest.unstable_mockModule('../webhookService.js', () => ({
+    webhookService: { dispatch: jest.fn<() => Promise<void>>().mockResolvedValue(undefined) },
+    SUPPORTED_WEBHOOK_EVENT_TYPES: [],
+  }));
+
+  jest.unstable_mockModule('../eventStreamService.js', () => ({
+    eventStreamService: { broadcast: jest.fn() },
+  }));
+
+  jest.unstable_mockModule('../notificationService.js', () => ({
+    notificationService: {
+      createNotification: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    },
+  }));
+
+  jest.unstable_mockModule('../../utils/logger.js', () => ({
+    default: {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      withContext: jest.fn().mockReturnValue({
+        warn: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+      }),
+    },
+  }));
+
+  jest.unstable_mockModule('../../utils/requestContext.js', () => ({
+    createRequestId: jest.fn().mockReturnValue('test-req-id'),
+    runWithRequestContext: jest.fn((_id: string, fn: () => Promise<unknown>) => fn()),
+  }));
+
+  jest.unstable_mockModule('@stellar/stellar-sdk', () => ({
+    rpc: {
+      Server: jest.fn<(...args: unknown[]) => unknown>().mockImplementation(() => ({
+        getEvents: jest
+          .fn<() => Promise<{ events: unknown[] }>>()
+          .mockResolvedValue({ events: [] } as never),
+        getLatestLedger: jest
+          .fn<() => Promise<{ sequence: number }>>()
+          .mockResolvedValue({ sequence: 0 } as never),
+      })),
+    },
+    scValToNative: jest.fn(),
+    xdr: { ScVal: {} as never },
+  }));
+
+  jest.unstable_mockModule('../../errors/AppError.js', () => ({
+    AppError: { badRequest: (msg: string) => new Error(msg) },
+  }));
+
+  const mod = await import('../eventIndexer.js');
+  EventIndexer = (mod as unknown as { EventIndexer: typeof EventIndexer }).EventIndexer;
+  hasUnresolvedLedgerGaps = (
+    mod as unknown as { hasUnresolvedLedgerGaps: typeof hasUnresolvedLedgerGaps }
+  ).hasUnresolvedLedgerGaps;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function makeIndexer() {
+  return new EventIndexer({
+    rpcUrl: 'http://localhost:8000',
+    contractIds: ['CONTRACT001'],
+  });
+}
+
+describe('EventIndexer gap detection (contiguous-cursor invariant, #1376)', () => {
+  it('records a verified checkpoint on the very first poll (nothing prior to compare against)', async () => {
+    const inserted: Array<{ sql: string; params: unknown[] }> = [];
+
+    mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('SELECT last_ledger')) return { rows: [{ last_ledger: 0 }], rowCount: 1 };
+      if (sql.includes('FROM ledger_checkpoints')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('INSERT INTO ledger_checkpoints')) {
+        inserted.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('UPDATE indexer_state') || sql.includes('INSERT INTO indexer_state')) {
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const indexer = makeIndexer();
+    indexer.running = true;
+    indexer.rpc = {
+      getLatestLedger: async () => ({ sequence: 10 }),
+      getEvents: async () => ({ events: [] }),
+    };
+
+    await indexer.pollOnce();
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.sql).toContain("'verified'");
+    expect(inserted[0]?.params).toEqual(['CONTRACT001', 1, 10]);
+  });
+
+  it('records a contiguous verified checkpoint with no gap when the new range immediately follows the previous one', async () => {
+    const inserted: Array<{ sql: string; params: unknown[] }> = [];
+
+    mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('SELECT last_ledger')) return { rows: [{ last_ledger: 10 }], rowCount: 1 };
+      if (sql.includes('FROM ledger_checkpoints')) {
+        return { rows: [{ range_end: 10 }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO ledger_checkpoints')) {
+        inserted.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const indexer = makeIndexer();
+    indexer.running = true;
+    indexer.rpc = {
+      getLatestLedger: async () => ({ sequence: 20 }),
+      getEvents: async () => ({ events: [] }),
+    };
+
+    await indexer.pollOnce();
+
+    // Contiguous — exactly one insert (the new verified range), no suspect gap row.
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.sql).toContain("'verified'");
+    expect(inserted[0]?.params).toEqual(['CONTRACT001', 11, 20]);
+  });
+
+  it('flags a suspect gap when the new range does not immediately follow the previous checkpoint', async () => {
+    const inserted: Array<{ sql: string; params: unknown[] }> = [];
+
+    mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      // lastIndexedLedger is stale/clamped ahead — this is the exact
+      // scenario from the issue's walkthrough: indexer_state says we're
+      // caught up to 1000, but the last verified checkpoint only covers
+      // up to ledger 999... no — model it as: indexer_state (last_ledger)
+      // has jumped ahead to 1039 (simulating a clamp to RPC retention
+      // floor) while the checkpoint history only confirms up to 1000.
+      if (sql.includes('SELECT last_ledger')) return { rows: [{ last_ledger: 1039 }], rowCount: 1 };
+      if (sql.includes('FROM ledger_checkpoints')) {
+        return { rows: [{ range_end: 1000 }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO ledger_checkpoints')) {
+        inserted.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const indexer = makeIndexer();
+    indexer.running = true;
+    indexer.rpc = {
+      getLatestLedger: async () => ({ sequence: 1060 }),
+      getEvents: async () => ({ events: [] }),
+    };
+
+    await indexer.pollOnce();
+
+    // Two inserts: the suspect gap [1001, 1039], then the verified new range.
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0]?.sql).toContain("'suspect'");
+    expect(inserted[0]?.params).toEqual(['CONTRACT001', 1001, 1039]);
+    expect(inserted[1]?.sql).toContain("'verified'");
+    expect(inserted[1]?.params).toEqual(['CONTRACT001', 1040, 1060]);
+  });
+
+  it('getSuspectRanges returns only suspect ranges for this contract, oldest first', async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("status = 'suspect'")) {
+        return {
+          rows: [
+            { range_start: 1001, range_end: 1039 },
+            { range_start: 2001, range_end: 2010 },
+          ],
+          rowCount: 2,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const indexer = makeIndexer();
+    const ranges = await indexer.getSuspectRanges();
+
+    expect(ranges).toEqual([
+      { rangeStart: 1001, rangeEnd: 1039 },
+      { rangeStart: 2001, rangeEnd: 2010 },
+    ]);
+  });
+});
+
+describe('hasUnresolvedLedgerGaps (consumer-side gate, #1376)', () => {
+  it('returns true when the contract has a suspect ledger range', async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('has_suspect')) {
+        return { rows: [{ has_suspect: true }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(hasUnresolvedLedgerGaps('CONTRACT001')).resolves.toBe(true);
+  });
+
+  it('returns false when no suspect ranges exist for the contract', async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('has_suspect')) {
+        return { rows: [{ has_suspect: false }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(hasUnresolvedLedgerGaps('CONTRACT001')).resolves.toBe(false);
+  });
+
+  it('fails open (returns false) when the checkpoint query throws', async () => {
+    mockQuery.mockImplementation(async () => {
+      throw new Error('connection refused');
+    });
+
+    await expect(hasUnresolvedLedgerGaps('CONTRACT001')).resolves.toBe(false);
+  });
+});

--- a/backend/src/services/defaultChecker.ts
+++ b/backend/src/services/defaultChecker.ts
@@ -13,6 +13,7 @@ import { createSorobanRpcServer, getStellarNetworkPassphrase } from '../config/s
 
 import { cacheService } from './cacheService.js';
 import { jobMetricsService } from './jobMetricsService.js';
+import { hasUnresolvedLedgerGaps } from './ledgerCheckpoints.js';
 
 /**
  * Mirrors `LoanManager::DEFAULT_TERM_LEDGERS` in `contracts/loan_manager/src/lib.rs`.
@@ -42,6 +43,15 @@ export interface DefaultCheckRunResult {
   oldestDueLedger?: number;
   ledgersPastOldestDue?: number;
   batches: DefaultCheckBatchResult[];
+  /**
+   * True when this run was deliberately skipped instead of evaluating loans
+   * — currently only set when the indexer has an unresolved ('suspect')
+   * ledger gap for the loan manager contract (issue #1376). Conclusions
+   * drawn from `contract_events` are unreliable until the gap is
+   * reconciled, so no defaults are submitted for this run.
+   */
+  skipped?: boolean;
+  skippedReason?: string;
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -138,6 +148,20 @@ export class DefaultChecker {
     const passphrase = getStellarNetworkPassphrase();
 
     return { signer, server, passphrase };
+  }
+
+  /**
+   * Whether the indexer has an unresolved ('suspect') ledger gap for the
+   * loan manager contract. `fetchOverdueLoanIds`/`fetchOverdueStats` derive
+   * loan state entirely from indexed `contract_events`, so a gap means a
+   * `LoanApproved`, `LoanRepaid`, or `LoanDefaulted` event could be missing
+   * — submitting `check_defaults` against that view risks a false default
+   * (issue #1376). Extracted as its own method so tests can stub it out
+   * without needing a live database.
+   */
+  private async hasSuspectLedgerRanges(): Promise<boolean> {
+    if (!this.contractId) return false;
+    return hasUnresolvedLedgerGaps(this.contractId);
   }
 
   /**
@@ -443,6 +467,29 @@ export class DefaultChecker {
     try {
       const runId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
       const { signer, server, passphrase } = this.assertConfigured();
+
+      if (await this.hasSuspectLedgerRanges()) {
+        logger.withContext().warn('default_check.run.skipped_suspect_ledger_range', {
+          runId,
+          contractId: this.contractId,
+        });
+
+        const durationMs = Date.now() - startTime;
+        jobMetricsService.recordSuccess(jobName, durationMs);
+
+        return {
+          runId,
+          currentLedger: 0,
+          termLedgers: this.termLedgers,
+          overdueCount: 0,
+          loansChecked: 0,
+          successfulSubmissions: 0,
+          failedSubmissions: 0,
+          batches: [],
+          skipped: true,
+          skippedReason: 'unresolved_ledger_gap',
+        };
+      }
 
       const latest = await server.getLatestLedger();
       const currentLedger = latest.sequence;

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -285,8 +285,83 @@ export class EventIndexer {
     const toLedger = Math.min(fromLedger + this.batchSize - 1, latestLedger);
 
     const result = await this.processChunk(fromLedger, toLedger);
+    await this.recordCheckpoint(fromLedger, result.lastProcessedLedger);
     await this.updateLastIndexedLedger(result.lastProcessedLedger);
     recordIndexerLedgers(result.lastProcessedLedger, latestLedger);
+  }
+
+  /**
+   * Contiguous-cursor invariant (issue #1376): records the ledger range this
+   * poll iteration just requested, and flags a gap when it doesn't
+   * immediately follow the previously-recorded range for this contract.
+   *
+   * This does NOT prove every ledger in `rangeStart..rangeEnd` was scanned —
+   * only that `processChunk` was invoked for that exact range and returned
+   * without error. What it catches is the specific failure mode in the
+   * issue: `fromLedger` being derived from a value that skips ahead of what
+   * was actually verified (a stale/clamped starting point), which the old
+   * code had no way to detect since it only ever looked at the *current*
+   * chunk, never compared it against the *previous* one.
+   *
+   * Reorg detection (re-reading a suspect/verified range and comparing a
+   * content digest) is intentionally out of scope here — see this change's
+   * PR description.
+   */
+  private async recordCheckpoint(rangeStart: number, rangeEnd: number): Promise<void> {
+    const contract = this.getContractId();
+
+    const previous = await query(
+      `SELECT range_end
+       FROM ledger_checkpoints
+       WHERE contract = $1
+       ORDER BY range_end DESC
+       LIMIT 1`,
+      [contract],
+    );
+
+    const previousRangeEnd = previous.rows.length ? Number(previous.rows[0]?.range_end ?? 0) : null;
+
+    if (previousRangeEnd !== null && rangeStart > previousRangeEnd + 1) {
+      const gapStart = previousRangeEnd + 1;
+      const gapEnd = rangeStart - 1;
+      logger.withContext().warn('Indexer gap detected: ledger range was never scanned', {
+        contract,
+        gapStart,
+        gapEnd,
+      });
+      await query(
+        `INSERT INTO ledger_checkpoints (contract, range_start, range_end, status)
+         VALUES ($1, $2, $3, 'suspect')`,
+        [contract, gapStart, gapEnd],
+      );
+    }
+
+    await query(
+      `INSERT INTO ledger_checkpoints (contract, range_start, range_end, status)
+       VALUES ($1, $2, $3, 'verified')`,
+      [contract, rangeStart, rangeEnd],
+    );
+  }
+
+  /**
+   * Suspect (potentially-skipped) ledger ranges recorded for this contract,
+   * oldest first. Exposed so a consumer (an ops endpoint, or eventually
+   * defaultChecker.ts) can refuse to trust conclusions drawn from events in
+   * these ranges until they're backfilled and reconciled.
+   */
+  async getSuspectRanges(): Promise<Array<{ rangeStart: number; rangeEnd: number }>> {
+    const contract = this.getContractId();
+    const result = await query(
+      `SELECT range_start, range_end
+       FROM ledger_checkpoints
+       WHERE contract = $1 AND status = 'suspect'
+       ORDER BY range_start ASC`,
+      [contract],
+    );
+    return result.rows.map((row) => ({
+      rangeStart: Number(row.range_start),
+      rangeEnd: Number(row.range_end),
+    }));
   }
 
   private async getLatestLedgerSequence(): Promise<number> {
@@ -1186,3 +1261,11 @@ export class EventIndexer {
     }
   }
 }
+
+// Re-exported for discoverability alongside `recordCheckpoint` /
+// `getSuspectRanges` above; the implementation lives in
+// ledgerCheckpoints.ts so consumers that only need the gate check (e.g.
+// defaultChecker.ts) don't pull in this module's heavier dependency graph
+// (Soroban RPC client, webhook/notification/event-stream services) — see
+// that file's doc comment.
+export { hasUnresolvedLedgerGaps } from './ledgerCheckpoints.js';

--- a/backend/src/services/ledgerCheckpoints.ts
+++ b/backend/src/services/ledgerCheckpoints.ts
@@ -1,0 +1,44 @@
+import { query } from '../db/connection.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Whether any ledger range for `contract` is currently flagged `'suspect'`
+ * by the indexer's contiguous-cursor checkpoint table (see
+ * `EventIndexer.recordCheckpoint` in `eventIndexer.ts`). A consumer that
+ * draws conclusions from indexed events — e.g. `defaultChecker.ts` deciding
+ * a loan was never repaid — should treat events in a suspect window as
+ * unreliable until the gap is reconciled (issue #1376).
+ *
+ * Deliberately kept in its own module, separate from `eventIndexer.ts`:
+ * `defaultChecker.ts` needs this single query but not the rest of the
+ * indexer's dependency graph (Soroban RPC client, webhook/notification/
+ * event-stream services, etc.) — importing `eventIndexer.js` directly would
+ * pull all of that in transitively for a consumer that only wants to key
+ * off `LOAN_MANAGER_CONTRACT_ID` and ask "is there a gap right now?".
+ *
+ * Fails open (returns `false`) on a query error so a checkpoint-table
+ * hiccup does not, by itself, block downstream processing; the error is
+ * logged for operator visibility instead.
+ */
+export async function hasUnresolvedLedgerGaps(contract: string): Promise<boolean> {
+  try {
+    const result = await query(
+      `SELECT EXISTS (
+         SELECT 1 FROM ledger_checkpoints WHERE contract = $1 AND status = 'suspect'
+       ) AS has_suspect`,
+      [contract],
+    );
+    return Boolean((result.rows[0] as { has_suspect?: boolean } | undefined)?.has_suspect);
+  } catch (error) {
+    logger
+      .withContext()
+      .warn(
+        'Failed to check for unresolved ledger gaps; proceeding without the suspect-range gate',
+        {
+          contract,
+          error,
+        },
+      );
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

`eventIndexer.ts` advanced its cursor (`indexer_state.last_ledger`) whenever it was monotonic, with no record of which ledger ranges had actually been confirmed scanned by the RPC. A restart that resumes from a stale or clamped starting point could silently skip a range of ledgers with no error — empty ledgers legitimately produce no events, so the old code had no way to distinguish "empty" from "skipped."

This adds a checkpoint table so the indexer can detect that kind of gap and flag it, and gates the one consumer (`defaultChecker.ts`) that draws conclusions from indexed events on there being no unresolved gap for the loan manager contract.

- New `ledger_checkpoints` table (`contract`, `range_start`, `range_end`, `status`). After every poll iteration, `EventIndexer.recordCheckpoint` records the range that was just requested from the RPC:
  - `'verified'` when `range_start` immediately follows the previously-recorded range's `range_end`.
  - `'suspect'` for the gap in between when it doesn't — logged and persisted for follow-up.
- `EventIndexer.getSuspectRanges()` and a standalone `hasUnresolvedLedgerGaps(contract)` (in the new `ledgerCheckpoints.ts`, kept separate from `eventIndexer.ts` so consumers don't pull in the indexer's full dependency graph) expose this to callers.
- `defaultChecker.checkOverdueLoans()` now checks `hasUnresolvedLedgerGaps` for `LOAN_MANAGER_CONTRACT_ID` before evaluating overdue loans, since `fetchOverdueLoanIds`/`fetchOverdueStats` derive loan state entirely from indexed `contract_events` — a missed `LoanRepaid` or `LoanDefaulted` in a gap risks a false default. The run is skipped (not failed) when a gap is unresolved, returning `{ skipped: true, skippedReason: 'unresolved_ledger_gap' }`. The gate itself fails open on a query error so a checkpoint-table hiccup alone doesn't block default checking.
- Fixed `migrations/1801..._create-pause-state-table.js`: it used CommonJS `exports.up = async (db) => ...` in an ESM package (`"type": "module"`), which throws `ReferenceError: exports is not defined` when node-pg-migrate loads it. This migration runs immediately before the new `1802..._create-ledger-checkpoints.js` in file order, so it had to be fixed to verify `migrate:up`/`migrate:down` at all. Converted to the same ESM `pgm`-style used by every other migration in the directory — no behavior change.

## Out of scope

Issue #1376's full spec covers five phases across contracts, backend, frontend, and CI. This PR is the backend detection primitive plus the one known consumer that needed gating. Left out, each being its own multi-hour, multi-file change:
- Reorg detection via a content digest (`range_digest`) — requires the contract-level `event_seq` identifier added to `loan_manager`/`lending_pool`/`multisig_governance`/`remittance_nft` first.
- Automatic backfill of a detected gap (`backfillRange`).
- The frontend SSE `resync` frame and TanStack Query cache invalidation.
- The `docker-compose.yml` fixture RPC and the corresponding CI job wiring.

Also unrelated and pre-existing on `main` (verified against a clean checkout before making any changes, not introduced by this PR):
- `npm run build` / `npm run typecheck` in `backend/` already fail on `transactionController.ts`, `pagination.ts`, `pauseGuard.ts`, `sorobanService.ts`, and others.
- The migration-check job's "roll back every migration one at a time" loop breaks on migration `1800..._keyset-pagination-seq-columns.js`: its `down()` drops an index name that doesn't match what its own `up()` created.

## Test plan

- [x] `npm test -- --testPathPatterns="eventIndexer|defaultChecker"` — 32/32 passing (7 new: gap/contiguous/first-checkpoint scenarios, `getSuspectRanges`, `hasUnresolvedLedgerGaps` happy/empty/error paths; 2 new: `defaultChecker` skips when a gap exists, proceeds when it doesn't).
- [x] Full `npm test` — same 30 pre-existing failing suites / 15 pre-existing failing tests as a clean checkout of `main` (confirmed via `git stash`); no new failures, 9 more passing tests than baseline.
- [x] `npx eslint` on every changed/added file — clean.
- [x] Migration verified against a local Postgres 16: `migrate:up` → `migrate:down` (removes `ledger_checkpoints` and `pause_state` with no residual objects) → `migrate:up` again succeeds.

Closes #1376