### PR TITLE
docs: document bug-hunt answer key is teacher-only and gitignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ For details on how to report a security vulnerability, please see our [Security 
 
 We welcome contributions from developers of all skill levels! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on how to get started.
 
+### Bug-hunt exercise
+
+Some issues are intentionally seeded bugs used for contributor bug-hunting. The
+answer key for these bugs is **teacher-only** and is deliberately **not** part of
+the public repository (it is listed in `.gitignore` and never committed to the
+default branch) so that browsing the repo does not spoil the exercise. Do not
+commit a `BUG_HUNT_ANSWER_KEY.md` file in any pull request.
+
 ### Environment Variables
 
 See [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) for a full reference of all environment variables across backend, frontend, and scripts. Each `.env.example` file also links to this document.


### PR DESCRIPTION
Closes #1510

## Problem Statement (The Bug)

The issue claims `BUG_HUNT_ANSWER_KEY.md` "sits at the repo root" and appears to catalog intentionally introduced bugs, risking spoiling the seeded bug-hunt exercise for contributors who browse the repo before picking up an issue.

On investigation, this cannot be "patched" because the file does not exist in the repository at all — it is not in the working tree, not in any commit's history, and not on any branch. It is already explicitly protected in `.gitignore`:

```gitignore
# Teacher-only bug-hunt answer key (never commit)
BUG_HUNT_ANSWER_KEY.md
```

Because the file is absent from git history and ignored, the spoiling risk is not something any local edit to the file can resolve — the fix is to permanently codify the policy in the contribution documentation so it can never be reintroduced, which is why this is a documentation-level fix rather than a file deletion.

## Solution Comparison and Decision

- **Option A — Delete `BUG_HUNT_ANSWER_KEY.md` from the default branch.** Infeasible: there is nothing to delete; the file has never been committed.
- **Option B — Move it to a maintainers-only branch / less discoverable location.** Infeasible: the file is not in the repo at all, so there is no location to move. `.gitignore` already keeps it entirely out of git.
- **Option C — Add a README note codifying the policy.** Chosen: documents the existing guard so the answer key stays teacher-only and out of the public default branch, satisfying the "gate it behind a less discoverable location / confirm intent" criterion and preventing accidental commits in future PRs.

Option C is the only correct path because the infrastructure to keep the answer key private already exists (`.gitignore`); the missing piece is the documentation that makes the policy self-explanatory to contributors and maintainers.

## The Change (Code modifications)

Added a "Bug-hunt exercise" note in the Contributing section of `README.md`:

```markdown
### Bug-hunt exercise

Some issues are intentionally seeded bugs used for contributor bug-hunting. The
answer key for these bugs is **teacher-only** and is deliberately **not** part of
the public repository (it is listed in `.gitignore` and never committed to the
default branch) so that browsing the repo does not spoil the exercise. Do not
commit a `BUG_HUNT_ANSWER_KEY.md` file in any pull request.
```

| Entry point | Before | After |
|---|---|---|
| Repo root | (no file present) | (no file present) |
| `.gitignore` | Already ignores `BUG_HUNT_ANSWER_KEY.md` | Unchanged |
| `README.md` | No mention of the answer-key policy | Documents that the key is teacher-only and must never be committed |

## Compatibility Note (On INTERFACE_VERSION)

No interface version change. This is a documentation-only change to `README.md` and touches no API, contract ABI, or runtime behavior, so a version bump is unnecessary and would add churn with no benefit.

## Incidental Fixes

- Reinforces the existing (previously undocumented) never-commit policy for `BUG_HUNT_ANSWER_KEY.md` by explaining its purpose in the README.
- States explicitly that a `BUG_HUNT_ANSWER_KEY.md` file must not be committed in any pull request, providing an unambiguous guideline for future contributors.

## Testing

Not applicable to this change as it is documentation-only with no runtime code path. There is no endpoint, guard, or UI to exercise. The change was verified by confirming the issue's premise:

- `git ls-files | grep -i 'BUG_HUNT_ANSWER_KEY'` → no tracked file
- `git log --all -- 'BUG_HUNT_ANSWER_KEY.md'` → no commits ever touched it
- `git check-ignore -v BUG_HUNT_ANSWER_KEY.md` → `.gitignore:24:BUG_HUNT_ANSWER_KEY.md` (ignored)

These checks prove the answer key is not discoverable in the public default branch and that the `.gitignore` guard is active. No test suite failures are introduced since no code is changed.

## Additional Notes

The branch is `fix/issue-1510-bug-hunt-answer-key-docs`, created from the current `main`. Scope is limited to `README.md`; no backend, frontend, contract, or script modules are affected.