### PR TITLE
fix(frontend): scope toast id per mutation call in useContractMutation #1487

### DIFF
--- a/frontend/src/app/hooks/useContractMutation.test.tsx
+++ b/frontend/src/app/hooks/useContractMutation.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * hooks/useContractMutation.test.tsx
+ *
+ * Tests for #1487: useContractMutation must scope the toast id per mutation call so
+ * that overlapping mutations each resolve their own pending toast.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useMutation } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useContractMutation } from "./useContractMutation";
+import { useToastStore } from "../stores/useToastStore";
+
+function createTestHarness() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+interface Deferred {
+  promise: Promise<{ txHash: string }>;
+  resolve: (value: { txHash: string }) => void;
+  reject: (reason: unknown) => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve!: Deferred["resolve"];
+  let reject!: Deferred["reject"];
+  const promise = new Promise<{ txHash: string }>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useContractMutation concurrent toasts", () => {
+  beforeEach(() => {
+    useToastStore.getState().clearToasts();
+  });
+
+  it("resolves each concurrent mutation's own toast to success without leaving a pending toast", async () => {
+    const { wrapper } = createTestHarness();
+    const deferredA = createDeferred();
+    const deferredB = createDeferred();
+
+    const mutationFn = jest.fn((id: string) =>
+      id === "A" ? deferredA.promise : deferredB.promise,
+    );
+
+    const { result } = renderHook(
+      () =>
+        useContractMutation(useMutation({ mutationFn }), {
+          pendingMessage: "Processing...",
+          successMessage: "Done!",
+        }),
+      { wrapper },
+    );
+
+    const promiseA = result.current.mutateAsync("A");
+    const promiseB = result.current.mutateAsync("B");
+
+    await waitFor(() => {
+      const pending = useToastStore.getState().toasts.filter((t) => t.type === "info");
+      expect(pending).toHaveLength(2);
+    });
+
+    const pendingIds = useToastStore
+      .getState()
+      .toasts.filter((t) => t.type === "info")
+      .map((t) => t.id);
+
+    deferredA.resolve({ txHash: "hash-a" });
+    deferredB.resolve({ txHash: "hash-b" });
+
+    await Promise.all([promiseA, promiseB]);
+
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.filter((t) => t.type === "info")).toHaveLength(0);
+      expect(toasts.filter((t) => t.type === "success")).toHaveLength(2);
+    });
+
+    const successIds = useToastStore
+      .getState()
+      .toasts.filter((t) => t.type === "success")
+      .map((t) => t.id);
+
+    expect(successIds.sort()).toEqual(pendingIds.sort());
+    expect(successIds).toHaveLength(2);
+  });
+
+  it("resolves each concurrent mutation's own toast to error without leaving a pending toast", async () => {
+    const { wrapper } = createTestHarness();
+    const deferredA = createDeferred();
+    const deferredB = createDeferred();
+
+    const mutationFn = jest.fn((id: string) =>
+      id === "A" ? deferredA.promise : deferredB.promise,
+    );
+
+    const { result } = renderHook(
+      () =>
+        useContractMutation(useMutation({ mutationFn }), {
+          pendingMessage: "Processing...",
+          errorMessage: "Failed!",
+        }),
+      { wrapper },
+    );
+
+    const promiseA = result.current.mutateAsync("A");
+    const promiseB = result.current.mutateAsync("B");
+
+    await waitFor(() => {
+      const pending = useToastStore.getState().toasts.filter((t) => t.type === "info");
+      expect(pending).toHaveLength(2);
+    });
+
+    const pendingIds = useToastStore
+      .getState()
+      .toasts.filter((t) => t.type === "info")
+      .map((t) => t.id);
+
+    deferredA.reject(new Error("boom-a"));
+    deferredB.reject(new Error("boom-b"));
+
+    await Promise.allSettled([promiseA, promiseB]);
+
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.filter((t) => t.type === "info")).toHaveLength(0);
+      expect(toasts.filter((t) => t.type === "error")).toHaveLength(2);
+    });
+
+    const errorIds = useToastStore
+      .getState()
+      .toasts.filter((t) => t.type === "error")
+      .map((t) => t.id);
+
+    expect(errorIds.sort()).toEqual(pendingIds.sort());
+    expect(errorIds).toHaveLength(2);
+  });
+
+  it("resolves mixed success/error outcomes to their own toasts", async () => {
+    const { wrapper } = createTestHarness();
+    const deferredA = createDeferred();
+    const deferredB = createDeferred();
+
+    const mutationFn = jest.fn((id: string) =>
+      id === "A" ? deferredA.promise : deferredB.promise,
+    );
+
+    const { result } = renderHook(
+      () =>
+        useContractMutation(useMutation({ mutationFn }), {
+          pendingMessage: "Processing...",
+          successMessage: "Done!",
+          errorMessage: "Failed!",
+        }),
+      { wrapper },
+    );
+
+    const promiseA = result.current.mutateAsync("A");
+    const promiseB = result.current.mutateAsync("B");
+
+    await waitFor(() => {
+      const pending = useToastStore.getState().toasts.filter((t) => t.type === "info");
+      expect(pending).toHaveLength(2);
+    });
+
+    const pendingIds = useToastStore
+      .getState()
+      .toasts.filter((t) => t.type === "info")
+      .map((t) => t.id);
+
+    deferredA.resolve({ txHash: "hash-a" });
+    deferredB.reject(new Error("boom-b"));
+
+    await Promise.allSettled([promiseA, promiseB]);
+
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts.filter((t) => t.type === "info")).toHaveLength(0);
+      expect(toasts.filter((t) => t.type === "success")).toHaveLength(1);
+      expect(toasts.filter((t) => t.type === "error")).toHaveLength(1);
+    });
+
+    const remainingIds = useToastStore
+      .getState()
+      .toasts.map((t) => t.id)
+      .sort();
+    expect(remainingIds).toEqual(pendingIds.sort());
+  });
+});

