### PR TITLE
fix: use UTF-8 byte length for Stellar MEMO_TEXT validation in RemittanceForm

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,1 +1,8 @@
+import "jest-environment-jsdom"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import "@testing-library/jest-dom";
+
+// Polyfill TextEncoder for jsdom environment (Node.js < 20)
+if (typeof globalThis.TextEncoder === "undefined") {
+  const { TextEncoder } = require("util");
+  globalThis.TextEncoder = TextEncoder;
+}

--- a/frontend/src/app/components/remittance/RemittanceForm.test.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.test.tsx
@@ -106,7 +106,7 @@ describe("RemittanceForm", () => {
     });
   });
 
-  it("should show warning for memo longer than 28 characters", async () => {
+  it("should show warning for memo longer than 28 bytes", async () => {
     const user = userEvent.setup();
     render(<RemittanceForm onSuccess={mockOnSuccess} />);
 
@@ -126,11 +126,35 @@ describe("RemittanceForm", () => {
     fireEvent.click(reviewButton);
 
     await waitFor(() => {
-      expect(screen.getByText("Memo must be 28 characters or less")).toBeInTheDocument();
+      expect(screen.getByText("Memo must be 28 bytes or less (Stellar MEMO_TEXT limit)")).toBeInTheDocument();
     });
   });
 
-  it("should display character count for memo", async () => {
+  it("should reject multibyte memo that exceeds 28 bytes", async () => {
+    const user = userEvent.setup();
+    render(<RemittanceForm onSuccess={mockOnSuccess} />);
+
+    const addressInput = screen.getByPlaceholderText("G... (Stellar public key)");
+    const amountInput = screen.getByPlaceholderText("0.00");
+
+    await user.type(addressInput, VALID_ADDRESS);
+    await user.type(amountInput, "100");
+
+    const memoInput = screen.getByLabelText(/^Memo/);
+    // "ñ" is 2 bytes in UTF-8, so 15 x ñ = 30 bytes (> 28)
+    fireEvent.change(memoInput, {
+      target: { value: "ñññññññññññññññ" },
+    });
+
+    const reviewButton = screen.getByRole("button", { name: /review/i });
+    fireEvent.click(reviewButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Memo must be 28 bytes or less (Stellar MEMO_TEXT limit)")).toBeInTheDocument();
+    });
+  });
+
+  it("should display byte count for memo", async () => {
     const user = userEvent.setup();
     render(<RemittanceForm onSuccess={mockOnSuccess} />);
 
@@ -138,7 +162,7 @@ describe("RemittanceForm", () => {
     await user.type(memoInput, "Test memo");
 
     await waitFor(() => {
-      expect(screen.getByText("9/28 characters")).toBeInTheDocument();
+      expect(screen.getByText("9/28 bytes")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/components/remittance/RemittanceForm.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.tsx
@@ -59,8 +59,9 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
       }
     }
 
-    if (memo && memo.length > 28) {
-      newErrors.memo = "Memo must be 28 characters or less";
+    if (memo && new TextEncoder().encode(memo).length > 28) {
+      newErrors.memo =
+        "Memo must be 28 bytes or less (Stellar MEMO_TEXT limit)";
     }
 
     setErrors(newErrors);
@@ -224,11 +225,10 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
               </label>
               <textarea
                 id="memo"
-                placeholder="Add a note for the recipient (max 28 characters)"
+                placeholder="Add a note for the recipient (max 28 bytes)"
                 value={memo}
                 onChange={(e) => handleMemoChange(e.target.value)}
                 disabled={mutation.isPending}
-                maxLength={28}
                 rows={2}
                 className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-600 dark:focus:ring-indigo-400 resize-none dark:border-zinc-700 ${
                   errors.memo ? "border-red-600" : "border-zinc-300"
@@ -241,7 +241,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
                 </div>
               )}
               <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                {memo.length}/28 characters
+                {new TextEncoder().encode(memo).length}/28 bytes
               </p>
             </div>
 


### PR DESCRIPTION
### Fix Stellar MEMO_TEXT validation: use UTF-8 byte length instead of character count

**Closes #1074**

### Problem

The memo field validated by character count (`memo.length > 28`), but Stellar `MEMO_TEXT` caps at **28 bytes**, not 28 characters. Multibyte UTF-8 memos (accented characters, emoji, CJK) could pass the 28-character check and still exceed 28 bytes, failing at transaction submission time.

### Changes

- **`validateForm`**: Replaced `memo.length > 28` with `new TextEncoder().encode(memo).length > 28` (UTF-8 byte-length check)
- **Textarea**: Removed `maxLength={28}` attribute (character-level cap) in favor of byte-aware validation at submit time
- **Counter**: Updated from `{memo.length}/28 characters` to `{new TextEncoder().encode(memo).length}/28 bytes`
- **Error message**: Updated to "Memo must be 28 bytes or less (Stellar MEMO_TEXT limit)"
- **Tests**: Added multibyte rejection test (15×ñ = 30 bytes > 28); updated existing tests for new error message and byte counter

### Acceptance Criteria

- [x] Memo validation uses UTF-8 byte length (`new TextEncoder().encode(memo).length <= 28`)
- [x] The textarea counter reflects bytes, not characters
- [x] A memo that's under 28 characters but over 28 bytes gets rejected with a clear message
- [x] Pure-ASCII memos up to 28 bytes still pass
- [x] Unit test covers the multibyte-over-28-bytes rejection and byte counter display

### Files modified

- `frontend/src/app/components/remittance/RemittanceForm.tsx` — validation, textarea, counter
- `frontend/src/app/components/remittance/RemittanceForm.test.tsx` — updated + new test