### PR TITLE
fix(notifications): validate GET /notifications query parameters with Zod schema

### DIFF
--- a/backend/src/__tests__/notificationFilters.test.ts
+++ b/backend/src/__tests__/notificationFilters.test.ts
@@ -192,4 +192,43 @@ describe('notification filters', () => {
     expect(response.status).toBe(200);
     expect(response.body.data.notifications).toHaveLength(10);
   });
+
+  it('rejects invalid status', async () => {
+    const response = await request(app)
+      .get('/api/notifications?status=invalid_status')
+      .set(bearer(userId));
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('rejects invalid type', async () => {
+    const response = await request(app)
+      .get('/api/notifications?type=invalid_type')
+      .set(bearer(userId));
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('rejects non-numeric limit', async () => {
+    const response = await request(app).get('/api/notifications?limit=abc').set(bearer(userId));
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('rejects out-of-bounds limit', async () => {
+    const response = await request(app).get('/api/notifications?limit=0').set(bearer(userId));
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+
+    const responseTooLarge = await request(app)
+      .get('/api/notifications?limit=101')
+      .set(bearer(userId));
+
+    expect(responseTooLarge.status).toBe(400);
+    expect(responseTooLarge.body.success).toBe(false);
+  });
 });

--- a/backend/src/controllers/notificationController.ts
+++ b/backend/src/controllers/notificationController.ts
@@ -25,14 +25,6 @@ export const getNotifications = asyncHandler(async (req: Request, res: Response)
   const from = req.query.from as string | undefined;
   const to = req.query.to as string | undefined;
 
-  // Validate date formats
-  if (from && Number.isNaN(Date.parse(from))) {
-    throw AppError.badRequest("Invalid 'from' date format");
-  }
-  if (to && Number.isNaN(Date.parse(to))) {
-    throw AppError.badRequest("Invalid 'to' date format");
-  }
-
   const [notifications, unreadCount] = await Promise.all([
     notificationService.getNotificationsForUser(userId, limit, type, status, from, to),
     notificationService.getUnreadCount(userId),

--- a/backend/src/routes/notificationsRoutes.ts
+++ b/backend/src/routes/notificationsRoutes.ts
@@ -8,6 +8,8 @@ import {
   updateNotificationPreferences,
 } from '../controllers/notificationController.js';
 import { requireJwtAuth, requireScopes } from '../middleware/jwtAuth.js';
+import { validateQuery } from '../middleware/validation.js';
+import { getNotificationsQuerySchema } from '../schemas/notificationSchemas.js';
 
 const router = Router();
 
@@ -33,7 +35,7 @@ const router = Router();
  *         name: type
  *         schema:
  *           type: string
- *           enum: [loan_approved, repayment_due, repayment_confirmed, loan_defaulted, score_changed]
+ *           enum: [loan_approved, repayment_due, repayment_confirmed, loan_defaulted, loan_liquidated, score_changed]
  *         description: Filter by notification type
  *       - in: query
  *         name: status
@@ -61,7 +63,13 @@ const router = Router();
  *             schema:
  *               $ref: '#/components/schemas/NotificationsResponse'
  */
-router.get('/', requireJwtAuth, requireScopes('read:notifications'), getNotifications);
+router.get(
+  '/',
+  requireJwtAuth,
+  requireScopes('read:notifications'),
+  validateQuery(getNotificationsQuerySchema),
+  getNotifications,
+);
 
 /**
  * @swagger

--- a/backend/src/schemas/notificationSchemas.ts
+++ b/backend/src/schemas/notificationSchemas.ts
@@ -30,6 +30,7 @@ export const getNotificationsQuerySchema = z.object({
       'repayment_due',
       'repayment_confirmed',
       'loan_defaulted',
+      'loan_liquidated',
       'score_changed',
     ])
     .optional(),
@@ -38,6 +39,8 @@ export const getNotificationsQuerySchema = z.object({
   to: isoDateString.optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
+
+export type GetNotificationsQuery = z.infer<typeof getNotificationsQuerySchema>;
 
 export const validateNotificationPhone = (phone: string | null): boolean => {
   if (!phone) return true;


### PR DESCRIPTION
## Fix: Validate GET /notifications Query Parameters Using Zod Schema

### Problem
`getNotificationsQuerySchema` was defined in `backend/src/schemas/notificationSchemas.ts` but was never imported or wired to the `GET /notifications` route in `backend/src/routes/notificationsRoutes.ts`. Consequently, `type` and `status` query parameters were read directly from `req.query` without validation and forwarded directly to the SQL query layer in `notificationService.getNotificationsForUser`. Furthermore, date and limit parameters did not share a unified validation pipeline with the other endpoints.

#### Scenarios
| Scenario | Previous Behavior | Expected / New Behavior |
| :--- | :--- | :--- |
| `GET /api/notifications?status=invalid` | Query passed raw to SQL; returned empty list or unexpected SQL execution | Rejected with `400 Bad Request` and structured validation error details |
| `GET /api/notifications?type=invalid` | Query passed raw to SQL; returned empty list or unexpected SQL execution | Rejected with `400 Bad Request` and structured validation error details |
| `GET /api/notifications?limit=-1` or `limit=101` | Silently defaulted or capped | Rejected with `400 Bad Request` |
| `GET /api/notifications?from=invalid-date` | Threw manual `AppError.badRequest` in controller | Validated through Zod schema via `isoDateString` and rejected with `400 Bad Request` |
| Valid queries (`type`, `status`, `from`, `to`, `limit`) | Processed successfully | Processed successfully |

### Solution
1. Wired `validateQuery(getNotificationsQuerySchema)` middleware to `GET /notifications` in `backend/src/routes/notificationsRoutes.ts`.
2. Updated `getNotificationsQuerySchema` in `backend/src/schemas/notificationSchemas.ts` to include `loan_liquidated` in the `type` enum to match `NotificationType` and Swagger schemas, and exported the `GetNotificationsQuery` type.
3. Removed redundant manual `from`/`to` date checks in `backend/src/controllers/notificationController.ts` so that all parameter validation (`type`, `status`, `from`, `to`, `limit`) cleanly flows through the schema validation middleware.
4. Added regression tests in `backend/src/__tests__/notificationFilters.test.ts` covering invalid status, invalid type, non-numeric limit, and out-of-bounds limit rejection.

### Changes
#### `backend/src/schemas/notificationSchemas.ts`
- Added `'loan_liquidated'` to `getNotificationsQuerySchema.type` enum to cover all supported notification types.
- Exported `GetNotificationsQuery` TypeScript type.

#### `backend/src/routes/notificationsRoutes.ts`
- Imported `validateQuery` from `../middleware/validation.js` and `getNotificationsQuerySchema` from `../schemas/notificationSchemas.js`.
- Applied `validateQuery(getNotificationsQuerySchema)` to `router.get('/', ...)`.
- Updated Swagger documentation for `type` query parameter to include `'loan_liquidated'`.

#### `backend/src/controllers/notificationController.ts`
- Removed redundant manual date format validations in `getNotifications` controller since date formats are validated by the Zod query schema middleware.

#### `backend/src/__tests__/notificationFilters.test.ts`
- Added tests asserting rejection of invalid `status`, invalid `type`, non-numeric `limit`, and out-of-bounds `limit` with HTTP 400.

### Regression Tests
| Acceptance Criteria | Test Name | Status |
| :--- | :--- | :--- |
| Invalid `status` yields 400 | `notification filters > rejects invalid status` | Pass |
| Invalid `type` yields 400 | `notification filters > rejects invalid type` | Pass |
| Invalid date format yields 400 | `notification filters > rejects invalid date formats` | Pass |
| Non-numeric limit yields 400 | `notification filters > rejects non-numeric limit` | Pass |
| Out-of-bounds limit yields 400 | `notification filters > rejects out-of-bounds limit` | Pass |
| Valid type filter | `notification filters > filters notifications by type` | Pass |
| Valid status filter | `notification filters > filters notifications by status` | Pass |
| Valid date range filter | `notification filters > filters notifications by date range` | Pass |
| Combined valid filters | `notification filters > combines multiple filters` | Pass |
| Respects valid limit | `notification filters > respects limit parameter` | Pass |

### Testing
```text
PASS src/__tests__/notificationFilters.test.ts
  notification filters
    √ filters notifications by type (1365 ms)
    √ filters notifications by status (22 ms)
    √ filters notifications by date range (23 ms)
    √ combines multiple filters (20 ms)
    √ rejects invalid date formats (58 ms)
    √ respects limit parameter (74 ms)
    √ rejects invalid status (56 ms)
    √ rejects invalid type (27 ms)
    √ rejects non-numeric limit (55 ms)
    √ rejects out-of-bounds limit (40 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        18.704 s
```

`npm run typecheck` output:
```text
> backend@1.0.0 typecheck
> tsc -p tsconfig.build.json --noEmit
```

`npm run build` output:
```text
> backend@1.0.0 build
> tsc -p tsconfig.build.json
```

`npm run lint` output:
```text
> backend@1.0.0 lint
> eslint .

✖ 27 problems (0 errors, 27 warnings)
```

`npm run format:check` output:
```text
> backend@1.0.0 format:check
> prettier --check .

Checking formatting...
All matched files use Prettier code style!
```

### Notes for Reviewers
- No breaking changes: valid queries behave identically to before.
- Query parameter validation matches patterns in `loanRoutes.ts` and other list endpoints.

Closes #1492
