### PR TITLE
fix(backend): add missing min_shares_out param to buildDepositTx

### DIFF
--- a/backend/src/controllers/poolController.ts
+++ b/backend/src/controllers/poolController.ts
@@ -194,21 +194,31 @@ export const getDepositorYieldHistory = asyncHandler(async (req: Request, res: R
  * Build an unsigned LendingPool deposit transaction.
  */
 export const depositToPool = asyncHandler(async (req: Request, res: Response) => {
-  const { depositorPublicKey, token, amount } = req.body as {
+  const { depositorPublicKey, token, amount, minSharesOut } = req.body as {
     depositorPublicKey: string;
     token: string;
     amount: number;
+    minSharesOut: number;
   };
 
   if (!depositorPublicKey || !token || !amount || amount === 0) {
     throw AppError.badRequest('depositorPublicKey, token, and a positive amount are required');
   }
 
+  if (minSharesOut === undefined || minSharesOut < 0) {
+    throw AppError.badRequest('minSharesOut is required and must be non-negative');
+  }
+
   if (depositorPublicKey !== req.user?.publicKey) {
     throw AppError.forbidden('depositorPublicKey must match your authenticated wallet');
   }
 
-  const result = await sorobanService.buildDepositTx(depositorPublicKey, token, amount);
+  const result = await sorobanService.buildDepositTx(
+    depositorPublicKey,
+    token,
+    amount,
+    minSharesOut,
+  );
 
   // Invalidate stale pool stats cache now that a deposit has been initiated
   await invalidateOnDeposit(depositorPublicKey);

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -286,7 +286,7 @@ class SorobanService {
   }
 
   /**
-   * Builds an unsigned Soroban `deposit(provider, token, amount)` transaction
+   * Builds an unsigned Soroban `deposit(provider, token, amount, min_shares_out)` transaction
    * against the LendingPool contract.
    * Returns base64 XDR for the frontend to sign with the user's wallet.
    */
@@ -294,6 +294,7 @@ class SorobanService {
     providerPublicKey: string,
     tokenAddress: string,
     amount: number,
+    minSharesOut: number,
   ): Promise<{ unsignedTxXdr: string; networkPassphrase: string }> {
     const server = this.getRpcServer();
     const contractId = this.getLendingPoolContractId();
@@ -308,6 +309,7 @@ class SorobanService {
       type: 'address',
     });
     const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const minSharesOutScVal = nativeToScVal(BigInt(minSharesOut), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -317,7 +319,7 @@ class SorobanService {
         Operation.invokeContractFunction({
           contract: contractId,
           function: 'deposit',
-          args: [providerScVal, tokenScVal, amountScVal],
+          args: [providerScVal, tokenScVal, amountScVal, minSharesOutScVal],
         }),
       )
       .setTimeout(30)
@@ -330,6 +332,7 @@ class SorobanService {
       provider: providerPublicKey,
       token: tokenAddress,
       amount,
+      minSharesOut,
     });
 
     return { unsignedTxXdr, networkPassphrase: passphrase };


### PR DESCRIPTION
## Overview

This PR fixes a critical bug where `buildDepositTx` was calling `LendingPool::deposit` with only 3 arguments `[provider, token, amount]`, but the contract expects 4 arguments `[provider, token, amount, min_shares_out]`. This caused all pool deposit transactions to fail on-chain with an argument count mismatch.

## Related Issue

Closes #1595

## Changes

### 🔧 Bug Fix

- **[MODIFY]** `backend/src/services/sorobanService.ts` — Added `minSharesOut: number` parameter to `buildDepositTx`. Converts it to `i128` ScVal and appends it as the 4th argument to the `deposit` invocation.
- **[MODIFY]** `backend/src/controllers/poolController.ts` — Updated the `depositToPool` handler to accept `minSharesOut` from the request body, validate it (required, non-negative), and forward it to `buildDepositTx`.

## Verification Results

```
npx tsc -p tsconfig.build.json --noEmit
✅ Passed

npx eslint src/services/sorobanService.ts src/controllers/poolController.ts
✅ Passed

npm test
✅ 638/638 passed (32 skipped, 0 failed)
```

## Acceptance Criteria

| Criteria | Status |
|---|---|
| buildDepositTx passes 4 args matching contract ABI | ✅ `[provider, token, amount, min_shares_out]` |
| minSharesOut is accepted from the API request body | ✅ With validation (required, non-negative) |
| Typecheck passes | ✅ `tsc --noEmit` clean |
| Lint passes | ✅ eslint clean |
| Tests pass | ✅ 638 passed, 0 failed |
| PR references issue with `Closes #` | ✅ Closes #1595 |

