### PR TITLE
fix(ci): restore green main (prettier, cargo fmt, loan_events view migration)

### DIFF
--- a/backend/migrations/1800000000000_keyset-pagination-seq-columns.js
+++ b/backend/migrations/1800000000000_keyset-pagination-seq-columns.js
@@ -9,7 +9,7 @@ export const shorthands = undefined;
  */
 export const up = async (pgm) => {
   // ─── Add seq identity columns for keyset pagination ───────────────────
-  
+
   // 1. contract_events (formerly loan_events)
   pgm.addColumn('contract_events', {
     seq: {
@@ -78,29 +78,41 @@ export const up = async (pgm) => {
   // ─── Create composite seek indexes ────────────────────────────────────
 
   // contract_events: (created_at DESC, seq DESC) for keyset pagination
-  pgm.createIndex('contract_events', [
-    { name: 'created_at', direction: 'DESC' },
-    { name: 'seq', direction: 'DESC' },
-  ], {
-    name: 'idx_contract_events_seek',
-  });
+  pgm.createIndex(
+    'contract_events',
+    [
+      { name: 'created_at', direction: 'DESC' },
+      { name: 'seq', direction: 'DESC' },
+    ],
+    {
+      name: 'idx_contract_events_seek',
+    },
+  );
 
   // remittances: (created_at DESC, seq DESC) for keyset pagination
-  pgm.createIndex('remittances', [
-    { name: 'created_at', direction: 'DESC' },
-    { name: 'seq', direction: 'DESC' },
-  ], {
-    name: 'idx_remittances_seek',
-  });
+  pgm.createIndex(
+    'remittances',
+    [
+      { name: 'created_at', direction: 'DESC' },
+      { name: 'seq', direction: 'DESC' },
+    ],
+    {
+      name: 'idx_remittances_seek',
+    },
+  );
 
   // loan_disputes: (created_at DESC, seq DESC) for keyset pagination (if exists)
   if (disputesTableExists.rows[0].exists) {
-    pgm.createIndex('loan_disputes', [
-      { name: 'created_at', direction: 'DESC' },
-      { name: 'seq', direction: 'DESC' },
-    ], {
-      name: 'idx_loan_disputes_seek',
-    });
+    pgm.createIndex(
+      'loan_disputes',
+      [
+        { name: 'created_at', direction: 'DESC' },
+        { name: 'seq', direction: 'DESC' },
+      ],
+      {
+        name: 'idx_loan_disputes_seek',
+      },
+    );
   }
 };
 
@@ -110,8 +122,8 @@ export const up = async (pgm) => {
  */
 export const down = async (pgm) => {
   // Drop seek indexes
-  pgm.dropIndex('contract_events', 'idx_contract_events_seek');
-  pgm.dropIndex('remittances', 'idx_remittances_seek');
+  pgm.dropIndex('contract_events', [], { name: 'idx_contract_events_seek' });
+  pgm.dropIndex('remittances', [], { name: 'idx_remittances_seek' });
 
   const disputesTableExists = await pgm.db.query(`
     SELECT EXISTS (
@@ -121,7 +133,7 @@ export const down = async (pgm) => {
   `);
 
   if (disputesTableExists.rows[0].exists) {
-    pgm.dropIndex('loan_disputes', 'idx_loan_disputes_seek');
+    pgm.dropIndex('loan_disputes', [], { name: 'idx_loan_disputes_seek' });
   }
 
   // Drop seq columns

--- a/backend/migrations/1802000000000_money_stroops_integer.js
+++ b/backend/migrations/1802000000000_money_stroops_integer.js
@@ -51,11 +51,34 @@ const MONEY_COLUMNS = [
   },
 ];
 
+// The backward-compat `loan_events` view (1788000000018_unified-contract-events)
+// selects `contract_events.amount`, and PostgreSQL refuses to retype a column a
+// view depends on. Drop the view around the ALTER and recreate it verbatim.
+const CREATE_LOAN_EVENTS_VIEW = `
+  CREATE VIEW loan_events AS
+  SELECT
+    id,
+    event_id,
+    event_type,
+    loan_id,
+    address AS borrower,
+    amount,
+    ledger,
+    ledger_closed_at,
+    tx_hash,
+    contract_id,
+    topics,
+    value,
+    created_at
+  FROM contract_events;
+`;
+
 /**
  * @param pgm {import('node-pg-migrate').MigrationBuilder}
  * @returns {void}
  */
 export const up = (pgm) => {
+  pgm.sql('DROP VIEW IF EXISTS loan_events;');
   for (const { table, column, constraint } of MONEY_COLUMNS) {
     // Round any pre-existing fractional values down to whole stroops before
     // the CHECK is added, so historical rows (if any ever slipped in with a
@@ -70,6 +93,7 @@ export const up = (pgm) => {
       check: `"${column}" IS NULL OR "${column}" = trunc("${column}")`,
     });
   }
+  pgm.sql(CREATE_LOAN_EVENTS_VIEW);
 };
 
 /**
@@ -77,8 +101,10 @@ export const up = (pgm) => {
  * @returns {void}
  */
 export const down = (pgm) => {
+  pgm.sql('DROP VIEW IF EXISTS loan_events;');
   for (const { table, column, constraint } of [...MONEY_COLUMNS].reverse()) {
     pgm.dropConstraint(table, constraint);
     pgm.alterColumn(table, column, { type: 'numeric' });
   }
+  pgm.sql(CREATE_LOAN_EVENTS_VIEW);
 };

--- a/backend/src/services/__tests__/crossContractReconciler.test.ts
+++ b/backend/src/services/__tests__/crossContractReconciler.test.ts
@@ -36,7 +36,8 @@ function routeQueries(opts: {
   const { backfilled = 0, unresolved = [], matchByBorrower = {} } = opts;
   mockQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
     if (sql.includes('/* backfill */')) return { rows: [], rowCount: backfilled };
-    if (sql.includes('/* fetch-unresolved */')) return { rows: unresolved, rowCount: unresolved.length };
+    if (sql.includes('/* fetch-unresolved */'))
+      return { rows: unresolved, rowCount: unresolved.length };
     if (sql.includes('/* match-score */')) {
       const borrower = String(params?.[0] ?? '');
       const ledger = matchByBorrower[borrower];

--- a/backend/src/services/crossContractReconciler.ts
+++ b/backend/src/services/crossContractReconciler.ts
@@ -165,7 +165,11 @@ class CrossContractReconciler {
     return row?.ledger == null ? null : Number(row.ledger);
   }
 
-  private async markReconciled(id: number, scoreLedger: number | null, applied: boolean): Promise<void> {
+  private async markReconciled(
+    id: number,
+    scoreLedger: number | null,
+    applied: boolean,
+  ): Promise<void> {
     await query(
       `/* update */
       UPDATE cross_contract_reconciliation
@@ -247,10 +251,12 @@ class CrossContractReconciler {
               const onChainScore = await sorobanService.getOnChainCreditScore(row.borrower);
               corrections.set(row.borrower, onChainScore);
             } catch (err) {
-              logger.withContext().error('cross_contract_reconciliation.autocorrect.lookup_failed', {
-                borrower: row.borrower,
-                error: err,
-              });
+              logger
+                .withContext()
+                .error('cross_contract_reconciliation.autocorrect.lookup_failed', {
+                  borrower: row.borrower,
+                  error: err,
+                });
             }
           }
         } else {

--- a/contracts/fuzz/Cargo.lock
+++ b/contracts/fuzz/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
 name = "lending_pool"
 version = "0.0.1"
 dependencies = [
+ "money",
  "soroban-sdk",
 ]
 
@@ -818,6 +819,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 name = "loan_manager"
 version = "0.0.1"
 dependencies = [
+ "money",
  "soroban-sdk",
 ]
 
@@ -832,6 +834,13 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "money"
+version = "0.0.1"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "multisig_governance"

--- a/contracts/fuzz/fuzz_targets/lending_pool_fuzz.rs
+++ b/contracts/fuzz/fuzz_targets/lending_pool_fuzz.rs
@@ -5,7 +5,7 @@ use lending_pool::{LendingPool, LendingPoolClient};
 use libfuzzer_sys::fuzz_target;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-use soroban_sdk::{Address, Env, Symbol, IntoVal, Val};
+use soroban_sdk::{Address, Env, IntoVal, Symbol, Val};
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 
@@ -34,7 +34,10 @@ struct Operation {
     is_deposit: bool,
 }
 
-fn setup_token_contract<'a>(env: &Env, admin: &Address) -> (Address, StellarAssetClient<'a>, TokenClient<'a>) {
+fn setup_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (Address, StellarAssetClient<'a>, TokenClient<'a>) {
     let contract_id = env.register_stellar_asset_contract_v2(admin.clone());
     let stellar_asset_client = StellarAssetClient::new(env, &contract_id.address());
     let token_client = TokenClient::new(env, &contract_id.address());
@@ -60,7 +63,7 @@ fuzz_target!(|data: FuzzAction| {
     match data {
         FuzzAction::Deposit { user_id, amount } => {
             let user = Address::generate(&env);
-            
+
             // Skip invalid amounts
             if amount <= 0 {
                 return;
@@ -76,9 +79,13 @@ fuzz_target!(|data: FuzzAction| {
                 let balance = pool_client.get_deposit(&user, &token_id);
                 assert!(balance >= 0, "Balance should never be negative");
                 assert_eq!(balance, amount, "Balance should match deposited amount");
-                
+
                 // Verify pool token balance
-                assert_eq!(token_client.balance(&pool_id), amount, "Pool token balance should match deposit");
+                assert_eq!(
+                    token_client.balance(&pool_id),
+                    amount,
+                    "Pool token balance should match deposit"
+                );
             }
         }
 
@@ -96,7 +103,7 @@ fuzz_target!(|data: FuzzAction| {
                 None => return,
             };
             stellar_asset_client.mint(&user, &deposit_amount);
-            pool_client.deposit(&user, &token_id, &deposit_amount);
+            pool_client.deposit(&user, &token_id, &deposit_amount, &0);
 
             let balance_before = pool_client.get_deposit(&user, &token_id);
             let result = rcall!(&env, pool_client, "withdraw", (user, amount));
@@ -111,9 +118,13 @@ fuzz_target!(|data: FuzzAction| {
                     "Balance should decrease by withdrawal amount"
                 );
                 assert!(balance_after >= 0, "Balance should never be negative");
-                
+
                 // Verify pool token balance
-                assert_eq!(token_client.balance(&pool_id), deposit_amount - amount, "Pool token balance mismatch after withdrawal");
+                assert_eq!(
+                    token_client.balance(&pool_id),
+                    deposit_amount - amount,
+                    "Pool token balance mismatch after withdrawal"
+                );
             }
         }
 
@@ -130,19 +141,26 @@ fuzz_target!(|data: FuzzAction| {
             let mut total_expected_deposits = 0i128;
 
             for op in operations {
-                let user_addr = users.entry(op.user_id).or_insert_with(|| Address::generate(&env)).clone();
+                let user_addr = users
+                    .entry(op.user_id)
+                    .or_insert_with(|| Address::generate(&env))
+                    .clone();
 
                 if op.is_deposit {
-                    if op.amount <= 0 { continue; }
-                    
+                    if op.amount <= 0 {
+                        continue;
+                    }
+
                     stellar_asset_client.mint(&user_addr, &op.amount);
                     let result = rcall!(&env, pool_client, "deposit", (user_addr, op.amount));
                     if result.is_ok() {
                         total_expected_deposits += op.amount;
                     }
                 } else {
-                    if op.amount <= 0 { continue; }
-                    
+                    if op.amount <= 0 {
+                        continue;
+                    }
+
                     // Attempt withdrawal
                     let result = rcall!(&env, pool_client, "withdraw", (user_addr, op.amount));
                     if result.is_ok() {
@@ -165,12 +183,14 @@ fuzz_target!(|data: FuzzAction| {
                 total_expected_deposits,
                 "Total deposits should match pool token balance"
             );
-            
+
             // Verify all individual balances are non-negative
             for (_, user_addr) in users {
-                assert!(pool_client.get_deposit(&user_addr, &token_id) >= 0, "Individual balance should never be negative");
+                assert!(
+                    pool_client.get_deposit(&user_addr, &token_id) >= 0,
+                    "Individual balance should never be negative"
+                );
             }
         }
     }
 });
-

--- a/contracts/fuzz/fuzz_targets/loan_manager_fuzz.rs
+++ b/contracts/fuzz/fuzz_targets/loan_manager_fuzz.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use libfuzzer_sys::fuzz_target;
 use lending_pool::LendingPool;
+use libfuzzer_sys::fuzz_target;
 use loan_manager::{LoanManager, LoanManagerClient};
 use remittance_nft::{RemittanceNFT, RemittanceNFTClient};
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env, BytesN, Symbol, IntoVal, Val};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, Val};
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 
@@ -66,7 +66,7 @@ fuzz_target!(|data: FuzzAction| {
     let loan_manager_id = env.register(LoanManager, ());
     let loan_manager_client = LoanManagerClient::new(&env, &loan_manager_id);
     loan_manager_client.initialize(&nft_id, &lending_pool_id, &token_id, &admin);
-    
+
     // Authorize LoanManager to update scores in NFT contract
     nft_client.authorize_minter(&loan_manager_id);
 
@@ -85,7 +85,14 @@ fuzz_target!(|data: FuzzAction| {
 
             // Mint NFT for user with specific score
             let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-            nft_client.mint(&user, &score, &history_hash, &soroban_sdk::String::from_str(&env, "ipfs://test"), &BytesN::from_array(&env, &[0u8; 32]), &None);
+            nft_client.mint(
+                &user,
+                &score,
+                &history_hash,
+                &soroban_sdk::String::from_str(&env, "ipfs://test"),
+                &BytesN::from_array(&env, &[0u8; 32]),
+                &None,
+            );
 
             let result = rcall!(&env, loan_manager_client, "request_loan", (user, amount));
 
@@ -117,7 +124,14 @@ fuzz_target!(|data: FuzzAction| {
 
             // Mint NFT for user
             let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-            nft_client.mint(&user, &initial_score, &history_hash, &soroban_sdk::String::from_str(&env, "ipfs://test"), &BytesN::from_array(&env, &[0u8; 32]), &None);
+            nft_client.mint(
+                &user,
+                &initial_score,
+                &history_hash,
+                &soroban_sdk::String::from_str(&env, "ipfs://test"),
+                &BytesN::from_array(&env, &[0u8; 32]),
+                &None,
+            );
 
             let score_before = nft_client.get_score(&user);
             let result = rcall!(&env, loan_manager_client, "repay", (user, amount));
@@ -127,7 +141,11 @@ fuzz_target!(|data: FuzzAction| {
 
                 // Verify invariant: score should be updated (increased by 1 per 100 units)
                 let expected_increase = (amount / 100) as u32;
-                assert_eq!(score_after, score_before + expected_increase, "Score should increase correctly after repayment");
+                assert_eq!(
+                    score_after,
+                    score_before + expected_increase,
+                    "Score should increase correctly after repayment"
+                );
                 assert!(score_after >= 0, "Score should never be negative");
             }
         }
@@ -136,18 +154,33 @@ fuzz_target!(|data: FuzzAction| {
             let mut users = HashMap::new();
 
             for op in operations {
-                let user_addr = users.entry(op.user_id).or_insert_with(|| {
-                    let addr = Address::generate(&env);
-                    let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-                    // Initialize user with some score
-                    nft_client.mint(&addr, &op.score, &history_hash, &soroban_sdk::String::from_str(&env, "ipfs://test"), &BytesN::from_array(&env, &[0u8; 32]), &None);
-                    addr
-                }).clone();
+                let user_addr = users
+                    .entry(op.user_id)
+                    .or_insert_with(|| {
+                        let addr = Address::generate(&env);
+                        let history_hash = BytesN::from_array(&env, &[0u8; 32]);
+                        // Initialize user with some score
+                        nft_client.mint(
+                            &addr,
+                            &op.score,
+                            &history_hash,
+                            &soroban_sdk::String::from_str(&env, "ipfs://test"),
+                            &BytesN::from_array(&env, &[0u8; 32]),
+                            &None,
+                        );
+                        addr
+                    })
+                    .clone();
 
                 match op.operation_type % 2 {
                     0 if op.amount > 0 => {
                         // Request loan
-                        let _ = rcall!(&env, loan_manager_client, "request_loan", (user_addr, op.amount));
+                        let _ = rcall!(
+                            &env,
+                            loan_manager_client,
+                            "request_loan",
+                            (user_addr, op.amount)
+                        );
                     }
                     1 if op.amount > 0 => {
                         // Repay
@@ -159,4 +192,3 @@ fuzz_target!(|data: FuzzAction| {
         }
     }
 });
-

--- a/contracts/fuzz/fuzz_targets/multisig_governance_fuzz.rs
+++ b/contracts/fuzz/fuzz_targets/multisig_governance_fuzz.rs
@@ -21,8 +21,14 @@ const POOL_SIZE: usize = 8;
 
 #[derive(Arbitrary, Debug)]
 enum FuzzAction {
-    Propose { num_signers: u8, threshold: u8, delay: u32 },
-    Approve { signer_idx: u8 },
+    Propose {
+        num_signers: u8,
+        threshold: u8,
+        delay: u32,
+    },
+    Approve {
+        signer_idx: u8,
+    },
     Expire,
     Cancel,
 }
@@ -39,18 +45,22 @@ fuzz_target!(|actions: std::vec::Vec<FuzzAction>| {
     client.initialize(&admin, &target);
 
     // A stable pool of candidate signers so indices are meaningful across actions.
-    let pool: std::vec::Vec<Address> =
-        (0..POOL_SIZE).map(|_| Address::generate(&env)).collect();
+    let pool: std::vec::Vec<Address> = (0..POOL_SIZE).map(|_| Address::generate(&env)).collect();
 
     for action in actions {
         match action {
-            FuzzAction::Propose { num_signers, threshold, delay } => {
+            FuzzAction::Propose {
+                num_signers,
+                threshold,
+                delay,
+            } => {
                 let n = (num_signers as usize % POOL_SIZE) + 1; // 1..=POOL_SIZE
                 let mut signers = Vec::new(&env);
                 for s in pool.iter().take(n) {
                     signers.push_back(s.clone());
                 }
                 let thr = (threshold as u32 % n as u32) + 1; // 1..=n
+
                 // try_* so contract panics (cooldown, already-pending, …) don't abort the fuzzer.
                 let _ = client.try_propose_admin_transfer(
                     &Address::generate(&env),

--- a/contracts/fuzz/fuzz_targets/remittance_nft_fuzz.rs
+++ b/contracts/fuzz/fuzz_targets/remittance_nft_fuzz.rs
@@ -2,9 +2,11 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use remittance_nft::{DataKey as RemittanceDataKey, RemittanceMetadata, RemittanceNFT, RemittanceNFTClient};
+use remittance_nft::{
+    DataKey as RemittanceDataKey, RemittanceMetadata, RemittanceNFT, RemittanceNFTClient,
+};
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, BytesN, Env, Symbol, IntoVal, Val};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, Val};
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 
@@ -113,7 +115,12 @@ fuzz_target!(|data: FuzzAction| {
                 nft_client.authorize_minter(m);
             }
 
-            let result = rcall!(&env, nft_client, "mint", (user, initial_score, history_hash, minter));
+            let result = rcall!(
+                &env,
+                nft_client,
+                "mint",
+                (user, initial_score, history_hash, minter)
+            );
 
             if result.is_ok() {
                 // Verify invariant: user should have metadata
@@ -128,7 +135,12 @@ fuzz_target!(|data: FuzzAction| {
                 }
 
                 // Verify invariant: duplicate mint should fail
-                let result = rcall!(&env, nft_client, "mint", (user, initial_score, history_hash, minter));
+                let result = rcall!(
+                    &env,
+                    nft_client,
+                    "mint",
+                    (user, initial_score, history_hash, minter)
+                );
                 assert!(result.is_err(), "Duplicate mint should fail");
             }
         }
@@ -143,14 +155,26 @@ fuzz_target!(|data: FuzzAction| {
 
             // First mint an NFT for the user
             let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-            nft_client.mint(&user, &100u32, &history_hash, &soroban_sdk::String::from_str(&env, "ipfs://test"), &BytesN::from_array(&env, &[0u8; 32]), &None);
+            nft_client.mint(
+                &user,
+                &100u32,
+                &history_hash,
+                &soroban_sdk::String::from_str(&env, "ipfs://test"),
+                &BytesN::from_array(&env, &[0u8; 32]),
+                &None,
+            );
 
             if let Some(ref m) = minter {
                 nft_client.authorize_minter(m);
             }
 
             let score_before = nft_client.get_score(&user);
-            let result = rcall!(&env, nft_client, "update_score", (user, repayment_amount, minter));
+            let result = rcall!(
+                &env,
+                nft_client,
+                "update_score",
+                (user, repayment_amount, minter)
+            );
 
             if result.is_ok() {
                 let score_after = nft_client.get_score(&user);
@@ -175,13 +199,25 @@ fuzz_target!(|data: FuzzAction| {
 
             // First mint an NFT for the user
             let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-            nft_client.mint(&user, &100u32, &history_hash, &soroban_sdk::String::from_str(&env, "ipfs://test"), &BytesN::from_array(&env, &[0u8; 32]), &None);
+            nft_client.mint(
+                &user,
+                &100u32,
+                &history_hash,
+                &soroban_sdk::String::from_str(&env, "ipfs://test"),
+                &BytesN::from_array(&env, &[0u8; 32]),
+                &None,
+            );
 
             if let Some(ref m) = minter {
                 nft_client.authorize_minter(m);
             }
 
-            let result = rcall!(&env, nft_client, "update_history_hash", (user, new_history_hash, minter));
+            let result = rcall!(
+                &env,
+                nft_client,
+                "update_history_hash",
+                (user, new_history_hash, minter)
+            );
 
             if result.is_ok() {
                 // Verify invariant: history hash should be updated
@@ -193,32 +229,45 @@ fuzz_target!(|data: FuzzAction| {
             }
         }
 
-        FuzzAction::LegacyMigration { user_id, legacy_score } => {
+        FuzzAction::LegacyMigration {
+            user_id,
+            legacy_score,
+        } => {
             let user = Address::generate(&env);
-            
+
             // Manually set legacy score in storage
             // In a real scenario, this would be done by an older version of the contract
             // We use the same DataKey enum but setter might be different if we were external
             // But here we are testing the contract's ability to read old keys
-            
+
             // We need to know the exact key format. In lib.rs: Score(Address)
             // Since we're in the same crate (via dependency), we can try to use it if public
             // or just mock the storage if we have access to Env test utils
-            
+
             env.as_contract(&nft_id, || {
-                env.storage().persistent().set(&(RemittanceDataKey::Score(user.clone())), &legacy_score);
+                env.storage()
+                    .persistent()
+                    .set(&(RemittanceDataKey::Score(user.clone())), &legacy_score);
             });
-            
+
             let score = nft_client.get_score(&user);
             assert_eq!(score, legacy_score, "Should correctly read legacy score");
-            
+
             // Getting metadata should trigger migration
             let metadata = nft_client.get_metadata(&user).unwrap();
-            assert_eq!(metadata.score, legacy_score, "Metadata score should match legacy score");
-            
+            assert_eq!(
+                metadata.score, legacy_score,
+                "Metadata score should match legacy score"
+            );
+
             // Legacy key should be removed
             env.as_contract(&nft_id, || {
-                assert!(!env.storage().persistent().has(&(RemittanceDataKey::Score(user.clone()))), "Legacy key should be removed after migration");
+                assert!(
+                    !env.storage()
+                        .persistent()
+                        .has(&(RemittanceDataKey::Score(user.clone()))),
+                    "Legacy key should be removed after migration"
+                );
             });
         }
 
@@ -227,29 +276,50 @@ fuzz_target!(|data: FuzzAction| {
             let mut minters = HashMap::new();
 
             for op in operations {
-                let user_addr = users.entry(op.user_id).or_insert_with(|| Address::generate(&env)).clone();
+                let user_addr = users
+                    .entry(op.user_id)
+                    .or_insert_with(|| Address::generate(&env))
+                    .clone();
                 let minter_addr = op.minter_id.map(|id| {
-                    minters.entry(id).or_insert_with(|| {
-                        let addr = Address::generate(&env);
-                        nft_client.authorize_minter(&addr);
-                        addr
-                    }).clone()
+                    minters
+                        .entry(id)
+                        .or_insert_with(|| {
+                            let addr = Address::generate(&env);
+                            nft_client.authorize_minter(&addr);
+                            addr
+                        })
+                        .clone()
                 });
 
                 match op.operation_type % 4 {
                     0 => {
                         // Mint
                         let history_hash = BytesN::from_array(&env, &[0u8; 32]);
-                        let _ = rcall!(&env, nft_client, "mint", (user_addr, op.score, history_hash, minter_addr));
+                        let _ = rcall!(
+                            &env,
+                            nft_client,
+                            "mint",
+                            (user_addr, op.score, history_hash, minter_addr)
+                        );
                     }
                     1 => {
                         // Update score
-                        let _ = rcall!(&env, nft_client, "update_score", (user_addr, op.amount, minter_addr));
+                        let _ = rcall!(
+                            &env,
+                            nft_client,
+                            "update_score",
+                            (user_addr, op.amount, minter_addr)
+                        );
                     }
                     2 => {
                         // Update history hash
                         let new_history_hash = BytesN::from_array(&env, &[op.operation_type; 32]);
-                        let _ = rcall!(&env, nft_client, "update_history_hash", (user_addr, new_history_hash, minter_addr));
+                        let _ = rcall!(
+                            &env,
+                            nft_client,
+                            "update_history_hash",
+                            (user_addr, new_history_hash, minter_addr)
+                        );
                     }
                     3 => {
                         // Revoke minter
@@ -263,4 +333,3 @@ fuzz_target!(|data: FuzzAction| {
         }
     }
 });
-

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -270,9 +270,7 @@ impl LendingPool {
         let assets_den = total_managed_assets_before
             .checked_add(Self::VIRTUAL_ASSETS)
             .expect("virtual assets overflow");
-        let numerator = amount
-            .checked_mul(shares_num)
-            .expect("share mint overflow");
+        let numerator = amount.checked_mul(shares_num).expect("share mint overflow");
         // Floor: minting fewer shares than the exact exchange rate would
         // imply protects existing holders from dilution by rounding in
         // the protocol's favor, matching `money::round_div`'s Floor mode


### PR DESCRIPTION
Join us on Telegram: https://t.me/+DOylgFv1jyJlNzM0

Main CI has been red since ~July 30, which makes every contributor PR fail the backend, contracts and migration-check jobs through no fault of their own. This fixes the three causes:

1. backend eslint: prettier formatting errors in `src/services/crossContractReconciler.ts` and its test.
2. contracts: `cargo fmt` diff in `lending_pool/src/lib.rs`.
3. migration-check: `1802000000000_money_stroops_integer` retypes `contract_events.amount`, but the backward-compat `loan_events` view depends on that column, so postgres aborts with "cannot alter type of a column used by a view or rule" on a fresh schema. The migration now drops the view before the ALTER and recreates it verbatim afterwards (up and down).

Note: we also have two migrations sharing the number `1802000000000` (create-ledger-checkpoints and money_stroops_integer). They run in a deterministic alphabetical order so nothing breaks today, but new migrations should start at `1803000000000` or higher.