--- a/frontend/src/app/hooks/useContractMutation.ts
+++ b/frontend/src/app/hooks/useContractMutation.ts
@@ -19,7 +19,7 @@
 
 import { type UseMutationResult } from "@tanstack/react-query";
 import { useContractToast } from "./useContractToast";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useGamificationStore } from "../stores/useGamificationStore";
 
 interface ContractMutationOptions {
@@ -51,7 +51,6 @@ export function useContractMutation<TData extends { txHash?: string }, TError, T
 ) {
   const toast = useContractToast();
   const gamificationStore = useGamificationStore();
-  const toastIdRef = useRef<string | number | null>(null);
 
   const {
     pendingMessage = "Processing transaction...",
@@ -84,15 +83,13 @@ export function useContractMutation<TData extends { txHash?: string }, TError, T
     variables: TVariables,
     mutationOptions?: Parameters<typeof mutation.mutate>[1],
   ) => {
-    if (!disableToast) {
-      toastIdRef.current = toast.showPending(pendingMessage);
-    }
+    const toastId = !disableToast ? toast.showPending(pendingMessage) : null;
 
     mutation.mutate(variables, {
       ...mutationOptions,
       onSuccess: (data, vars, onMutateResult, context) => {
-        if (!disableToast && toastIdRef.current !== null) {
-          toast.showSuccess(toastIdRef.current, {
+        if (!disableToast && toastId !== null) {
+          toast.showSuccess(toastId, {
             successMessage,
             txHash: data.txHash,
             network,
@@ -102,8 +99,8 @@ export function useContractMutation<TData extends { txHash?: string }, TError, T
         mutationOptions?.onSuccess?.(data, vars, onMutateResult, context);
       },
       onError: (error, vars, onMutateResult, context) => {
-        if (!disableToast && toastIdRef.current !== null) {
-          toast.showError(toastIdRef.current, {
+        if (!disableToast && toastId !== null) {
+          toast.showError(toastId, {
             errorMessage: error instanceof Error ? error.message : errorMessage,
           });
         }
@@ -116,15 +113,13 @@ export function useContractMutation<TData extends { txHash?: string }, TError, T
     variables: TVariables,
     mutationOptions?: Parameters<typeof mutation.mutateAsync>[1],
   ) => {
-    if (!disableToast) {
-      toastIdRef.current = toast.showPending(pendingMessage);
-    }
+    const toastId = !disableToast ? toast.showPending(pendingMessage) : null;
 
     try {
       const data = await mutation.mutateAsync(variables, mutationOptions);
 
-      if (!disableToast && toastIdRef.current !== null) {
-        toast.showSuccess(toastIdRef.current, {
+      if (!disableToast && toastId !== null) {
+        toast.showSuccess(toastId, {
           successMessage,
           txHash: data.txHash,
           network,
@@ -135,8 +130,8 @@ export function useContractMutation<TData extends { txHash?: string }, TError, T
 
       return data;
     } catch (error) {
-      if (!disableToast && toastIdRef.current !== null) {
-        toast.showError(toastIdRef.current, {
+      if (!disableToast && toastId !== null) {
+        toast.showError(toastId, {
           errorMessage: error instanceof Error ? error.message : errorMessage,
         });
       }


### PR DESCRIPTION
## Overview

This PR fixes a bug in `useContractMutation` where a single shared `toastIdRef` was overwritten on every `mutate`/`mutateAsync` call. When two wrapped mutations were in flight at once (e.g. two deposits, or a deposit plus a repay), the second call overwrote `toastIdRef.current` before the first settled. The first mutation's `onSuccess`/`onError` then updated the second toast, and the first pending toast was never resolved and stayed on screen indefinitely.

The fix scopes the toast id per mutation call so that each in-flight mutation tracks and resolves its own toast.

## Related Issue

Closes [#1487](https://github.com/LabsCrypt/remitlend/issues/1487)

## Changes

- **[MODIFY]** `src/app/hooks/useContractMutation.ts`
  - Removed the shared `toastIdRef`.
  - Each `mutate`/`mutateAsync` call now captures its own local `toastId` from `showPending`.
  - `onSuccess`/`onError` resolve only the toast for that specific call.
- **[ADD]** `src/app/hooks/useContractMutation.test.tsx`
  - Fires two concurrent mutations (success/success, error/error, and mixed outcomes) using deferred promises.
  - Asserts both pending toasts exist while in flight and both resolve with no pending toast left behind.

## Verification Results

```
npx jest src/app/hooks/useContractMutation.test.tsx
✅ 3/3 passed

Full hooks suite:
✅ 36/36 passed

Prettier: ✅ all files formatted
ESLint:   ✅ no issues
Typecheck: no new errors (pre-existing lucide-react declaration warnings only)
```

Regression check: temporarily reverted the hook to the shared-ref implementation and re-ran the tests — all 3 failed with exactly the reported symptom (a pending `info` toast left unresolved), confirming the tests catch the original bug and the fix resolves it.

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Toast id is scoped per mutation call rather than a shared ref | ✅ Each call captures its own `toastId` |
| Overlapping mutations each resolve their own toast | ✅ Tests fire two concurrent mutations |
| No pending toast is left unresolved when mutations overlap | ✅ 0 pending toasts remain after both settle |
