### PR TITLE
Fix #1369: Add accrued interest instead of subtracting it

### DIFF
--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -560,7 +560,7 @@ export const getLoanDetails = asyncHandler(async (req: Request, res: Response) =
   const accruedInterest = isPending
     ? 0
     : (principal * rateBps * elapsedLedgers) / (10000 * termLedgers);
-  const totalOwed = principal - accruedInterest - totalRepaid;
+  const totalOwed = principal + accruedInterest - totalRepaid;
 
   res.json({
     success: true,


### PR DESCRIPTION
Description: closes #1369.

The getLoanDetails function in backend/src/controllers/loanController.ts contained a logic defect where accrued interest was being incorrectly subtracted from the total owed amount, rather than being added to it.

This PR corrects the calculation logic from: const totalOwed = principal - accruedInterest - totalRepaid; to const totalOwed = principal + accruedInterest - totalRepaid;

This ensures borrowers must properly pay accrued interest to fully repay their loan.

