### PR TITLE
fix(security): configure Express trust proxy for accurate client IP resolution (#1069)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,9 @@ FRONTEND_URL=http://localhost:3000
 
 # Server Configuration
 PORT=3001
+# Express trust proxy setting behind reverse proxies / load balancers (e.g. 1, true, false, or comma-separated IPs)
+# Defaults to 1 in production and false in development/test.
+TRUST_PROXY=1
 
 DATABASE_URL=postgres://postgres:postgres@db:5432/remitlend
 # Docker default (use redis://localhost:6379 if running Redis outside docker-compose)

--- a/backend/src/__tests__/trustProxy.test.ts
+++ b/backend/src/__tests__/trustProxy.test.ts
@@ -1,0 +1,88 @@
+import express from 'express';
+import request from 'supertest';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+
+describe('Express Trust Proxy & Rate Limiting IP Resolution (Issue #1069)', () => {
+  describe('Trust Proxy IP Resolution', () => {
+    it('resolves real client IP from X-Forwarded-For when trust proxy is enabled (1 hop)', async () => {
+      const app = express();
+      app.set('trust proxy', 1);
+
+      app.get('/test-ip', (req, res) => {
+        res.json({
+          ip: req.ip,
+          ips: req.ips,
+        });
+      });
+
+      const res = await request(app)
+        .get('/test-ip')
+        .set('X-Forwarded-For', '203.0.113.195, 10.0.0.1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ip).toBe('203.0.113.195');
+    });
+
+    it('does not trust spoofed X-Forwarded-For when trust proxy is disabled', async () => {
+      const app = express();
+      app.set('trust proxy', false);
+
+      app.get('/test-ip', (req, res) => {
+        res.json({
+          ip: req.ip,
+        });
+      });
+
+      const res = await request(app)
+        .get('/test-ip')
+        .set('X-Forwarded-For', '203.0.113.195');
+
+      expect(res.status).toBe(200);
+      // Behind false, req.ip will not be the spoofed 203.0.113.195 (defaults to supertest localhost IP ::ffff:127.0.0.1 or 127.0.0.1)
+      expect(res.body.ip).not.toBe('203.0.113.195');
+    });
+  });
+
+  describe('Rate Limiter Per-Client IP Isolation Behind Proxy', () => {
+    it('isolates rate-limit counters per distinct client IP behind reverse proxy', async () => {
+      const app = express();
+      app.set('trust proxy', 1);
+
+      const limiter = rateLimit({
+        windowMs: 60 * 1000,
+        max: 2,
+        keyGenerator: (req) => ipKeyGenerator(req.ip ?? 'unknown'),
+        standardHeaders: true,
+        legacyHeaders: false,
+      });
+
+      app.use('/limited', limiter);
+      app.get('/limited', (req, res) => {
+        res.json({ success: true, ip: req.ip });
+      });
+
+      // Client A makes 2 requests (allowed)
+      const resA1 = await request(app)
+        .get('/limited')
+        .set('X-Forwarded-For', '198.51.100.1, 10.0.0.1');
+      expect(resA1.status).toBe(200);
+
+      const resA2 = await request(app)
+        .get('/limited')
+        .set('X-Forwarded-For', '198.51.100.1, 10.0.0.1');
+      expect(resA2.status).toBe(200);
+
+      // Client A makes 3rd request (rate limited)
+      const resA3 = await request(app)
+        .get('/limited')
+        .set('X-Forwarded-For', '198.51.100.1, 10.0.0.1');
+      expect(resA3.status).toBe(429);
+
+      // Client B from a different IP is NOT blocked by Client A's rate limit
+      const resB1 = await request(app)
+        .get('/limited')
+        .set('X-Forwarded-For', '198.51.100.2, 10.0.0.1');
+      expect(resB1.status).toBe(200);
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,8 +31,30 @@ import { requestLogger } from './middleware/requestLogger.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { pauseGuard } from './middleware/pauseGuard.js';
 import { asyncHandler } from './utils/asyncHandler.js';
-import { AppError } from './errors/AppError.js';
 const app = express();
+
+// Configure Express 'trust proxy' so req.ip and rate-limiting resolve real client IPs
+// behind reverse proxies / load balancers (issue #1069).
+const trustProxyConfig = process.env.TRUST_PROXY?.trim();
+if (trustProxyConfig !== undefined && trustProxyConfig !== '') {
+  if (trustProxyConfig.toLowerCase() === 'true') {
+    app.set('trust proxy', true);
+  } else if (trustProxyConfig.toLowerCase() === 'false') {
+    app.set('trust proxy', false);
+  } else if (!isNaN(Number(trustProxyConfig))) {
+    app.set('trust proxy', Number(trustProxyConfig));
+  } else {
+    // Comma-separated list of IPs, subnets or trust options (e.g. 'loopback, linklocal')
+    const proxies = trustProxyConfig.split(',').map((p) => p.trim()).filter(Boolean);
+    app.set('trust proxy', proxies.length === 1 ? proxies[0] : proxies);
+  }
+} else if (process.env.NODE_ENV === 'production') {
+  // In production default to 1 proxy hop (e.g. Nginx, ALB, Cloud Run)
+  app.set('trust proxy', 1);
+} else {
+  // Safe default in local dev and testing (do not trust arbitrary spoofed headers)
+  app.set('trust proxy', false);
+}
 
 const isProduction = process.env.NODE_ENV === 'production';
 const configuredFrontendUrl = process.env.FRONTEND_URL?.trim();

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -39,6 +39,7 @@ stricter rate limit (10 requests/minute/IP) to prevent abuse.
 | `CORS_ALLOWED_ORIGINS` | ✓ | ✓ | ✓ | `http://localhost:3000,http://localhost:3001` | Comma-separated origins allowed by CORS | `backend/src/config/index.ts` |
 | `FRONTEND_URL` | ✓ | ✓ | ✓ | `http://localhost:3000` | Frontend base URL used for links | `backend/src/config/index.ts` |
 | `PORT` | ✓ | ✓ | ✓ | `3001` | HTTP port the API listens on | `backend/src/index.ts` |
+| `TRUST_PROXY` | — | ✓ | ✓ | `false` (dev) / `1` (prod) | Express `trust proxy` setting (e.g. `1`, `true`, `false`, or comma-separated IP subnets) for resolving client IPs behind reverse proxies / load balancers | `backend/src/app.ts` |
 | `DATABASE_URL` | ✓ | ✓ | ✓ | `postgres://postgres:postgres@db:5432/remitlend` | PostgreSQL connection string | `backend/src/db/connection.js` |
 | `DB_CONN_TIMEOUT_MS` | — | ✓ | ✓ | `10000` | Pool connection timeout in ms; pool.connect() rejects instead of hanging | `backend/src/db/connection.ts` |
 | `DB_STATEMENT_TIMEOUT_MS` | — | ✓ | ✓ | `30000` | Per-query statement_timeout in ms; a stuck query never holds a connection indefinitely | `backend/src/db/connection.ts` |


### PR DESCRIPTION
Closes #1069

### Summary of Changes
- **Configured Express \	rust proxy\ in \ackend/src/app.ts\**: Supports dynamic configuration via \TRUST_PROXY\ (boolean \	rue\/\alse\, numeric hop count, or comma-separated IP/subnet list). Defaults to \1\ in production and \alse\ in development/testing to prevent header spoofing in local dev.
- **Accurate Client IP Resolution for Rate Limiting & Audit Logging**: Allows \express-rate-limit\ and audit logger to correctly resolve real client IPs from \X-Forwarded-For\ rather than the proxy/load balancer socket IP.
- **Environment Documentation**: Documented \TRUST_PROXY\ in \ackend/.env.example\ and \docs/ENVIRONMENT.md\.
- **Integration Tests**: Added \ackend/src/__tests__/trustProxy.test.ts\ verifying proxy IP resolution and per-client rate limit isolation.