### PR TITLE
Fix requested-term preservation on approved loans

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1155,7 +1155,7 @@ impl LoanManager {
     ///
     /// Requires admin authorization and the loan manager, lending pool, and NFT
     /// contract to be unpaused. The target loan must be [`LoanStatus::Pending`];
-    /// approval records the default term, due date, interest/late-fee ledgers,
+    /// approval records the requested term, due date, interest/late-fee ledgers,
     /// and total outstanding balance before transferring funds from the lending
     /// pool to the borrower.
     ///
@@ -1195,7 +1195,10 @@ impl LoanManager {
             .instance()
             .get(&DataKey::Token)
             .expect("token not set");
-        let term_ledgers = Self::read_default_term(&env);
+        let term_ledgers = loan.term_ledgers;
+        if term_ledgers == 0 {
+            return Err(LoanError::InvalidTerm);
+        }
 
         // Cross-contract READ for liquidity check — still in the CHECKS phase.
         let pool_client = PoolClient::new(&env, &lending_pool);

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -659,6 +659,46 @@ fn test_admin_transfer_via_propose_accept() {
 }
 
 #[test]
+fn test_approved_loan_preserves_requested_term_boundaries() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let min_term = 1u32;
+    let max_term = 100_000u32;
+    manager.set_min_term_ledgers(&min_term);
+    manager.set_max_term_ledgers(&max_term);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &600,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &10_000_000);
+
+    for requested_term in [min_term, max_term] {
+        let loan_id = manager.request_loan(&borrower, &1_000, &requested_term);
+        let pending_loan = manager.get_loan(&loan_id);
+        assert_eq!(pending_loan.term_ledgers, requested_term);
+
+        let approval_ledger = env.ledger().sequence();
+        manager.approve_loan(&loan_id);
+
+        let approved_loan = manager.get_loan(&loan_id);
+        assert_eq!(approved_loan.term_ledgers, requested_term);
+        assert_eq!(approved_loan.due_date, approval_ledger + requested_term);
+    }
+}
+
+#[test]
 fn test_configurable_interest_rate_and_default_term() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
## Summary

- Add a regression covering non-default requested terms through approval.
- Assert that the approved loan keeps the original requested term and the due date is calculated from approval ledger + requested term.
- Cover both min- and max-boundary terms.
- Fix approve_loan so it preserves loan.term_ledgers instead of replacing it with the default term.

## Verification

- 
running 1 test
test test::test_approved_loan_preserves_requested_term_boundaries ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 117 filtered out; finished in 0.26s

Closes #1484