### PR TITLE
fix(backend): replace duplicated isValidStellarAddress in remittanceService with shared util (Closes #1012)

### DIFF
--- a/backend/src/services/remittanceService.ts
+++ b/backend/src/services/remittanceService.ts
@@ -5,6 +5,7 @@ import { query } from '../db/connection.js';
 import { withTransaction } from '../db/transaction.js';
 import { AppError } from '../errors/AppError.js';
 import logger from '../utils/logger.js';
+import { isValidStellarAddress } from '../utils/stellar.js';
 
 export interface CreateRemittancePayload {
   recipientAddress: string;
@@ -28,15 +29,6 @@ export interface Remittance {
   xdr?: string;
   createdAt: string;
   updatedAt: string;
-}
-
-/**
- * Validates a Stellar public key format
- */
-function isValidStellarAddress(address: string): boolean {
-  if (!address || typeof address !== 'string') return false;
-  if (address.length !== 56 || !address.startsWith('G')) return false;
-  return /^G[A-Z2-7]{55}$/.test(address);
 }
 
 const normalizeCurrency = (currency: string): string => currency.trim().toUpperCase();


### PR DESCRIPTION
Closes #1012

### Summary of Changes (Closes #1012)

- Imported `isValidStellarAddress` from `../utils/stellar.js` in `backend/src/services/remittanceService.ts`.
- Removed the local duplicate `isValidStellarAddress` implementation from `remittanceService.ts`.
- Standardized address validation across remittance services to use the shared source of truth.

### Verification
- Ran `npm test -- src/__tests__/remittanceService.test.ts`: 10 passed, 0 failed.
- Ran `npm run typecheck` (`tsc -p tsconfig.build.json --noEmit`): Passed with 0 errors.
- Ran `eslint` on modified and test files: Passed with 0 errors.