### PR TITLE
fix(scripts): scope env-docs check keys to their Backend/Frontend sections (#1501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,8 @@ jobs:
           node-version: 20
       - name: Check env docs are in sync
         run: node scripts/check-env-docs.mjs
+      - name: Run env docs check unit tests
+        run: node scripts/check-env-docs.test.mjs
 
   error-code-mapping-check:
     runs-on: ubuntu-latest

--- a/scripts/__fixtures__/env-docs/correct-sections/ENVIRONMENT.md
+++ b/scripts/__fixtures__/env-docs/correct-sections/ENVIRONMENT.md
@@ -1,0 +1,28 @@
+# Environment Variable Reference
+
+## Demo Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEMO_MODE` | (unset) | Enables sandbox responses for demo-gated routes |
+
+## Backend (`backend/`)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `BACKEND_ONLY_KEY` | A backend-only key | `backend/src/config/index.ts` |
+
+## Frontend (`frontend/`)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `NEXT_PUBLIC_API_URL` | Backend API base URL | `frontend/src/app/hooks/useApi.ts` |
+| `SENTRY_ORG` | Sentry organization slug | `frontend/sentry.client.config.ts` |
+| `SENTRY_PROJECT` | Sentry project slug | `frontend/sentry.client.config.ts` |
+| `SENTRY_AUTH_TOKEN` | Sentry auth token for source maps | `frontend/next.config.ts` |
+
+## Contracts / Scripts (`contracts/`, `scripts/`)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `SOROBAN_RPC_URL` | RPC URL for contract deployment | `scripts/deploy.ts` |

--- a/scripts/__fixtures__/env-docs/correct-sections/backend.env.example
+++ b/scripts/__fixtures__/env-docs/correct-sections/backend.env.example
@@ -1,0 +1,2 @@
+# Backend template
+BACKEND_ONLY_KEY=value

--- a/scripts/__fixtures__/env-docs/correct-sections/frontend.env.example
+++ b/scripts/__fixtures__/env-docs/correct-sections/frontend.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+SENTRY_ORG=org
+SENTRY_PROJECT=project
+SENTRY_AUTH_TOKEN=token

--- a/scripts/__fixtures__/env-docs/wrong-section/ENVIRONMENT.md
+++ b/scripts/__fixtures__/env-docs/wrong-section/ENVIRONMENT.md
@@ -1,0 +1,15 @@
+# Environment Variable Reference
+
+## Backend (`backend/`)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `BACKEND_ONLY_KEY` | A backend-only key | `backend/src/config/index.ts` |
+| `SENTRY_AUTH_TOKEN` | Frontend key wrongly listed under Backend | `frontend/next.config.ts` |
+
+## Frontend (`frontend/`)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `NEXT_PUBLIC_API_URL` | Backend API base URL | `frontend/src/app/hooks/useApi.ts` |
+| `SENTRY_ORG` | Sentry organization slug | `frontend/sentry.client.config.ts` |

--- a/scripts/__fixtures__/env-docs/wrong-section/backend.env.example
+++ b/scripts/__fixtures__/env-docs/wrong-section/backend.env.example
@@ -1,0 +1,1 @@
+BACKEND_ONLY_KEY=value

--- a/scripts/__fixtures__/env-docs/wrong-section/frontend.env.example
+++ b/scripts/__fixtures__/env-docs/wrong-section/frontend.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+SENTRY_AUTH_TOKEN=token

--- a/scripts/check-env-docs.mjs
+++ b/scripts/check-env-docs.mjs
@@ -6,6 +6,13 @@
  * Compares keys found in backend/.env.example and frontend/.env.example
  * against the tables listed in docs/ENVIRONMENT.md.
  *
+ * The "unexpected" direction is scoped per section: keys from
+ * docs/ENVIRONMENT.md are only compared against the section matching the
+ * package (`## Backend` for backend/.env.example, `## Frontend` for
+ * frontend/.env.example). Without this scoping, frontend-only keys such as
+ * SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN were falsely flagged as
+ * unexpected against backend/.env.example (see issue #1501).
+ *
  * Exits with code 1 if any key is missing from either side.
  *
  * Usage:
@@ -13,14 +20,17 @@
  */
 
 import { readFileSync } from "fs";
-import { join, dirname } from "path";
+import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
 
-function parseEnvKeys(filePath) {
-  const content = readFileSync(filePath, "utf-8");
+/** Section headings that scope an .env.example file's "unexpected" check. */
+const BACKEND_SECTION = /^Backend\b/;
+const FRONTEND_SECTION = /^Frontend\b/;
+
+export function parseEnvKeys(content) {
   const keys = [];
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
@@ -32,60 +42,126 @@ function parseEnvKeys(filePath) {
   return keys;
 }
 
-function parseDocKeys(filePath) {
-  const content = readFileSync(filePath, "utf-8");
-  const keys = [];
+/**
+ * Splits the doc into `## `-headed sections and returns each section's keys,
+ * keyed by heading text. Rows are recognized as `| \`KEY\` | ...` table rows.
+ */
+export function parseDocSections(content) {
+  const sections = new Map();
+  let current = null;
   for (const line of content.split("\n")) {
-    const match = line.match(/^\|\s*`([A-Z_][A-Z0-9_]*)`\s*\|/);
-    if (match) {
-      keys.push(match[1]);
+    const heading = line.match(/^##\s+(.+)$/);
+    if (heading) {
+      current = heading[1].trim();
+      sections.set(current, []);
+      continue;
     }
+    if (current === null) continue;
+    const row = line.match(/^\|\s*`([A-Z_][A-Z0-9_]*)`\s*\|/);
+    if (row) sections.get(current).push(row[1]);
   }
-  return keys;
+  return sections;
 }
 
-const envFiles = [
-  { path: join(root, "backend", ".env.example"), label: "backend/.env.example" },
-  { path: join(root, "frontend", ".env.example"), label: "frontend/.env.example" },
-];
+/**
+ * Returns the doc's keys as `{ all, backend, frontend }`, where `all` is the
+ * union of every section (used for the "missing from docs" check) and
+ * `backend` / `frontend` are scoped to the matching `## ` section (used for
+ * the "unexpected" check).
+ */
+export function parseDocKeys(content) {
+  const sections = parseDocSections(content);
+  const all = [];
+  const backend = [];
+  const frontend = [];
+  for (const [heading, keys] of sections) {
+    all.push(...keys);
+    if (BACKEND_SECTION.test(heading)) backend.push(...keys);
+    if (FRONTEND_SECTION.test(heading)) frontend.push(...keys);
+  }
+  return { all, backend, frontend };
+}
 
-const docPath = join(root, "docs", "ENVIRONMENT.md");
-const docKeys = new Set(parseDocKeys(docPath));
+/**
+ * Compares .env.example contents against the doc.
+ *
+ * @param {string} docContent Contents of docs/ENVIRONMENT.md
+ * @param {Array<{label: string, content: string}>} envFiles .env.example contents keyed by label
+ * @returns {{ errors: Array<{kind: string, label?: string, keys?: string[], section?: string}>, warnings: Array<{label: string, keys: string[]}> }}
+ */
+export function checkEnvDocs(docContent, envFiles) {
+  const { all, backend, frontend } = parseDocKeys(docContent);
+  const sectionKeys = { backend, frontend };
 
-let exitCode = 0;
+  const errors = [];
+  const warnings = [];
 
-for (const { path, label } of envFiles) {
-  const envKeys = parseEnvKeys(path);
-  const missingInDoc = envKeys.filter((k) => !docKeys.has(k));
-  const unexpected = [...docKeys].filter(
-    (k) => !envKeys.includes(k) && (label.includes("backend") ? !k.startsWith("NEXT_PUBLIC_") : k.startsWith("NEXT_PUBLIC_"))
+  const sectionHeadings = [...parseDocSections(docContent).keys()];
+  if (!sectionHeadings.some((h) => BACKEND_SECTION.test(h))) {
+    errors.push({ kind: "missing-section", section: "Backend" });
+  }
+  if (!sectionHeadings.some((h) => FRONTEND_SECTION.test(h))) {
+    errors.push({ kind: "missing-section", section: "Frontend" });
+  }
+
+  for (const { label, content } of envFiles) {
+    const envKeys = parseEnvKeys(content);
+    const isBackend = label.includes("backend");
+
+    const missingInDoc = envKeys.filter((k) => !all.includes(k));
+    if (missingInDoc.length > 0) {
+      errors.push({ kind: "missing", label, keys: missingInDoc });
+    }
+
+    const unexpected = sectionKeys[isBackend ? "backend" : "frontend"].filter(
+      (k) =>
+        !envKeys.includes(k) &&
+        (isBackend ? !k.startsWith("NEXT_PUBLIC_") : k.startsWith("NEXT_PUBLIC_"))
+    );
+    if (unexpected.length > 0) {
+      warnings.push({ label, keys: unexpected });
+    }
+  }
+
+  return { errors, warnings };
+}
+
+function run() {
+  const envFiles = [
+    { path: join(root, "backend", ".env.example"), label: "backend/.env.example" },
+    { path: join(root, "frontend", ".env.example"), label: "frontend/.env.example" },
+  ];
+
+  const docPath = join(root, "docs", "ENVIRONMENT.md");
+  const { errors, warnings } = checkEnvDocs(
+    readFileSync(docPath, "utf-8"),
+    envFiles.map(({ path, label }) => ({ label, content: readFileSync(path, "utf-8") }))
   );
 
-  if (missingInDoc.length > 0) {
-    console.error(`\n❌ [${label}] Keys missing from docs/ENVIRONMENT.md:`);
-    for (const k of missingInDoc) console.error(`   - ${k}`);
+  let exitCode = 0;
+
+  for (const error of errors) {
+    if (error.kind === "missing-section") {
+      console.error(`\n❌ docs/ENVIRONMENT.md is missing '## ${error.section}' section`);
+    } else {
+      console.error(`\n❌ [${error.label}] Keys missing from docs/ENVIRONMENT.md:`);
+      for (const k of error.keys) console.error(`   - ${k}`);
+    }
     exitCode = 1;
   }
 
-  if (unexpected.length > 0) {
+  for (const { label, keys } of warnings) {
     console.error(`\n⚠️  [${label}] Keys in docs/ENVIRONMENT.md but not in .env.example:`);
-    for (const k of unexpected) console.error(`   - ${k}`);
+    for (const k of keys) console.error(`   - ${k}`);
   }
+
+  if (exitCode === 0) {
+    console.log("✅ docs/ENVIRONMENT.md is in sync with all .env.example files.");
+  }
+
+  process.exit(exitCode);
 }
 
-// Also check that doc has the backend and frontend sections
-const docContent = readFileSync(docPath, "utf-8");
-if (!docContent.includes("## Backend")) {
-  console.error("\n❌ docs/ENVIRONMENT.md is missing '## Backend' section");
-  exitCode = 1;
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run();
 }
-if (!docContent.includes("## Frontend")) {
-  console.error("\n❌ docs/ENVIRONMENT.md is missing '## Frontend' section");
-  exitCode = 1;
-}
-
-if (exitCode === 0) {
-  console.log("✅ docs/ENVIRONMENT.md is in sync with all .env.example files.");
-}
-
-process.exit(exitCode);

--- a/scripts/check-env-docs.test.mjs
+++ b/scripts/check-env-docs.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for scripts/check-env-docs.mjs (issue #1501).
+ *
+ * Verifies that doc keys are scoped to their `## Backend` / `## Frontend`
+ * section so frontend-only keys are not flagged against backend/.env.example,
+ * and that a key documented under the wrong section is still caught.
+ *
+ * Run with: node scripts/check-env-docs.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocKeys, checkEnvDocs } from "./check-env-docs.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesRoot = join(__dirname, "__fixtures__", "env-docs");
+
+function loadFixture(name) {
+  const dir = join(fixturesRoot, name);
+  return {
+    doc: readFileSync(join(dir, "ENVIRONMENT.md"), "utf-8"),
+    envFiles: [
+      {
+        label: "backend/.env.example",
+        content: readFileSync(join(dir, "backend.env.example"), "utf-8"),
+      },
+      {
+        label: "frontend/.env.example",
+        content: readFileSync(join(dir, "frontend.env.example"), "utf-8"),
+      },
+    ],
+  };
+}
+
+test("parseDocKeys scopes keys to the Backend/Frontend sections", () => {
+  const { doc } = loadFixture("correct-sections");
+  const { all, backend, frontend } = parseDocKeys(doc);
+
+  assert.ok(backend.includes("BACKEND_ONLY_KEY"));
+  assert.ok(frontend.includes("NEXT_PUBLIC_API_URL"));
+  assert.ok(frontend.includes("SENTRY_ORG"));
+  assert.ok(!backend.includes("SENTRY_ORG"), "frontend key leaked into backend section keys");
+  assert.ok(!frontend.includes("BACKEND_ONLY_KEY"), "backend key leaked into frontend section keys");
+  // Non-Backend/Frontend sections still count for the "missing from docs" direction
+  assert.ok(all.includes("DEMO_MODE"));
+  assert.ok(all.includes("SOROBAN_RPC_URL"));
+});
+
+test("frontend-section keys are not flagged as unexpected for backend/.env.example (issue #1501)", () => {
+  const { doc, envFiles } = loadFixture("correct-sections");
+  const { errors, warnings } = checkEnvDocs(doc, envFiles);
+
+  assert.deepEqual(errors, []);
+  const backendUnexpected = warnings
+    .filter((w) => w.label.includes("backend"))
+    .flatMap((w) => w.keys);
+  assert.ok(!backendUnexpected.includes("SENTRY_ORG"));
+  assert.ok(!backendUnexpected.includes("SENTRY_PROJECT"));
+  assert.ok(!backendUnexpected.includes("SENTRY_AUTH_TOKEN"));
+});
+
+test("a key documented under the wrong section is caught as unexpected", () => {
+  const { doc, envFiles } = loadFixture("wrong-section");
+  const { errors, warnings } = checkEnvDocs(doc, envFiles);
+
+  assert.deepEqual(errors, []);
+  const backendUnexpected = warnings
+    .filter((w) => w.label.includes("backend"))
+    .flatMap((w) => w.keys);
+  // SENTRY_AUTH_TOKEN is a frontend key but the fixture doc lists it under
+  // the Backend heading, so the backend check must flag it.
+  assert.ok(backendUnexpected.includes("SENTRY_AUTH_TOKEN"));
+  assert.ok(!backendUnexpected.includes("BACKEND_ONLY_KEY"));
+});
+
+test("genuinely undocumented .env.example keys still fail the check", () => {
+  const { doc, envFiles } = loadFixture("correct-sections");
+  const badEnv = [
+    { label: "backend/.env.example", content: "BACKEND_ONLY_KEY=value\nUNDOCUMENTED_BACKEND_KEY=value\n" },
+    envFiles[1],
+  ];
+  const { errors, warnings } = checkEnvDocs(doc, badEnv);
+
+  const missing = errors.find((e) => e.kind === "missing");
+  assert.ok(missing, "expected a 'missing' error");
+  assert.ok(missing.keys.includes("UNDOCUMENTED_BACKEND_KEY"));
+  assert.deepEqual(warnings, []);
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "gen:money": "ts-node gen-money.ts",
     "gen:money:check": "ts-node gen-money.ts --check",
+    "test:env-docs": "node check-env-docs.test.mjs",
     "money:property-test": "tsx money-property-test.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes #1501.

`scripts/check-env-docs.mjs` parsed every `` `KEY` `` cell out of the whole `docs/ENVIRONMENT.md` into one flat `docKeys` set, without noting which `## ` section each row lives under. The "unexpected" comparison (`Keys in docs/ENVIRONMENT.md but not in .env.example`) then compared that full set against `backend/.env.example`, so frontend-only keys such as `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` (documented under the `## Frontend` heading) were flagged as unexpected for the backend — a false positive that also buried any genuinely undocumented backend key in a noisy, unscoped warning list.

## Root cause

The "unexpected" direction was computed from the flat doc key set instead of the section matching the package being checked.

## Changes

- **`scripts/check-env-docs.mjs`**
  - `parseDocSections(content)` splits the doc by `## ` headings and returns each section's keys, keyed by heading text.
  - `parseDocKeys(content)` now returns `{ all, backend, frontend }`: `all` is the union of every section (unchanged behavior for the "missing from docs" check), and `backend` / `frontend` are scoped to the matching `## Backend` / `## Frontend` sections.
  - New `checkEnvDocs(docContent, envFiles)` helper drives the comparison so the logic is unit-testable; the CLI entry point is unchanged and only runs when the file is executed directly.
  - The "unexpected" comparison for `backend/.env.example` now only checks the Backend section's keys, and the frontend comparison only checks the Frontend section's keys. The `NEXT_PUBLIC_` prefix filtering is preserved.
- **`scripts/check-env-docs.test.mjs` + `scripts/__fixtures__/env-docs/`** — fixture-based unit tests (using `node:test`, no new dependencies):
  - keys are scoped to their correct section (frontend keys do not leak into the backend set, and vice versa);
  - `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` documented under `## Frontend` are **not** flagged as unexpected for `backend/.env.example` (the issue's false positive);
  - a frontend key documented under the **wrong** (`## Backend`) section **is** still caught as unexpected for backend;
  - genuinely undocumented `.env.example` keys still fail the check.
- **`.github/workflows/ci.yml`** — the `env-docs-check` job now also runs the unit tests.
- **`scripts/package.json`** — added `test:env-docs` script for local runs.

## Verification

`node scripts/check-env-docs.mjs` against the current repo state now passes cleanly with no warnings (previously it reported `DEMO_MODE`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`, `NODE_ENV`, `SOROBAN_RPC_URL`, `SOROBAN_NETWORK_PASSPHRASE`, `SOROBAN_ACCOUNT`, `DEPLOY_CONFIG_PATH` as unexpected for `backend/.env.example`):

```
✅ docs/ENVIRONMENT.md is in sync with all .env.example files.
```

`node scripts/check-env-docs.test.mjs` — all 4 tests pass.

## Out of scope (per the issue)

- Making the "unexpected key" case a hard CI failure (`exitCode = 1`) — separate policy decision.
- Auditing every individual env var listed in `ENVIRONMENT.md` for accuracy.
- No changes to `docs/ENVIRONMENT.md` were needed: the `## Backend (`backend/`)` / `## Frontend (`frontend/`)` boundaries are already unambiguous for the parser.

Closes #1501