### PR TITLE
fix(frontend): fall back to English when locale messages fail to load

### DIFF
--- a/frontend/i18n.config.test.ts
+++ b/frontend/i18n.config.test.ts
@@ -1,0 +1,30 @@
+import en from "./messages/en.json";
+import es from "./messages/es.json";
+import i18nConfig from "./i18n.config";
+
+jest.mock("next-intl/server", () => ({
+  getRequestConfig: (configFn: unknown) => configFn,
+}));
+
+type RequestConfigFunction = (args: { locale?: string }) => Promise<{
+  locale: string;
+  messages: typeof en;
+}>;
+
+const requestConfig = i18nConfig as unknown as RequestConfigFunction;
+
+describe("i18n.config", () => {
+  it("loads messages for a supported locale", async () => {
+    const config = await requestConfig({ locale: "es" });
+
+    expect(config.locale).toBe("es");
+    expect(config.messages).toEqual(es);
+  });
+
+  it("falls back to English messages when the requested locale file cannot be loaded", async () => {
+    const config = await requestConfig({ locale: "xx" });
+
+    expect(config.locale).toBe("xx");
+    expect(config.messages).toEqual(en);
+  });
+});

--- a/frontend/i18n.config.ts
+++ b/frontend/i18n.config.ts
@@ -1,8 +1,17 @@
 import { getRequestConfig } from "next-intl/server";
 
 export default getRequestConfig(async ({ locale }) => {
-  return {
-    locale: locale || "en",
-    messages: (await import(`./messages/${locale || "en"}.json`)).default,
-  };
+  const resolvedLocale = locale || "en";
+
+  try {
+    return {
+      locale: resolvedLocale,
+      messages: (await import(`./messages/${resolvedLocale}.json`)).default,
+    };
+  } catch {
+    return {
+      locale: resolvedLocale,
+      messages: (await import("./messages/en.json")).default,
+    };
+  }
 });


### PR DESCRIPTION
PR #1503: Fix i18n locale fallback when a messages file fails to load

## Summary


The frontend `i18n.config.ts` dynamically imports the messages JSON for the
resolved locale with no error handling. If the locale segment resolves to a
value outside `en`, `es`, or `tl` — or the file is missing or malformed — the
unhandled import rejection bubbles up and breaks the request instead of
gracefully falling back to English.

## Changes

- **`frontend/i18n.config.ts`**
  - Wrap the dynamic import of `./messages/${locale}.json` in a `try/catch`.
  - On failure, fall back to the English messages file (`./messages/en.json`).
  - Preserve the originally resolved locale in the returned config so
    `next-intl` routing/lang-switching behavior is unchanged.

- **`frontend/i18n.config.test.ts`** (new)
  - Unit test verifying a supported locale loads its messages.
  - Unit test verifying an unsupported/missing locale (`xx`) falls back to the
    English messages.

## Acceptance criteria

- [x] Dynamic import wrapped in try/catch
- [x] Falls back to `frontend/messages/en.json` on failure
- [x] Unit test covering the fallback path

## Out of scope

- Adding new locales.

## Verification

- `npx jest i18n.config.test.ts` — 2 passed
- `npx tsc --noEmit` — no errors
- `npx prettier --check .` — clean

> Note: The unrelated `RemittanceForm.test.tsx` suite has pre-existing failures
> on `main` (interaction-timing timeouts and a character-count assertion). These
> are reproduced on a clean checkout and are not touched by this change.

Closes #1503 