### PR TITLE
Fix auth replay and stroop-scaled accounting bugs

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -46,6 +46,7 @@ describe('Auth API', () => {
 
       const challengeResponse = await request(app)
         .post('/api/auth/challenge')
+        .set('X-Forwarded-For', '10.10.10.1')
         .send({ publicKey: keypair.publicKey() })
         .expect(200);
 
@@ -310,6 +311,31 @@ describe('authService unit tests', () => {
 
       const result = authService.verifyChallengeTimestamp(timestamp, maxAge);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('challenge nonce consumption', () => {
+    it('allows a server-issued challenge exactly once', async () => {
+      const keypair = Keypair.random();
+      const challenge = await authService.generateChallenge(keypair.publicKey());
+
+      await expect(
+        authService.verifyAndConsumeChallenge(keypair.publicKey(), challenge.message),
+      ).resolves.toBe(true);
+      await expect(
+        authService.verifyAndConsumeChallenge(keypair.publicKey(), challenge.message),
+      ).resolves.toBe(false);
+    });
+
+    it('rejects self-issued challenge messages', async () => {
+      const keypair = Keypair.random();
+      const nonce = 'a'.repeat(64);
+      const timestamp = Date.now();
+      const message = `Sign this message to authenticate with RemitLend.\n\nNonce: ${nonce}\nTimestamp: ${timestamp}\n\nThis request will expire in 5 minutes.`;
+
+      await expect(
+        authService.verifyAndConsumeChallenge(keypair.publicKey(), message),
+      ).resolves.toBe(false);
     });
   });
 

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -25,6 +25,7 @@ import {
   generateChallenge,
   verifySignature,
   verifyChallengeTimestamp,
+  verifyAndConsumeChallenge,
   generateJwtToken,
   revokeToken,
 } from '../services/authService.js';
@@ -40,7 +41,7 @@ const logAuthFailure = (req: Request, publicKey: string | undefined, reason: str
   });
 };
 
-export const requestChallenge = (req: Request, res: Response): void => {
+export const requestChallenge = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { publicKey } = req.body;
 
   if (!publicKey || typeof publicKey !== 'string') {
@@ -50,7 +51,7 @@ export const requestChallenge = (req: Request, res: Response): void => {
 
   let challenge;
   try {
-    challenge = generateChallenge(publicKey);
+    challenge = await generateChallenge(publicKey);
   } catch (error) {
     if (error instanceof Error && error.message === 'Invalid Stellar public key') {
       logAuthFailure(req, publicKey, 'invalid_public_key');
@@ -67,9 +68,9 @@ export const requestChallenge = (req: Request, res: Response): void => {
     success: true,
     data: challenge,
   });
-};
+});
 
-export const login = (req: Request, res: Response): void => {
+export const login = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { publicKey, message, signature } = req.body;
 
   if (!publicKey || typeof publicKey !== 'string') {
@@ -105,6 +106,12 @@ export const login = (req: Request, res: Response): void => {
     throw AppError.unauthorized('Invalid signature', ErrorCode.INVALID_SIGNATURE);
   }
 
+  const isIssuedChallenge = await verifyAndConsumeChallenge(publicKey, message);
+  if (!isIssuedChallenge) {
+    logAuthFailure(req, publicKey, 'challenge_not_issued_or_replayed');
+    throw AppError.unauthorized('Invalid or already used challenge', ErrorCode.INVALID_CHALLENGE);
+  }
+
   const token = generateJwtToken(publicKey);
   const cookieName = process.env.JWT_COOKIE_NAME ?? 'remitlend_jwt';
 
@@ -125,7 +132,7 @@ export const login = (req: Request, res: Response): void => {
       publicKey,
     },
   });
-};
+});
 
 export async function listAuditLogs(
   req: Request,

--- a/backend/src/services/__tests__/eventIndexerCheckpoints.test.ts
+++ b/backend/src/services/__tests__/eventIndexerCheckpoints.test.ts
@@ -11,7 +11,7 @@ import { jest, describe, it, expect, beforeAll, beforeEach } from '@jest/globals
 
 let mockQuery: jest.Mock<(...args: unknown[]) => Promise<{ rows: unknown[]; rowCount: number }>>;
 let EventIndexer: new (config: { rpcUrl: string; contractIds?: string[] }) => {
-  getSuspectRanges: () => Promise<Array<{ rangeStart: number; rangeEnd: number }>>;
+  getSuspectRanges: (contract?: string) => Promise<Array<{ rangeStart: number; rangeEnd: number }>>;
   pollOnce: () => Promise<void>;
   running: boolean;
   rpc: { getEvents: unknown; getLatestLedger: unknown };
@@ -230,11 +230,69 @@ describe('EventIndexer gap detection (contiguous-cursor invariant, #1376)', () =
     });
 
     const indexer = makeIndexer();
-    const ranges = await indexer.getSuspectRanges();
+    const ranges = await indexer.getSuspectRanges('CONTRACT002');
 
     expect(ranges).toEqual([
       { rangeStart: 1001, rangeEnd: 1039 },
       { rangeStart: 2001, rangeEnd: 2010 },
+    ]);
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining("status = 'suspect'"), [
+      'CONTRACT002',
+    ]);
+  });
+
+  it('tracks checkpoints and cursors independently for each configured contract', async () => {
+    const inserted: Array<{ sql: string; params: unknown[] }> = [];
+    const updated: unknown[][] = [];
+    const eventFilters: unknown[] = [];
+
+    mockQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('SELECT last_ledger')) {
+        return {
+          rows: [{ last_ledger: params[0] === 'CONTRACT001' ? 10 : 20 }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes('FROM ledger_checkpoints')) {
+        return {
+          rows: [{ range_end: params[0] === 'CONTRACT001' ? 10 : 20 }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes('INSERT INTO ledger_checkpoints')) {
+        inserted.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('UPDATE indexer_state')) {
+        updated.push(params);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const indexer = new EventIndexer({
+      rpcUrl: 'http://localhost:8000',
+      contractIds: ['CONTRACT001', 'CONTRACT002'],
+    });
+    indexer.running = true;
+    indexer.rpc = {
+      getLatestLedger: async () => ({ sequence: 25 }),
+      getEvents: async (request: { filters: Array<{ contractIds: string[] }> }) => {
+        eventFilters.push(request.filters[0]?.contractIds);
+        return { events: [] };
+      },
+    };
+
+    await indexer.pollOnce();
+
+    expect(eventFilters).toEqual([['CONTRACT001'], ['CONTRACT002']]);
+    expect(inserted.map((row) => row.params)).toEqual([
+      ['CONTRACT001', 11, 25],
+      ['CONTRACT002', 21, 25],
+    ]);
+    expect(updated).toEqual([
+      [25, 'CONTRACT001'],
+      [25, 'CONTRACT002'],
     ]);
   });
 });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -22,9 +22,12 @@ export interface ChallengeMessage {
 
 const JWT_EXPIRES_IN = '24h';
 const CHALLENGE_EXPIRES_IN_MS = 5 * 60 * 1000;
+const CHALLENGE_EXPIRES_IN_SECONDS = CHALLENGE_EXPIRES_IN_MS / 1000;
+const CHALLENGE_NONCE_PREFIX = 'auth-challenge:';
 // Small allowance for client/server clock drift when a challenge timestamp
 // is slightly in the future.
 const CLOCK_SKEW_TOLERANCE_MS = 5 * 1000;
+const testChallengeStore = new Map<string, { message: string; expiresAt: number }>();
 
 function getJwtSecret(): string {
   const secret = process.env.JWT_SECRET;
@@ -34,7 +37,35 @@ function getJwtSecret(): string {
   return secret;
 }
 
-export function generateChallenge(publicKey: string): ChallengeMessage {
+function challengeNonceKey(publicKey: string, nonce: string): string {
+  return `${CHALLENGE_NONCE_PREFIX}${publicKey}:${nonce}`;
+}
+
+function parseChallengeNonce(message: string): string | null {
+  const nonceMatch = message.match(/Nonce: ([a-f0-9]{64})/);
+  return nonceMatch?.[1] ?? null;
+}
+
+async function storeChallengeNonce(
+  publicKey: string,
+  nonce: string,
+  message: string,
+  timestamp: number,
+): Promise<boolean> {
+  const key = challengeNonceKey(publicKey, nonce);
+
+  if (process.env.NODE_ENV === 'test') {
+    testChallengeStore.set(key, {
+      message,
+      expiresAt: timestamp + CHALLENGE_EXPIRES_IN_MS,
+    });
+    return true;
+  }
+
+  return cacheService.setNotExists(key, message, CHALLENGE_EXPIRES_IN_SECONDS);
+}
+
+export async function generateChallenge(publicKey: string): Promise<ChallengeMessage> {
   if (!StrKey.isValidEd25519PublicKey(publicKey)) {
     throw new Error('Invalid Stellar public key');
   }
@@ -43,6 +74,10 @@ export function generateChallenge(publicKey: string): ChallengeMessage {
   const timestamp = Date.now();
 
   const message = `Sign this message to authenticate with RemitLend.\n\nNonce: ${nonce}\nTimestamp: ${timestamp}\n\nThis request will expire in 5 minutes.`;
+  const stored = await storeChallengeNonce(publicKey, nonce, message, timestamp);
+  if (!stored) {
+    throw new Error('Failed to store challenge nonce');
+  }
 
   return {
     message,
@@ -50,6 +85,33 @@ export function generateChallenge(publicKey: string): ChallengeMessage {
     timestamp,
     expiresIn: CHALLENGE_EXPIRES_IN_MS,
   };
+}
+
+export async function verifyAndConsumeChallenge(
+  publicKey: string,
+  message: string,
+): Promise<boolean> {
+  if (!StrKey.isValidEd25519PublicKey(publicKey)) {
+    return false;
+  }
+
+  const nonce = parseChallengeNonce(message);
+  if (!nonce) {
+    return false;
+  }
+
+  const key = challengeNonceKey(publicKey, nonce);
+
+  if (process.env.NODE_ENV === 'test') {
+    const stored = testChallengeStore.get(key);
+    if (!stored || stored.message !== message || stored.expiresAt < Date.now()) {
+      return false;
+    }
+    testChallengeStore.delete(key);
+    return true;
+  }
+
+  return cacheService.deleteIfMatch(key, message);
 }
 
 export function verifySignature(publicKey: string, message: string, signature: string): boolean {

--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -266,7 +266,6 @@ export class EventIndexer {
   private async pollOnce(): Promise<void> {
     if (!this.running) return;
 
-    const lastIndexedLedger = await this.getLastIndexedLedger();
     const latestLedger = await this.getLatestLedgerSequence();
 
     // latestLedger === 0 means getLatestLedgerSequence failed (RPC error or
@@ -277,18 +276,22 @@ export class EventIndexer {
       return;
     }
 
-    if (latestLedger <= lastIndexedLedger) {
-      recordIndexerLedgers(lastIndexedLedger, latestLedger);
-      return;
+    for (const contractId of this.contractIds) {
+      const lastIndexedLedger = await this.getLastIndexedLedger(contractId);
+
+      if (latestLedger <= lastIndexedLedger) {
+        recordIndexerLedgers(lastIndexedLedger, latestLedger);
+        continue;
+      }
+
+      const fromLedger = lastIndexedLedger + 1;
+      const toLedger = Math.min(fromLedger + this.batchSize - 1, latestLedger);
+
+      const result = await this.processChunk(fromLedger, toLedger, contractId);
+      await this.recordCheckpoint(contractId, fromLedger, result.lastProcessedLedger);
+      await this.updateLastIndexedLedger(contractId, result.lastProcessedLedger);
+      recordIndexerLedgers(result.lastProcessedLedger, latestLedger);
     }
-
-    const fromLedger = lastIndexedLedger + 1;
-    const toLedger = Math.min(fromLedger + this.batchSize - 1, latestLedger);
-
-    const result = await this.processChunk(fromLedger, toLedger);
-    await this.recordCheckpoint(fromLedger, result.lastProcessedLedger);
-    await this.updateLastIndexedLedger(result.lastProcessedLedger);
-    recordIndexerLedgers(result.lastProcessedLedger, latestLedger);
   }
 
   /**
@@ -308,9 +311,11 @@ export class EventIndexer {
    * content digest) is intentionally out of scope here — see this change's
    * PR description.
    */
-  private async recordCheckpoint(rangeStart: number, rangeEnd: number): Promise<void> {
-    const contract = this.getContractId();
-
+  private async recordCheckpoint(
+    contract: string,
+    rangeStart: number,
+    rangeEnd: number,
+  ): Promise<void> {
     const previous = await query(
       `SELECT range_end
        FROM ledger_checkpoints
@@ -350,8 +355,9 @@ export class EventIndexer {
    * defaultChecker.ts) can refuse to trust conclusions drawn from events in
    * these ranges until they're backfilled and reconciled.
    */
-  async getSuspectRanges(): Promise<Array<{ rangeStart: number; rangeEnd: number }>> {
-    const contract = this.getContractId();
+  async getSuspectRanges(
+    contract: string = this.getContractId(),
+  ): Promise<Array<{ rangeStart: number; rangeEnd: number }>> {
     const result = await query(
       `SELECT range_start, range_end
        FROM ledger_checkpoints
@@ -387,8 +393,7 @@ export class EventIndexer {
     return this.contractIds[0] ?? 'default';
   }
 
-  private async getLastIndexedLedger(): Promise<number> {
-    const contract = this.getContractId();
+  private async getLastIndexedLedger(contract: string = this.getContractId()): Promise<number> {
     const result = await query(
       `SELECT last_ledger
        FROM indexer_state
@@ -410,8 +415,10 @@ export class EventIndexer {
     return Number(result.rows[0]?.last_ledger ?? 0);
   }
 
-  private async updateLastIndexedLedger(ledger: number): Promise<void> {
-    const contract = this.getContractId();
+  private async updateLastIndexedLedger(
+    contract: string = this.getContractId(),
+    ledger: number,
+  ): Promise<void> {
     const updateResult = await query(
       `UPDATE indexer_state
        SET last_ledger = GREATEST(last_ledger, $1),
@@ -429,7 +436,11 @@ export class EventIndexer {
     }
   }
 
-  private async processChunk(startLedger: number, endLedger: number): Promise<ProcessChunkResult> {
+  private async processChunk(
+    startLedger: number,
+    endLedger: number,
+    contractId: string = this.getContractId(),
+  ): Promise<ProcessChunkResult> {
     const correlationId = `indexer-${createRequestId()}`;
 
     return runWithRequestContext(correlationId, async () => {
@@ -449,7 +460,7 @@ export class EventIndexer {
       }
 
       try {
-        const events = await this.fetchEventsInRange(startLedger, endLedger);
+        const events = await this.fetchEventsInRange(startLedger, endLedger, contractId);
         if (events.length === 0) {
           return {
             lastProcessedLedger: endLedger,
@@ -490,6 +501,7 @@ export class EventIndexer {
   private async fetchEventsInRange(
     startLedger: number,
     endLedger: number,
+    contractId: string,
   ): Promise<SorobanRawEvent[]> {
     const result: SorobanRawEvent[] = [];
     let cursor: string | undefined;
@@ -504,7 +516,7 @@ export class EventIndexer {
         filters: [
           {
             type: 'contract',
-            contractIds: this.contractIds,
+            contractIds: [contractId],
           },
         ],
       } as never)) as unknown as {

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -15,6 +15,7 @@ import {
   getStellarNetworkPassphrase,
   getStellarRpcUrl,
 } from '../config/stellar.js';
+import { toStroops } from '../money/decimal.js';
 
 /**
  * Service for building and submitting Soroban contract transactions.
@@ -499,7 +500,7 @@ class SorobanService {
     const account = await server.getAccount(borrowerPublicKey);
 
     const loanIdScVal = nativeToScVal(loanId, { type: 'u32' });
-    const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,

--- a/contracts/lending_pool/test_snapshots/test/test_full_loan_cycle_with_interest.1.json
+++ b/contracts/lending_pool/test_snapshots/test/test_full_loan_cycle_with_interest.1.json
@@ -669,6 +669,42 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "TotalManagedAssets"
+                            },
+                            {
+                              "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 40
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalOutstanding"
+                            },
+                            {
+                              "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "TotalShares"
                             },
                             {

--- a/contracts/lending_pool/test_snapshots/test/test_pro_rata_yield_distribution_on_withdrawal.1.json
+++ b/contracts/lending_pool/test_snapshots/test/test_pro_rata_yield_distribution_on_withdrawal.1.json
@@ -679,6 +679,24 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "TotalManagedAssets"
+                            },
+                            {
+                              "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 50
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "TotalShares"
                             },
                             {

--- a/contracts/lending_pool/test_snapshots/test/test_subsequent_depositor_does_not_dilute_existing_holders.1.json
+++ b/contracts/lending_pool/test_snapshots/test/test_subsequent_depositor_does_not_dilute_existing_holders.1.json
@@ -681,6 +681,24 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "TotalManagedAssets"
+                            },
+                            {
+                              "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 51
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "TotalShares"
                             },
                             {

--- a/contracts/lending_pool/test_snapshots/test/test_withdraw_returns_principal_plus_interest.1.json
+++ b/contracts/lending_pool/test_snapshots/test/test_withdraw_returns_principal_plus_interest.1.json
@@ -528,6 +528,24 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "TotalManagedAssets"
+                            },
+                            {
+                              "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 100
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "TotalShares"
                             },
                             {

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -162,6 +162,7 @@ impl LoanManager {
     const DEFAULT_SCORE_PENALTY_POINTS: u32 = 50;
     const NFT_MAX_SCORE: u32 = 850;
     const DEFAULT_MIN_REPAYMENT_AMOUNT: i128 = 100;
+    const STROOPS_PER_TOKEN: i128 = 10_000_000;
     const MAX_EXTENSIONS: u32 = 3;
     const EXTENSION_FEE_BPS: u32 = 100; // 1% of remaining principal
     /// Default minimum interest rate (configurable via set_rate_bounds). #631
@@ -638,14 +639,12 @@ impl LoanManager {
         } else {
             loan.term_ledgers as i128
         };
-        let incremental_fee = remaining_principal
+        let late_fee_numerator = remaining_principal
             .checked_mul(Self::late_fee_rate_bps(env) as i128)
             .and_then(|value| value.checked_mul(overdue_ledgers as i128))
-            .and_then(|value| value.checked_div(10_000))
-            .and_then(|value| value.checked_div(term_ledgers))
             .expect("late fee overflow");
         let late_fee_denominator = 10_000i128
-            .checked_mul(Self::DEFAULT_TERM_LEDGERS as i128)
+            .checked_mul(term_ledgers)
             .expect("late fee overflow");
         let incremental_fee = money::round_div(
             late_fee_numerator,
@@ -1435,7 +1434,7 @@ impl LoanManager {
                     // Use apply_score_delta rather than update_score so score adjustments
                     // work for any token denomination without hitting RemittanceNFT's
                     // anti-dust repayment floor (which assumes XLM stroops).
-                    let points_i128 = amount / 100;
+                    let points_i128 = amount / (100 * Self::STROOPS_PER_TOKEN);
                     let points_i32 = if points_i128 > i32::MAX as i128 {
                         i32::MAX
                     } else if points_i128 <= 0 {

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -825,8 +825,8 @@ fn test_repayment_flow() {
     let completed = manager.get_loan(&loan_id);
     assert_eq!(completed.status, LoanStatus::Repaid);
 
-    // Score updates include both partial and final repayment contributions.
-    assert_eq!(nft_client.get_score(&borrower), 610);
+    // Tiny raw amounts do not cross the whole-token score threshold.
+    assert_eq!(nft_client.get_score(&borrower), 600);
 }
 
 #[test]
@@ -985,6 +985,41 @@ fn test_small_repayment_does_not_change_score() {
     manager.repay(&borrower, &loan_id, &99);
 
     assert_eq!(nft_client.get_score(&borrower), 600);
+}
+
+#[test]
+fn test_stroop_repayment_score_uses_whole_token_scale() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &600,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &2_000_000_000);
+    stellar_token.mint(&borrower, &2_000_000_000);
+    manager.set_max_loan_amount(&1_000_000_000);
+    manager.set_min_repayment_amount(&1);
+
+    let small_loan_id = manager.request_loan(&borrower, &100_000_000, &17280);
+    manager.approve_loan(&small_loan_id);
+    manager.repay(&borrower, &small_loan_id, &100_000_000);
+    assert_eq!(nft_client.get_score(&borrower), 600);
+
+    let threshold_loan_id = manager.request_loan(&borrower, &1_000_000_000, &17280);
+    manager.approve_loan(&threshold_loan_id);
+    manager.repay(&borrower, &threshold_loan_id, &1_000_000_000);
+    assert_eq!(nft_client.get_score(&borrower), 601);
 }
 
 #[test]

--- a/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_enforced_and_released_on_repay.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_borrower_max_active_loans_enforced_and_released_on_repay.1.json
@@ -864,7 +864,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 710
+                        "u32": 700
                       }
                     }
                   ]
@@ -913,88 +913,6 @@
                 "durability": "persistent",
                 "val": {
                   "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 710
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 700
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
                 }
               }
             },

--- a/contracts/loan_manager/test_snapshots/test/test_check_default_already_repaid.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_check_default_already_repaid.1.json
@@ -676,7 +676,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 610
+                        "u32": 600
                       }
                     }
                   ]
@@ -725,88 +725,6 @@
                 "durability": "persistent",
                 "val": {
                   "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 610
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
                 }
               }
             },

--- a/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_and_auto_release_on_full_repayment.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_deposit_collateral_and_auto_release_on_full_repayment.1.json
@@ -731,7 +731,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 660
+                        "u32": 650
                       }
                     }
                   ]
@@ -780,88 +780,6 @@
                 "durability": "persistent",
                 "val": {
                   "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 660
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 650
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
                 }
               }
             },

--- a/contracts/loan_manager/test_snapshots/test/test_full_repayment_ignores_minimum_amount.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_full_repayment_ignores_minimum_amount.1.json
@@ -732,7 +732,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 610
+                        "u32": 600
                       }
                     }
                   ]
@@ -781,88 +781,6 @@
                 "durability": "persistent",
                 "val": {
                   "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 610
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
                 }
               }
             },

--- a/contracts/loan_manager/test_snapshots/test/test_get_borrower_loans.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_get_borrower_loans.1.json
@@ -787,7 +787,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 610
+                        "u32": 600
                       }
                     }
                   ]
@@ -842,88 +842,6 @@
             "ext": "v0"
           },
           518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 100
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 610
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518500
         ]
       ],
       [

--- a/contracts/loan_manager/test_snapshots/test/test_overdue_partial_repayment_still_reduces_principal.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_overdue_partial_repayment_still_reduces_principal.1.json
@@ -781,7 +781,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 603
+                        "u32": 600
                       }
                     }
                   ]
@@ -836,88 +836,6 @@
             "ext": "v0"
           },
           518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 25921
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 603
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          544321
         ]
       ],
       [

--- a/contracts/loan_manager/test_snapshots/test/test_overdue_repayment_charges_late_fee.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_overdue_repayment_charges_late_fee.1.json
@@ -782,7 +782,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 603
+                        "u32": 600
                       }
                     }
                   ]
@@ -837,88 +837,6 @@
             "ext": "v0"
           },
           518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 25921
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 603
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          544321
         ]
       ],
       [

--- a/contracts/loan_manager/test_snapshots/test/test_partial_repayment_tracks_split_balances.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_partial_repayment_tracks_split_balances.1.json
@@ -731,7 +731,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 850
+                        "u32": 600
                       }
                     }
                   ]
@@ -780,88 +780,6 @@
                 "durability": "persistent",
                 "val": {
                   "bytes": "0100000000000000000000000000000000000000000000000000000000000000"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 850
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
                 }
               }
             },

--- a/contracts/loan_manager/test_snapshots/test/test_repayment_flow.1.json
+++ b/contracts/loan_manager/test_snapshots/test/test_repayment_flow.1.json
@@ -732,7 +732,7 @@
                         "symbol": "score"
                       },
                       "val": {
-                        "u32": 610
+                        "u32": 600
                       }
                     }
                   ]
@@ -787,124 +787,6 @@
             "ext": "v0"
           },
           518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ScoreHistory"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ScoreHistory"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 2000
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 605
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 600
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "ledger"
-                          },
-                          "val": {
-                            "u32": 2000
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "new_score"
-                          },
-                          "val": {
-                            "u32": 610
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "old_score"
-                          },
-                          "val": {
-                            "u32": 605
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "reason"
-                          },
-                          "val": {
-                            "symbol": "ADJ"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          520400
         ]
       ],
       [

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -88,7 +88,7 @@ impl RemittanceNFT {
     /// Stroop scale (10^7) — token amounts are denominated in stroops.
     const STROOP_SCALE: i128 = 10_000_000;
     /// Points denominator: 1 point per 100 tokens (100 * STROOP_SCALE stroops).
-    const POINTS_DENOMINATOR: i128 = 100 * 10_000_000; // 1_000_000_000 stroops = $100
+    const POINTS_DENOMINATOR: i128 = 100 * Self::STROOP_SCALE; // 1_000_000_000 stroops = $100
     /// Minimum repayment amount accepted by update_score() (1 point worth in stroops).
     /// Dust repayments below this threshold award 0 score points due to integer
     /// division (`repayment_amount / POINTS_DENOMINATOR == 0`) but still write storage and emit


### PR DESCRIPTION
## Summary
- Persist auth challenge nonces with a 5-minute TTL and atomically consume them during login to block replayed or self-issued challenges.
- Track EventIndexer cursors/checkpoints/suspect ranges per configured contract instead of always using the first contract id.
- Scale deposit collateral amounts to stroops before building Soroban transactions.
- Scale repayment score deltas by whole-token stroop units and keep contract snapshots/tests aligned.
- Restore late-fee numerator rounding and reuse the remittance NFT stroop scale constant so the contracts CI checks compile cleanly.

## Testing
- npm run lint
- npm run build
- npm run typecheck
- npm run test -- auth.test.ts eventIndexerCheckpoints.test.ts
- npm test
- cargo fmt --check
- cargo clippy -p loan_manager
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p loan_manager test_stroop_repayment_score_uses_whole_token_scale
- cargo test -p loan_manager
- cargo test -- --test-threads=1

## Pull Request Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] I have verified the changes locally.

Closes #1668
Closes #1667
Closes #1666
Closes #1665