### PR TITLE
fix(backend): accrue loan interest on remaining principal, not original (#1600)

### DIFF
--- a/backend/src/__tests__/loanEndpoints.test.ts
+++ b/backend/src/__tests__/loanEndpoints.test.ts
@@ -303,7 +303,7 @@ describe('GET /api/loans/:loanId', () => {
         rows: [
           {
             event_type: 'LoanRequested',
-            amount: '1000',
+            amount: '10000000000',
             ledger: 10,
             ledger_closed_at: '2025-01-01T00:00:00.000Z',
             tx_hash: 'request-tx',
@@ -329,13 +329,62 @@ describe('GET /api/loans/:loanId', () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     expect(response.body.loanId).toBe('123');
-    expect(response.body.summary.principal).toBe(1000);
+    expect(response.body.summary.principal).toBe(10000000000);
     expect(response.body.summary.accruedInterest).toBeGreaterThan(0);
     expect(response.body.summary.totalOwed).toBe(
       response.body.summary.principal +
         response.body.summary.accruedInterest -
         response.body.summary.totalRepaid,
     );
+  });
+
+  it('should accrue interest against the remaining principal after partial repayments (issue #1600)', async () => {
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ address: TEST_BORROWER }] }) // address check
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            event_type: 'LoanRequested',
+            amount: '10000000000',
+            ledger: 10,
+            ledger_closed_at: '2025-01-01T00:00:00.000Z',
+            tx_hash: 'request-tx',
+            interest_rate_bps: null,
+            term_ledgers: null,
+          },
+          {
+            event_type: 'LoanApproved',
+            amount: null,
+            ledger: 20,
+            ledger_closed_at: '2025-01-02T00:00:00.000Z',
+            tx_hash: 'approve-tx',
+            interest_rate_bps: 1200,
+            term_ledgers: 17280,
+          },
+          {
+            event_type: 'LoanRepaid',
+            amount: '5000000000',
+            ledger: 25,
+            ledger_closed_at: '2025-01-03T00:00:00.000Z',
+            tx_hash: 'repay-tx',
+            interest_rate_bps: null,
+            term_ledgers: null,
+          },
+        ],
+      }) // loan events
+      .mockResolvedValueOnce({ rows: [{ last_indexed_ledger: 30 }] }) // getLatestLedger
+      .mockResolvedValueOnce({ rows: [] }); // loan_disputes (no open disputes)
+
+    const response = await request(app).get('/api/loans/123').set(bearer(TEST_BORROWER));
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary.principal).toBe(10000000000);
+    expect(response.body.summary.totalRepaid).toBe(5000000000);
+    // Half the principal repaid -> interest accrues on the remaining 5e9 stroops
+    // over 10 elapsed ledgers, not on the full 1e10 original principal.
+    expect(response.body.summary.accruedInterest).toBe(347222);
+    expect(response.body.summary.totalOwed).toBe(5000000000 + 347222);
+    expect(response.body.summary.status).toBe('active');
   });
 
   it('should return 403 when the loan belongs to another borrower', async () => {

--- a/backend/src/controllers/loanController.ts
+++ b/backend/src/controllers/loanController.ts
@@ -13,6 +13,7 @@ import { cacheService } from '../services/cacheService.js';
 import { notificationService } from '../services/notificationService.js';
 import { invalidateOnRepay, invalidateOnLoanRequest } from '../utils/cacheKeys.js';
 import { roundToCents } from '../money/decimal.js';
+import { parseStroopAmount, remainingPrincipal, accrueInterest } from '../money/loanAccrual.js';
 
 // ─── Test/Dev Only ────────────────────────────────────────────────────────────
 
@@ -371,7 +372,7 @@ export const getBorrowerLoans = asyncHandler(async (req: Request, res: Response)
       loan_fin AS (
         SELECT
           *,
-          (principal * effective_rate_bps * GREATEST(0, $2 - effective_approved_ledger)) / (10000 * effective_term_ledgers) as accrued_interest
+          FLOOR(GREATEST(0, principal - total_repaid) * effective_rate_bps * GREATEST(0, $2 - effective_approved_ledger) / (10000 * effective_term_ledgers)) as accrued_interest
         FROM loan_calculations
       ),
       loan_final AS (
@@ -518,11 +519,16 @@ export const getLoanDetails = asyncHandler(async (req: Request, res: Response) =
   );
 
   const principal = Number.parseFloat(requestEvent?.amount || '0');
-  const totalRepaid = repaymentEvents.reduce(
-    (sum: number, event: Record<string, unknown>) =>
-      sum + Number.parseFloat((event.amount as string) || '0'),
-    0,
+  // Accrue in exact integer stroops (issue #1600): interest is charged on the
+  // remaining unpaid principal (principal - totalRepaid), not the original
+  // principal, mirroring the contract's `accrue_interest` on `amount - principal_paid`.
+  const principalStroops = parseStroopAmount(String(requestEvent?.amount ?? ''));
+  const totalRepaidStroops = repaymentEvents.reduce(
+    (sum: bigint, event: Record<string, unknown>) =>
+      sum + parseStroopAmount(String(event.amount ?? '')),
+    0n,
   );
+  const totalRepaid = Number(totalRepaidStroops);
 
   const rateBps = approvalEvent?.interest_rate_bps || DEFAULT_INTEREST_RATE_BPS;
   const termLedgers = approvalEvent?.term_ledgers || DEFAULT_TERM_LEDGERS;
@@ -558,10 +564,19 @@ export const getLoanDetails = asyncHandler(async (req: Request, res: Response) =
 
   const isPending = approvedLedger <= 0 || currentLedger < approvedLedger;
 
-  const accruedInterest = isPending
-    ? 0
-    : (principal * rateBps * elapsedLedgers) / (10000 * termLedgers);
-  const totalOwed = principal + accruedInterest - totalRepaid;
+  const accruedInterestStroops = isPending
+    ? 0n
+    : accrueInterest({
+        remainingPrincipalStroops: remainingPrincipal(principalStroops, totalRepaidStroops),
+        interestRateBps: rateBps,
+        elapsedLedgers,
+        termLedgers,
+      });
+  const accruedInterest = Number(accruedInterestStroops);
+  // remaining principal + interest accrued on it == principal + accrued - totalRepaid
+  const totalOwed = Number(
+    remainingPrincipal(principalStroops, totalRepaidStroops) + accruedInterestStroops,
+  );
 
   res.json({
     success: true,

--- a/backend/src/money/__tests__/loanAccrual.test.ts
+++ b/backend/src/money/__tests__/loanAccrual.test.ts
@@ -1,0 +1,101 @@
+import { parseStroopAmount, remainingPrincipal, accrueInterest } from '../loanAccrual.js';
+import { MoneyError } from '../decimal.js';
+
+describe('parseStroopAmount', () => {
+  it('parses an integer stroop count', () => {
+    expect(parseStroopAmount('10000000000')).toBe(10000000000n);
+    expect(parseStroopAmount('0')).toBe(0n);
+  });
+
+  it('accepts an all-zero fractional part (Postgres NUMERIC formatting)', () => {
+    expect(parseStroopAmount('150.0')).toBe(150n);
+  });
+
+  it('treats missing values as zero', () => {
+    expect(parseStroopAmount(null)).toBe(0n);
+    expect(parseStroopAmount(undefined)).toBe(0n);
+    expect(parseStroopAmount('')).toBe(0n);
+  });
+
+  it('rejects a genuinely fractional stroop amount', () => {
+    expect(() => parseStroopAmount('150.5')).toThrow(MoneyError);
+  });
+});
+
+describe('remainingPrincipal', () => {
+  it('subtracts repaid amounts from principal', () => {
+    expect(remainingPrincipal(1000n, 400n)).toBe(600n);
+  });
+
+  it('floors at zero once the loan is fully repaid', () => {
+    expect(remainingPrincipal(1000n, 1000n)).toBe(0n);
+    expect(remainingPrincipal(1000n, 1500n)).toBe(0n);
+  });
+});
+
+describe('accrueInterest', () => {
+  const RATE_BPS = 1200; // 12%
+  const TERM_LEDGERS = 17280; // 1 day in ledgers
+
+  it('accrues simple interest on the remaining principal', () => {
+    // 1000 XLM (1e10 stroops) * 12% * 5 ledgers / (1 day term in ledgers)
+    expect(
+      accrueInterest({
+        remainingPrincipalStroops: 10000000000n,
+        interestRateBps: RATE_BPS,
+        elapsedLedgers: 5,
+        termLedgers: TERM_LEDGERS,
+      }),
+    ).toBe(347222n);
+  });
+
+  it('accrues less interest on a partially repaid principal (issue #1600)', () => {
+    const fullPrincipal = accrueInterest({
+      remainingPrincipalStroops: 10000000000n,
+      interestRateBps: RATE_BPS,
+      elapsedLedgers: 5,
+      termLedgers: TERM_LEDGERS,
+    });
+    const halfPrincipal = accrueInterest({
+      remainingPrincipalStroops: 5000000000n,
+      interestRateBps: RATE_BPS,
+      elapsedLedgers: 5,
+      termLedgers: TERM_LEDGERS,
+    });
+    expect(halfPrincipal).toBe(173611n);
+    expect(halfPrincipal).toBeLessThan(fullPrincipal);
+  });
+
+  it('returns zero for a fully repaid (zero remaining) loan', () => {
+    expect(
+      accrueInterest({
+        remainingPrincipalStroops: 0n,
+        interestRateBps: RATE_BPS,
+        elapsedLedgers: 5,
+        termLedgers: TERM_LEDGERS,
+      }),
+    ).toBe(0n);
+  });
+
+  it('returns zero when no time has elapsed', () => {
+    expect(
+      accrueInterest({
+        remainingPrincipalStroops: 10000000000n,
+        interestRateBps: RATE_BPS,
+        elapsedLedgers: 0,
+        termLedgers: TERM_LEDGERS,
+      }),
+    ).toBe(0n);
+  });
+
+  it('returns zero for a zero interest rate', () => {
+    expect(
+      accrueInterest({
+        remainingPrincipalStroops: 10000000000n,
+        interestRateBps: 0,
+        elapsedLedgers: 5,
+        termLedgers: TERM_LEDGERS,
+      }),
+    ).toBe(0n);
+  });
+});

--- a/backend/src/money/loanAccrual.ts
+++ b/backend/src/money/loanAccrual.ts
@@ -1,0 +1,82 @@
+/**
+ * Accrued-interest math for backend loan views (issue #1600).
+ *
+ * The loan manager contract accrues interest on the *remaining* principal
+ * (`loan.amount - loan.principal_paid`, see `accrue_interest` in
+ * `contracts/loan_manager/src/lib.rs`), not on the originally approved
+ * amount. The backend's event store records each `LoanRepaid` event as a
+ * single total amount (the contract publishes one amount; the
+ * principal/interest split is contract-internal state), so the
+ * principal-repayment signal available from `contract_events` is the
+ * cumulative repaid total. Both loan endpoints therefore accrue interest on
+ * `max(0, principal - totalRepaid)` — the issue's "remaining unpaid
+ * principal" — using exact integer stroop arithmetic routed through the
+ * shared money policy (`roundDiv` / `RoundingMode`), so the list and detail
+ * endpoints agree with each other and no float drift accumulates.
+ *
+ * All amounts are integer stroop counts (the unit `contract_events.amount`
+ * is stored in, mirroring `contracts/money`); callers convert to display
+ * units at the API boundary.
+ */
+import { roundDiv, RoundingMode, MoneyError } from './decimal.js';
+
+/**
+ * Parse a `contract_events.amount` value into a bigint stroop count.
+ *
+ * The column is Postgres `NUMERIC` and can format an integer stroop count
+ * with an all-zero fractional part (e.g. `150.0`), so accept that but reject
+ * any genuinely fractional stroop amount rather than silently truncating
+ * it.
+ */
+export function parseStroopAmount(raw: string | null | undefined): bigint {
+  if (!raw) return 0n;
+  const [wholeRaw, fraction = ''] = raw.split('.');
+  const whole = wholeRaw && wholeRaw.length > 0 ? wholeRaw : '0';
+  if (fraction.length > 0 && /[1-9]/.test(fraction)) {
+    throw new MoneyError(`amount must be an integer stroop count, got "${raw}"`);
+  }
+  return BigInt(whole);
+}
+
+/**
+ * Remaining unpaid principal (`principal - repaid`), floored at zero once
+ * the loan is fully repaid so accrual never goes negative.
+ */
+export function remainingPrincipal(principalStroops: bigint, totalRepaidStroops: bigint): bigint {
+  return principalStroops > totalRepaidStroops ? principalStroops - totalRepaidStroops : 0n;
+}
+
+/**
+ * Simple interest accrued on `remainingPrincipalStroops` over
+ * `elapsedLedgers` at `interestRateBps` across `termLedgers`, floored to a
+ * whole stroop count.
+ *
+ * Mirrors the contract's `accrue_interest` formula in
+ * `contracts/loan_manager/src/lib.rs`:
+ *
+ *   remaining_principal * rate_bps * elapsed_ledgers / (10_000 * term_ledgers)
+ *
+ * (The contract evaluates that numerator at 1e6 intermediate precision and
+ * carries the fractional remainder forward as `interest_residual`; the
+ * floored integer result here is identical for display purposes, since the
+ * residual is at most one stroop and never rounds a value up.)
+ */
+export function accrueInterest(params: {
+  remainingPrincipalStroops: bigint;
+  interestRateBps: number;
+  elapsedLedgers: number;
+  termLedgers: number;
+}): bigint {
+  const { remainingPrincipalStroops, interestRateBps, elapsedLedgers, termLedgers } = params;
+  if (
+    remainingPrincipalStroops <= 0n ||
+    interestRateBps <= 0 ||
+    elapsedLedgers <= 0 ||
+    termLedgers <= 0
+  ) {
+    return 0n;
+  }
+  const numerator = remainingPrincipalStroops * BigInt(interestRateBps) * BigInt(elapsedLedgers);
+  const denominator = 10_000n * BigInt(termLedgers);
+  return roundDiv(numerator, denominator, RoundingMode.Floor);
+}


### PR DESCRIPTION
## Summary

Fixes #1600.

`getBorrowerLoans` (SQL, `loanController.ts:374`) and `getLoanDetails` (JS, `loanController.ts:563`) computed accrued interest against the **full originally approved principal**:

```
accrued = principal * rate_bps * elapsed_ledgers / (10_000 * term_ledgers)
```

The loan manager contract instead accrues interest on the **remaining principal** (`loan.amount - loan.principal_paid`, see `accrue_interest` in `contracts/loan_manager/src/lib.rs`). For partially repaid loans the backend therefore showed inflated accrued interest, drifting from on-chain contract state.

## Changes

- **`getBorrowerLoans` (SQL)** — accrued interest now scales with `GREATEST(0, principal - total_repaid)` instead of `principal`, and is `FLOOR()`-ed to a whole stroop count so the list endpoint agrees with the detail endpoint and the contract (which accrues whole stroops):
  ```sql
  FLOOR(GREATEST(0, principal - total_repaid) * effective_rate_bps * GREATEST(0, $2 - effective_approved_ledger) / (10000 * effective_term_ledgers))
  ```
- **`getLoanDetails` (JS)** — accrual now runs on the remaining unpaid principal (`remainingPrincipal(principal, totalRepaid)`), computed in exact integer stroops with the shared money policy: repayment sums are accumulated as `bigint` via the new `parseStroopAmount` and the interest formula routes through `roundDiv(..., RoundingMode.Floor)` (`backend/src/money/loanAccrual.ts`), so no float drift accumulates and the result matches the SQL endpoint.
- **`backend/src/money/loanAccrual.ts`** (new) — `parseStroopAmount` (strict integer-stroop parser for `contract_events.amount`, which is NUMERIC and can format as `150.0`), `remainingPrincipal` (floored at zero once fully repaid), and `accrueInterest` (mirrors the contract formula).
- **Tests**
  - `backend/src/money/__tests__/loanAccrual.test.ts` — unit tests for the new helpers, including a partial-repayment case asserting interest accrues on the reduced principal.
  - `backend/src/__tests__/loanEndpoints.test.ts` — updated the detail-endpoint fixture to a realistic stroop amount and added a partial-repayment test asserting interest accrues on the remaining 5e9 stroops (347,222) rather than the full 1e10.

`totalOwed` is unchanged in shape and now equals `remaining principal + interest accrued on it` (equivalently `principal + accrued - totalRepaid`).

## Verification

- `npm run typecheck` — clean.
- Full backend suite: **662 passed, 32 skipped, 0 failures** (91 suites), including the new tests.
- `npm run lint` on changed files — clean (one pre-existing `no-explicit-any` warning at `loanController.ts:57`, untouched).

## Notes / limitations

The backend's event store records each `LoanRepaid` as a single total amount (the contract publishes one amount; the principal/interest split is contract-internal state), so the principal-repayment signal available from `contract_events` is the cumulative repaid total. Accruing on `principal - totalRepaid` is the issue's "remaining unpaid principal" and is applied consistently in both endpoints; a per-repayment replay that mirrors the contract's proportional principal/interest split (which would also need late-fee data) is a possible follow-up for stroop-exact alignment with the on-chain ledger-by-ledger accrual.

Closes #1600