### PR TITLE
fix(contracts): apply credit score penalty and record default upon liquidation (#1125)

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1710,6 +1710,16 @@ impl LoanManager {
         env.storage().persistent().set(&loan_key, &loan);
         Self::bump_persistent_ttl(&env, &loan_key);
         Self::decrement_borrower_loan_count(&env, &loan.borrower);
+
+        let nft_contract = Self::nft_contract(&env);
+        let nft_client = NftClient::new(&env, &nft_contract);
+        nft_client.decrease_score(
+            &loan.borrower,
+            &Self::DEFAULT_SCORE_PENALTY_POINTS,
+            &Some(env.current_contract_address()),
+        );
+        nft_client.record_default(&loan.borrower, &Some(env.current_contract_address()));
+
         let lending_pool: Address = env
             .storage()
             .instance()

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -3997,3 +3997,49 @@ fn test_set_rate_oracle_emits_rate_oracle_updated_event() {
         "RateOracleUpdated event should be emitted"
     );
 }
+
+#[test]
+fn test_liquidate_decreases_score_and_records_default() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &600,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &10_000);
+
+    let loan_id = manager.request_loan(&borrower, &1000, &17280);
+    manager.approve_loan(&loan_id);
+
+    stellar_token.mint(&borrower, &500);
+    manager.deposit_collateral(&loan_id, &500);
+
+    assert_eq!(nft_client.get_score(&borrower), 600);
+    assert_eq!(nft_client.get_default_count(&borrower), 0);
+    assert!(!nft_client.is_seized(&borrower));
+
+    env.ledger().set_sequence_number(50_000);
+
+    manager.liquidate(&liquidator, &loan_id);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Liquidated);
+    assert_eq!(loan.collateral_amount, 0);
+
+    assert_eq!(nft_client.get_score(&borrower), 550);
+    assert_eq!(nft_client.get_default_count(&borrower), 1);
+    assert!(nft_client.is_seized(&borrower));
+}
+


### PR DESCRIPTION
Closes #1125

### Summary of Changes
- **Updated \liquidate()\ in \contracts/loan_manager/src/lib.rs\**: Added calls to \
ft_client.decrease_score(&loan.borrower, &Self::DEFAULT_SCORE_PENALTY_POINTS, ...)\ and \
ft_client.record_default(&loan.borrower, ...)\, aligning the liquidation path with the default lifecycle in \check_default()\.
- **Preserved Non-Panicking Safety Guarantees**: Relies on \emittance_nft\'s internal active NFT check to safely handle burned or zero-score NFTs without panicking.
- **Unit Tests**: Added \	est_liquidate_decreases_score_and_records_default\ in \contracts/loan_manager/src/test.rs\ verifying that liquidating an under-collateralized loan applies the 50-point score penalty, increments the borrower's default count, and flags the borrower as seized.