### PR TITLE
docs(backend): add JSDoc to buildDepositorYieldHistory

### DIFF
--- a/backend/src/services/yieldHistoryService.ts
+++ b/backend/src/services/yieldHistoryService.ts
@@ -135,6 +135,34 @@ export function normalizeYieldHistoryDays(days: number | undefined): YieldHistor
   return YIELD_HISTORY_DEFAULT_DAYS;
 }
 
+/**
+ * Reconstructs a daily depositor yield time series by joining pool-level and
+ * depositor-level contract events.
+ *
+ * Pool-level events (Deposit, Withdraw, EmergencyWithdraw, YieldDistributed) are
+ * replayed to rebuild the pool's running balance and total share count, while
+ * depositor-level events (Deposit, Withdraw, EmergencyWithdraw) are replayed to
+ * track the depositor's accumulated share count and cost basis over time. For
+ * each daily bucket the depositor's share position is re-valued against the
+ * current pool state, and an on-chain `currentSharePrice` overrides the final
+ * day's valuation when provided. The result is one point per day representing
+ * the depositor's cost basis, estimated current value, and net yield.
+ *
+ * @param address - The wallet address whose depositor history is being built.
+ * @param _token - The pool token address passed through as part of the public
+ *   signature. Currently unused inside this function: the implementation
+ *   queries events by `address` and `LENDING_POOL_CONTRACT_ID` only, and the
+ *   caller uses the token independently to fetch the on-chain share price.
+ * @param days - The lookback window (7, 30, or 90) used to select the events
+ *   and the daily buckets that make up the returned time series.
+ * @param currentSharePrice - Optional on-chain share price (scaled by
+ *   SHARE_PRICE_SCALE) used to value the depositor's shares on the final day.
+ * @returns Daily `YieldHistoryPoint[]` entries, one per bucket date, each with
+ *   an ISO `timestamp`, the depositor's accumulated `depositedValue` (cost
+ *   basis), the estimated `currentValue` of the share position, and the clamped
+ *   `netYield` (currentValue - depositedValue). Leading buckets with no
+ *   depositor activity are trimmed.
+ */
 export async function buildDepositorYieldHistory(
   address: string,
   _token: string,


### PR DESCRIPTION
## Summary

Docs-only change that adds a JSDoc block directly above `buildDepositorYieldHistory` in `backend/src/services/yieldHistoryService.ts`. No behavioral changes, no logic changes, no refactoring.

Closes #1014

## What was added

A single comment block describing:

- **Purpose** — the function joins pool-level (`Deposit`, `Withdraw`, `EmergencyWithdraw`, `YieldDistributed`) and depositor-level (`Deposit`, `Withdraw`, `EmergencyWithdraw`) contract events, replays them to rebuild the pool's running balance/total shares and the depositor's share count/cost basis, and re-values the depositor's position each day to produce a daily time series.
- **Parameters** — `address`, `_token`, `days`, `currentSharePrice`.
- **Return value** — the `YieldHistoryPoint[]` shape (`timestamp`, `depositedValue`, `currentValue`, `netYield`).

Only `backend/src/services/yieldHistoryService.ts` changed: `28 insertions (+), 0 deletions (-)` of comment lines only.

## `_token` unused status

`_token` is currently **unused inside this function**. Traced via `git blame` and `git log -S "_token" -- backend/src/services/yieldHistoryService.ts`: it has been part of the signature since the function was introduced (commit `26027f2`, "feat: add depositor yield history API and loan manager read views"), and the body never references it — the implementation queries `contract_events` by `address` and `LENDING_POOL_CONTRACT_ID` only. The caller (`poolController.getDepositorYieldHistory`, line 171) passes the token and uses it independently to fetch the on-chain share price via `sorobanService.getSharePrice(token)`. There is no comment or commit hinting at a specific planned use, so the JSDoc notes it honestly as "currently unused inside this function" and explains the caller's separate use. The leading underscore matches the repo's `@typescript-eslint/no-unused-vars` `argsIgnorePattern: '^_'` convention.

## Verification (docs-only diff confirmed)

- `npm test` → `Test Suites: 5 skipped, 87 passed, 87 of 92 total` / `Tests: 32 skipped, 638 passed, 670 total` — **0 failed**. (A pre-existing teardown warning from `adminReindex.test.ts` — "trying to require a file after the Jest environment has been torn down" — is unrelated to this docs change.)
- `npm run lint` → **0 errors** (33 pre-existing `no-explicit-any`/`no-unused-vars` warnings, none in `yieldHistoryService.ts`; the docs comment added no new lint violations and there is no jsdoc-specific ESLint rule in the repo config).
- `npm run typecheck` → **clean**, no errors.
- `git diff --numstat` → `28 0 backend/src/services/yieldHistoryService.ts` — exclusively added comment lines, no other file touched.
