### PR TITLE
test(frontend): add soroban.ts unit tests for XDR builders (#1489)

### DIFF
--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -10,12 +10,113 @@ if (typeof global.TextDecoder === "undefined") {
 /* eslint-disable @typescript-eslint/no-require-imports */
 const {
   Account,
+  Address,
   Keypair,
   rpc,
   scValToNative,
   TransactionBuilder,
 } = require("@stellar/stellar-sdk");
-const { buildUnsignedRepaymentXdr } = require("./soroban");
+const { buildUnsignedLoanRequestXdr, buildUnsignedRepaymentXdr } = require("./soroban");
+
+const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+describe("buildUnsignedLoanRequestXdr", () => {
+  const borrower = Keypair.random().publicKey();
+  const contractId = Keypair.random().publicKey();
+
+  beforeEach(() => {
+    jest.spyOn(rpc.Server.prototype, "getAccount").mockResolvedValue(new Account(borrower, "100"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("invokes the request_loan function on the given contract", async () => {
+    const xdrString = await buildUnsignedLoanRequestXdr({
+      borrower,
+      amount: 1000,
+      term: 12,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+    expect(op.type).toBe("invokeHostFunction");
+
+    if (op.type === "invokeHostFunction") {
+      const invokeArgs = op.func.invokeContract();
+      expect(invokeArgs.functionName().toString()).toBe("request_loan");
+      expect(Address.fromScAddress(invokeArgs.contractAddress()).toString()).toBe(contractId);
+    }
+  });
+
+  it("orders arguments as [borrower, amount, term]", async () => {
+    const term = 12;
+
+    const xdrString = await buildUnsignedLoanRequestXdr({
+      borrower,
+      amount: 1000,
+      term,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      expect(args).toHaveLength(3);
+
+      const borrowerVal = scValToNative(args[0]);
+      const termVal = scValToNative(args[2]);
+
+      expect(borrowerVal).toBe(borrower);
+      expect(termVal).toBe(term);
+    }
+  });
+
+  it("encodes the full loan amount into the XDR, not a tenth of it", async () => {
+    const inputAmount = 1000;
+
+    const xdrString = await buildUnsignedLoanRequestXdr({
+      borrower,
+      amount: inputAmount,
+      term: 12,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      const amountVal = scValToNative(args[1]);
+
+      expect(amountVal).toBe(BigInt(inputAmount));
+      expect(amountVal).not.toBe(BigInt(inputAmount / 10));
+    }
+  });
+
+  it("floors fractional amounts before encoding as i128", async () => {
+    const xdrString = await buildUnsignedLoanRequestXdr({
+      borrower,
+      amount: 1000.75,
+      term: 12,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      const amountVal = scValToNative(args[1]);
+
+      expect(amountVal).toBe(BigInt(1000));
+    }
+  });
+});
 
 describe("buildUnsignedRepaymentXdr", () => {
   const borrower = Keypair.random().publicKey();
@@ -29,6 +130,50 @@ describe("buildUnsignedRepaymentXdr", () => {
     jest.restoreAllMocks();
   });
 
+  it("invokes the repay function on the given contract", async () => {
+    const xdrString = await buildUnsignedRepaymentXdr({
+      borrower,
+      loanId: "42",
+      amount: 1000,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+    expect(op.type).toBe("invokeHostFunction");
+
+    if (op.type === "invokeHostFunction") {
+      const invokeArgs = op.func.invokeContract();
+      expect(invokeArgs.functionName().toString()).toBe("repay");
+      expect(Address.fromScAddress(invokeArgs.contractAddress()).toString()).toBe(contractId);
+    }
+  });
+
+  it("orders arguments as [borrower, loanId, amount]", async () => {
+    const loanId = "42";
+
+    const xdrString = await buildUnsignedRepaymentXdr({
+      borrower,
+      loanId,
+      amount: 1000,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      expect(args).toHaveLength(3);
+
+      const borrowerVal = scValToNative(args[0]);
+      const loanIdVal = scValToNative(args[1]);
+
+      expect(borrowerVal).toBe(borrower);
+      expect(loanIdVal).toBe(BigInt(loanId));
+    }
+  });
+
   it("encodes the full repayment amount into the XDR, not a tenth of it", async () => {
     const inputAmount = 1000;
     const loanId = "42";
@@ -40,7 +185,7 @@ describe("buildUnsignedRepaymentXdr", () => {
       contractId,
     });
 
-    const tx = TransactionBuilder.fromXDR(xdrString, "Test SDF Network ; September 2015");
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
 
     const op = tx.operations[0];
     expect(op.type).toBe("invokeHostFunction");
@@ -54,6 +199,25 @@ describe("buildUnsignedRepaymentXdr", () => {
       expect(loanIdVal).toBe(BigInt(loanId));
       expect(amountVal).toBe(BigInt(inputAmount));
       expect(amountVal).not.toBe(BigInt(inputAmount / 10));
+    }
+  });
+
+  it("floors fractional amounts before encoding as i128", async () => {
+    const xdrString = await buildUnsignedRepaymentXdr({
+      borrower,
+      loanId: "42",
+      amount: 1000.5,
+      contractId,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      const amountVal = scValToNative(args[2]);
+
+      expect(amountVal).toBe(BigInt(1000));
     }
   });
 });

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -42,7 +42,7 @@ export async function buildUnsignedLoanRequestXdr({
   const server = new rpc.Server(rpcUrl);
   const source = await server.getAccount(borrower);
   const amountScVal = nativeToScVal(BigInt(Math.floor(amount)), { type: "i128" });
-  const termScVal = nativeToScVal(BigInt(term), { type: "u32" });
+  const termScVal = nativeToScVal(term, { type: "u32" });
   const borrowerScVal = new Address(borrower).toScVal();
 
   const tx = new TransactionBuilder(source, {


### PR DESCRIPTION
## Summary

Closes #1489.

`buildUnsignedLoanRequestXdr` and `buildUnsignedRepaymentXdr` (`frontend/src/app/utils/soroban.ts`) assemble the critical contract-call XDRs — including argument order and i128/u32/u64 scaling — yet had zero unit test coverage. This is exactly where two shipped bugs already lived (argument order #1350, tenth-amount scaling #1368), so the file was high risk and unguarded.

- Added `soroban.test.ts` coverage for `buildUnsignedLoanRequestXdr`:
  - asserts `request_loan` is invoked on the given contract
  - asserts argument order `[borrower, amount, term]`
  - asserts the full amount is encoded (not a tenth of it)
  - asserts fractional amounts are floored before i128 encoding
- Extended existing `buildUnsignedRepaymentXdr` coverage with function/contract invocation and argument order `[borrower, loanId, amount]` assertions (the tenth-amount regression test already existed from #1368).
- No dependence on a live network — `rpc.Server.prototype.getAccount` is mocked and only XDR construction is exercised.

## Bug found and fixed

Writing the new loan-request tests surfaced a real, previously untested bug: `term` was passed to `nativeToScVal` as a `BigInt` with `type: "u32"`. This builds an `ScVal` successfully, but throws `TypeError: XDR Write Error: invalid u32 value` once the transaction is serialized via `tx.toXDR()` — meaning `buildUnsignedLoanRequestXdr` was completely broken for any real caller. `u32` values must be passed as a plain `Number`, unlike `u64`/`i128` which need `BigInt`. Fixed in `soroban.ts`, and updated the corresponding test assertion (`scValToNative` on a u32 returns a `Number`, not a `BigInt`).

## Test plan

- [x] `npx jest soroban.test.ts` — 8/8 tests passing
- [x] No live network calls (RPC `getAccount` mocked)
- [x] Confirmed the fix against a minimal repro isolating `nativeToScVal(BigInt(n), { type: "u32" })` vs `nativeToScVal(n, { type: "u32" })`