### PR TITLE
fix(contracts): migrate and clean up RecipientCommitment on RemittanceNFT transfer (Closes #1592)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -544,9 +544,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -313,6 +313,10 @@ impl RemittanceNFT {
                 .storage()
                 .persistent()
                 .has(&DataKey::Score(user.clone()))
+            || env
+                .storage()
+                .persistent()
+                .has(&DataKey::RecipientCommitment(user.clone()))
     }
 
     fn burn_internal(env: &Env, user: &Address) {
@@ -334,6 +338,9 @@ impl RemittanceNFT {
         env.storage()
             .persistent()
             .remove(&DataKey::TransferCooldown(user.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RecipientCommitment(user.clone()));
 
         let burned_key = DataKey::Burned(user.clone());
         env.storage().persistent().set(&burned_key, &true);
@@ -1007,6 +1014,20 @@ impl RemittanceNFT {
             env.storage().persistent().set(&to_seized_key, &true);
             Self::bump_persistent_ttl(&env, &to_seized_key);
             env.storage().persistent().remove(&from_seized_key);
+        }
+
+        let from_commitment_key = DataKey::RecipientCommitment(from.clone());
+        if let Some(commitment) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, BytesN<32>>(&from_commitment_key)
+        {
+            let to_commitment_key = DataKey::RecipientCommitment(to.clone());
+            env.storage()
+                .persistent()
+                .set(&to_commitment_key, &commitment);
+            Self::bump_persistent_ttl(&env, &to_commitment_key);
+            env.storage().persistent().remove(&from_commitment_key);
         }
 
         env.storage()

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -983,6 +983,10 @@ fn test_transfer_moves_identity_state_to_new_wallet() {
     assert_eq!(client.get_default_count(&old_wallet), 0);
     assert!(!client.is_seized(&old_wallet));
     assert_eq!(client.get_score_history(&old_wallet, &0, &10).len(), 0);
+    assert_eq!(
+        client.try_get_recipient_commitment(&old_wallet),
+        Err(Ok(NftError::CommitmentMissing))
+    );
 
     let metadata = client.get_metadata(&new_wallet).unwrap();
     assert_eq!(metadata.score, 503);
@@ -990,6 +994,50 @@ fn test_transfer_moves_identity_state_to_new_wallet() {
     assert_eq!(client.get_default_count(&new_wallet), 1);
     assert!(client.is_seized(&new_wallet));
     assert_eq!(client.get_score_history(&new_wallet, &0, &10).len(), 1);
+    assert_eq!(
+        client.get_recipient_commitment(&new_wallet),
+        create_test_commitment(&env, 1)
+    );
+}
+
+#[test]
+fn test_transfer_migrates_recipient_commitment() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    let commitment = create_test_commitment(&env, 42);
+    client.mint(
+        &sender,
+        &600,
+        &create_test_hash(&env, 1),
+        &create_test_uri(&env),
+        &commitment,
+        &None,
+    );
+
+    assert_eq!(client.get_recipient_commitment(&sender), commitment);
+    assert_eq!(
+        client.try_get_recipient_commitment(&recipient),
+        Err(Ok(NftError::CommitmentMissing))
+    );
+
+    client.transfer(&sender, &recipient, &None);
+
+    // Sender's commitment is removed
+    assert_eq!(
+        client.try_get_recipient_commitment(&sender),
+        Err(Ok(NftError::CommitmentMissing))
+    );
+    // Recipient now has the valid commitment
+    assert_eq!(client.get_recipient_commitment(&recipient), commitment);
 }
 
 #[test]

--- a/contracts/remittance_nft/test_snapshots/test/test_burn_blocks_authorized_remint_without_admin_approval.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_burn_blocks_authorized_remint_without_admin_approval.1.json
@@ -374,51 +374,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "RecipientCommitment"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "RecipientCommitment"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_active.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_active.1.json
@@ -362,7 +362,7 @@
                   "symbol": "RecipientCommitment"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -382,7 +382,7 @@
                       "symbol": "RecipientCommitment"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },

--- a/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_expired.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_get_transfer_cooldown_remaining_expired.1.json
@@ -361,7 +361,7 @@
                   "symbol": "RecipientCommitment"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -381,7 +381,7 @@
                       "symbol": "RecipientCommitment"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },

--- a/contracts/remittance_nft/test_snapshots/test/test_is_remint_approved_true_after_approval.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_is_remint_approved_true_after_approval.1.json
@@ -328,51 +328,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "RecipientCommitment"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "RecipientCommitment"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": {
-              "vec": [
-                {
                   "symbol": "RemintApproval"
                 },
                 {

--- a/contracts/remittance_nft/test_snapshots/test/test_record_default_auto_burns_after_threshold.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_record_default_auto_burns_after_threshold.1.json
@@ -429,51 +429,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "RecipientCommitment"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "RecipientCommitment"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/contracts/remittance_nft/test_snapshots/test/test_transfer_enforces_cooldown_before_retransfer.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_transfer_enforces_cooldown_before_retransfer.1.json
@@ -361,7 +361,7 @@
                   "symbol": "RecipientCommitment"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -381,7 +381,7 @@
                       "symbol": "RecipientCommitment"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },

--- a/contracts/remittance_nft/test_snapshots/test/test_transfer_moves_identity_state_to_new_wallet.1.json
+++ b/contracts/remittance_nft/test_snapshots/test/test_transfer_moves_identity_state_to_new_wallet.1.json
@@ -136,6 +136,8 @@
     [],
     [],
     [],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -526,7 +528,7 @@
                   "symbol": "RecipientCommitment"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -546,7 +548,7 @@
                       "symbol": "RecipientCommitment"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },


### PR DESCRIPTION
Closes #1592

### Summary of Changes (Closes #1592)

#### 1. Transfer Commitment Migration
- Updated `RemittanceNFT::transfer` in `contracts/remittance_nft/src/lib.rs` to migrate `DataKey::RecipientCommitment(from)` to `DataKey::RecipientCommitment(to)`.
- Removed orphaned stale commitment from the `from` sender storage key on transfer.

#### 2. Storage & Burn Consistency
- Updated `has_any_remittance_state` to check `DataKey::RecipientCommitment` ensuring the destination address has no existing commitment state prior to transfer.
- Updated `burn_internal` to remove `DataKey::RecipientCommitment` when an NFT is burned.

#### 3. Test Suite
- Updated `test_transfer_moves_identity_state_to_new_wallet` in `contracts/remittance_nft/src/test.rs` to assert that the old wallet commitment returns `CommitmentMissing` and the new wallet receives the commitment.
- Added dedicated test `test_transfer_migrates_recipient_commitment` verifying commitment transfer and sender cleanup.

### Verification
- Ran `cargo test -p remittance_nft`: 76 passed, 0 failed.
- Ran workspace tests `cargo test`: 121 passed, 0 failed.