### PR TITLE
fix(backend): add missing term parameter to buildRequestLoanTx (Closes #1596)

### DIFF
--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -655,10 +655,13 @@ export const getLoanAmortizationSchedule = asyncHandler(async (req: Request, res
  * POST /api/loans/request
  */
 export const requestLoan = asyncHandler(async (req: Request, res: Response) => {
-  const { amount, borrowerPublicKey } = req.body as {
+  const { amount, borrowerPublicKey, term } = req.body as {
     amount: number;
     borrowerPublicKey: string;
+    term?: number;
   };
+
+  const termLedgers = term ?? DEFAULT_TERM_LEDGERS;
 
   if (borrowerPublicKey !== req.user?.publicKey) {
     throw AppError.forbidden(
@@ -684,8 +687,8 @@ export const requestLoan = asyncHandler(async (req: Request, res: Response) => {
     }
   }
 
-  // Idempotency: return existing unsigned tx if recently built for this borrower/amount
-  const cacheKey = `pending_loan_tx:${borrowerPublicKey}:${amount}`;
+  // Idempotency: return existing unsigned tx if recently built for this borrower/amount/term
+  const cacheKey = `pending_loan_tx:${borrowerPublicKey}:${amount}:${termLedgers}`;
   const cachedTx = await cacheService.get<{
     unsignedTxXdr: string;
     networkPassphrase: string;
@@ -695,6 +698,7 @@ export const requestLoan = asyncHandler(async (req: Request, res: Response) => {
     logger.withContext().info('Returning cached unsigned loan request tx', {
       borrower: borrowerPublicKey,
       amount,
+      termLedgers,
     });
     res.json({
       success: true,
@@ -704,7 +708,7 @@ export const requestLoan = asyncHandler(async (req: Request, res: Response) => {
     return;
   }
 
-  const result = await sorobanService.buildRequestLoanTx(borrowerPublicKey, amount);
+  const result = await sorobanService.buildRequestLoanTx(borrowerPublicKey, amount, termLedgers);
 
   // Cache for 60 seconds to prevent sequence number collisions from rapid requests
   await cacheService.set(cacheKey, result, 60);
@@ -715,6 +719,7 @@ export const requestLoan = asyncHandler(async (req: Request, res: Response) => {
   logger.withContext().info('Loan request transaction built', {
     borrower: borrowerPublicKey,
     amount,
+    termLedgers,
   });
 
   res.json({

--- a/backend/src/routes/loanRoutes.ts
+++ b/backend/src/routes/loanRoutes.ts
@@ -322,7 +322,7 @@ router.get(
  *   post:
  *     summary: Build an unsigned loan request transaction
  *     description: >
- *       Builds an unsigned Soroban `request_loan(borrower, amount)` transaction XDR.
+ *       Builds an unsigned Soroban `request_loan(borrower, amount, term)` transaction XDR.
  *       The frontend signs it with the user's wallet and submits via POST /api/loans/submit.
  *     tags: [Loans]
  *     security:
@@ -344,6 +344,10 @@ router.get(
  *               borrowerPublicKey:
  *                 type: string
  *                 description: Borrower's Stellar public key (must match JWT)
+ *               term:
+ *                 type: number
+ *                 description: Loan term in ledgers (defaults to 17280)
+ *                 example: 17280
  *     responses:
  *       200:
  *         description: Unsigned transaction XDR returned

--- a/backend/src/schemas/loanSchemas.ts
+++ b/backend/src/schemas/loanSchemas.ts
@@ -17,6 +17,7 @@ const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3
 export const requestLoanSchema = z.object({
   amount: positiveAmountSchema,
   borrowerPublicKey: stellarAddressSchema,
+  term: z.number().int().positive('Term must be a positive integer').optional(),
 });
 
 export const repayLoanSchema = z.object({

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -195,12 +195,13 @@ class SorobanService {
   }
 
   /**
-   * Builds an unsigned Soroban `request_loan(borrower, amount)` transaction.
+   * Builds an unsigned Soroban `request_loan(borrower, amount, term)` transaction.
    * Returns base64 XDR for the frontend to sign with the user's wallet.
    */
   async buildRequestLoanTx(
     borrowerPublicKey: string,
     amount: number,
+    termLedgers: number,
   ): Promise<{ unsignedTxXdr: string; networkPassphrase: string }> {
     const server = this.getRpcServer();
     const contractId = this.getLoanManagerContractId();
@@ -212,6 +213,7 @@ class SorobanService {
       type: 'address',
     });
     const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const termScVal = nativeToScVal(termLedgers, { type: 'u32' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -221,7 +223,7 @@ class SorobanService {
         Operation.invokeContractFunction({
           contract: contractId,
           function: 'request_loan',
-          args: [borrowerScVal, amountScVal],
+          args: [borrowerScVal, amountScVal, termScVal],
         }),
       )
       .setTimeout(30)
@@ -233,6 +235,7 @@ class SorobanService {
     logger.withContext().info('Built request_loan transaction', {
       borrower: borrowerPublicKey,
       amount,
+      termLedgers,
     });
 
     return { unsignedTxXdr, networkPassphrase: passphrase };


### PR DESCRIPTION
## Summary

Closes #1596

Fixes a **critical backend bug** where loan requests built by the backend were reverting on-chain with argument-count errors.

`LoanManager::request_loan` on the Soroban contract expects **3 arguments** — `(borrower: Address, amount: i128, term: u32)` — but `sorobanService.buildRequestLoanTx` was only supplying `[borrowerScVal, amountScVal]`. Stellar/Soroban is strict about function arity, so the missing `term` argument caused every submitted loan request to revert.

## Changes

### `backend/src/services/sorobanService.ts`
- `buildRequestLoanTx` now accepts a `termLedgers: number` parameter.
- Builds the term argument as `nativeToScVal(termLedgers, { type: 'u32' })` and includes it in the `request_loan` invocation args: `[borrowerScVal, amountScVal, termScVal]`.
- Includes `termLedgers` in the build log.

### `backend/src/controllers/loanController.ts`
- `requestLoan` reads an optional `term` from the request body.
- Falls back to `DEFAULT_TERM_LEDGERS` (17,280) when `term` is omitted, so existing callers remain backward compatible (the contract rejects `term == 0`).
- Threads the resolved `termLedgers` through to `buildRequestLoanTx`.
- Adds `termLedgers` to the idempotency cache key and logs so cached transactions are distinct per term.

### `backend/src/schemas/loanSchemas.ts`
- `requestLoanSchema` now allows an optional `term` (positive integer).

### `backend/src/routes/loanRoutes.ts`
- Updated the OpenAPI docs for `POST /api/loans/request` to document the optional `term` field.

## Trade-off / note
The contract requires `term > 0`, so `term` is functionally required for a successful on-chain call. It is accepted as optional in the API and defaults to `DEFAULT_TERM_LEDGERS` (1 day in ledgers) to preserve backward compatibility for existing clients that don't yet send a term.

## Verification
- `npm run typecheck` — passes
- `npm run lint` — clean on modified files (only a pre-existing warning remains)
- Backend loan + soroban test suites — **50/50 passed**
- Full backend suite — 89/90 suites pass; the single failure (`auth.test.ts` "accept timestamp at the window edge") is a pre-existing, time-sensitive flaky test that passes in isolation and is unrelated to these changes.

## Files changed
- `backend/src/controllers/loanController.ts`
- `backend/src/routes/loanRoutes.ts`
- `backend/src/schemas/loanSchemas.ts`
- `backend/src/services/sorobanService.ts`
