### PR TITLE
fix(frontend): sign and submit loan repayment transactions

### DIFF
--- a/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
+++ b/frontend/src/app/components/borrower/LoanRepaymentForm.tsx
@@ -194,6 +194,12 @@ export function LoanRepaymentForm({ loanId, totalOwed, minPayment = 0 }: LoanRep
 
           <OperationProgress transaction={repayment.transaction} type="repayment" />
 
+          {repayment.error && (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {repayment.error}
+            </p>
+          )}
+
           {/* Action Button */}
           <Button
             variant="primary"

--- a/frontend/src/app/components/providers/WalletProvider.tsx
+++ b/frontend/src/app/components/providers/WalletProvider.tsx
@@ -25,7 +25,10 @@ interface WalletProviderContextValue {
   disconnectWallet: () => void;
   refreshWallet: () => Promise<void>;
   isFreighterAvailable: boolean;
-  signTransaction: (unsignedTxXdr: string) => Promise<string>;
+  signTransaction: (
+    unsignedTxXdr: string,
+    options?: { networkPassphrase?: string },
+  ) => Promise<string>;
 }
 
 interface WalletProviderProps {
@@ -242,10 +245,16 @@ export function WalletProvider({ children }: WalletProviderProps) {
     STANDALONE: "Standalone Network ; Separate from SDF",
   };
 
-  async function signTransaction(unsignedTxXdr: string): Promise<string> {
+  async function signTransaction(
+    unsignedTxXdr: string,
+    options?: { networkPassphrase?: string },
+  ): Promise<string> {
     const api = (await loadFreighterApi()) as unknown as ExtendedFreighterApi;
     const networkName = useWalletStore.getState().network?.name ?? "TESTNET";
-    const networkPassphrase = NETWORK_PASSPHRASES[networkName] ?? NETWORK_PASSPHRASES.TESTNET;
+    const networkPassphrase =
+      options?.networkPassphrase ??
+      NETWORK_PASSPHRASES[networkName] ??
+      NETWORK_PASSPHRASES.TESTNET;
 
     const result = await api.signTransaction(unsignedTxXdr, {
       networkPassphrase,

--- a/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
+++ b/frontend/src/app/hooks/useApi.optimisticRollback.test.tsx
@@ -95,7 +95,7 @@ const seedDepositor = (): DepositorPortfolio => ({
   firstDepositAt: "2026-01-01",
 });
 
-describe("useRepayLoan optimistic rollback", () => {
+describe("useRepayLoan repayment transaction building", () => {
   const originalFetch = global.fetch;
 
   afterEach(() => {
@@ -115,38 +115,47 @@ describe("useRepayLoan optimistic rollback", () => {
     return { loanDetail, borrowerLoans, poolStats };
   }
 
-  it("onMutate updates loan detail optimistically while pending", async () => {
-    global.fetch = mockFetchSuccess({ txHash: "abc" }) as unknown as typeof fetch;
+  it("returns the unsigned XDR without marking the loan repaid", async () => {
+    global.fetch = mockFetchSuccess({
+      unsignedTxXdr: "xdr",
+      networkPassphrase: "passphrase",
+    }) as unknown as typeof fetch;
     const { queryClient, wrapper } = createTestHarness();
     seedRepayCache(queryClient);
 
     const { result } = renderHook(() => useRepayLoan(), { wrapper });
 
-    result.current.mutate({ loanId: LOAN_ID, amount: 100, borrowerAddress: BORROWER });
-
-    await waitFor(() => {
-      const cached = queryClient.getQueryData<LoanDetails>(queryKeys.loans.detail(String(LOAN_ID)));
-      expect(cached?.totalOwed).toBe(750);
-      expect(cached?.totalRepaid).toBe(300);
-      expect(cached?.status).toBe("active");
+    const built = await result.current.mutateAsync({
+      loanId: LOAN_ID,
+      amount: 100,
+      borrowerAddress: BORROWER,
     });
+
+    expect(built).toEqual({ unsignedTxXdr: "xdr", networkPassphrase: "passphrase" });
+    expect(queryClient.getQueryData(queryKeys.loans.detail(String(LOAN_ID)))).toEqual(
+      seedLoanDetail(),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/loans/${LOAN_ID}/repay`),
+      expect.objectContaining({
+        body: JSON.stringify({ amount: 100, borrowerPublicKey: BORROWER }),
+      }),
+    );
   });
 
-  it("onMutate flips status to repaid when repayment covers totalOwed", async () => {
-    global.fetch = mockFetchSuccess({ txHash: "abc" }) as unknown as typeof fetch;
+  it("rejects an invalid build response before signing can begin", async () => {
+    global.fetch = mockFetchSuccess({ unsignedTxXdr: "xdr" }) as unknown as typeof fetch;
     const { queryClient, wrapper } = createTestHarness();
     seedRepayCache(queryClient);
 
     const { result } = renderHook(() => useRepayLoan(), { wrapper });
 
-    result.current.mutate({ loanId: LOAN_ID, amount: 850, borrowerAddress: BORROWER });
-
-    await waitFor(() => {
-      const cached = queryClient.getQueryData<LoanDetails>(queryKeys.loans.detail(String(LOAN_ID)));
-      expect(cached?.totalOwed).toBe(0);
-      expect(cached?.totalRepaid).toBe(1050);
-      expect(cached?.status).toBe("repaid");
-    });
+    await expect(
+      result.current.mutateAsync({ loanId: LOAN_ID, amount: 850, borrowerAddress: BORROWER }),
+    ).rejects.toThrow("invalid transaction data");
+    expect(queryClient.getQueryData(queryKeys.loans.detail(String(LOAN_ID)))).toEqual(
+      seedLoanDetail(),
+    );
   });
 
   it("onError restores exact previous loan detail, borrower loans, and pool stats", async () => {
@@ -167,8 +176,11 @@ describe("useRepayLoan optimistic rollback", () => {
     expect(queryClient.getQueryData(queryKeys.pool.stats())).toEqual(poolStats);
   });
 
-  it("onSettled invalidates loans.detail, borrowerLoans.byAddress, and pool.stats", async () => {
-    global.fetch = mockFetchSuccess({ txHash: "abc" }) as unknown as typeof fetch;
+  it("does not invalidate repayment data until a signed transaction is submitted", async () => {
+    global.fetch = mockFetchSuccess({
+      unsignedTxXdr: "xdr",
+      networkPassphrase: "passphrase",
+    }) as unknown as typeof fetch;
     const { queryClient, wrapper } = createTestHarness();
     seedRepayCache(queryClient);
     const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
@@ -179,13 +191,7 @@ describe("useRepayLoan optimistic rollback", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: queryKeys.loans.detail(String(LOAN_ID)),
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: queryKeys.borrowerLoans.byAddress(BORROWER),
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.pool.stats() });
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -1549,96 +1549,38 @@ export function useResolveAdminDispute() {
 // ─── Optimistic mutations ─────────────────────────────────────────────────────
 
 /**
- * Submits a loan repayment directly to the server and updates the cache
- * with optimistic rollback on failure.
- *
- * This hook calls `/loans/{loanId}/repay` (a full server-side build+sign+submit
- * flow). It is NOT a build-only hook — the mutation succeeds only when the
- * server has submitted the transaction on-chain and returned a `txHash`.
- * The optimistic loan-status update is rolled back automatically on error.
+ * Builds an unsigned loan repayment transaction. The caller must sign the
+ * returned XDR and submit it with `submitLoanTransaction` before treating the
+ * repayment as successful.
  */
 export function useRepayLoan() {
-  const queryClient = useQueryClient();
-
-  type RepayContext = {
-    previousLoanDetail: unknown;
-    previousBorrowerLoans: unknown;
-    previousPoolStats: unknown;
-  };
-
   return useMutation<
-    { txHash: string },
+    { unsignedTxXdr: string; networkPassphrase: string },
     Error,
-    { loanId: number; amount: number; borrowerAddress: string },
-    RepayContext
+    { loanId: number; amount: number; borrowerAddress: string }
   >({
-    mutationFn: ({ loanId, amount }) =>
-      apiFetch<{ txHash: string }>(`/loans/${loanId}/repay`, {
-        method: "POST",
-        body: JSON.stringify({ amount }),
-      }),
-
-    onMutate: async ({ loanId, amount, borrowerAddress }) => {
-      await queryClient.cancelQueries({
-        queryKey: queryKeys.loans.detail(String(loanId)),
-      });
-      await queryClient.cancelQueries({
-        queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress),
-      });
-      await queryClient.cancelQueries({ queryKey: queryKeys.pool.stats() });
-
-      const previousLoanDetail = queryClient.getQueryData(queryKeys.loans.detail(String(loanId)));
-      const previousBorrowerLoans = queryClient.getQueryData(
-        queryKeys.borrowerLoans.byAddress(borrowerAddress),
-      );
-      const previousPoolStats = queryClient.getQueryData(queryKeys.pool.stats());
-
-      // Optimistically update the loan detail
-      queryClient.setQueryData(
-        queryKeys.loans.detail(String(loanId)),
-        (old: LoanDetails | undefined) => {
-          if (!old) return old;
-          const newOwed = Math.max(0, old.totalOwed - amount);
-          return {
-            ...old,
-            totalOwed: newOwed,
-            totalRepaid: old.totalRepaid + amount,
-            status: newOwed <= 0 ? ("repaid" as const) : old.status,
-          };
+    mutationFn: async ({ loanId, amount, borrowerAddress }) => {
+      const result = await apiFetch<{ unsignedTxXdr?: unknown; networkPassphrase?: unknown }>(
+        `/loans/${loanId}/repay`,
+        {
+          method: "POST",
+          body: JSON.stringify({ amount, borrowerPublicKey: borrowerAddress }),
         },
       );
 
-      return { previousLoanDetail, previousBorrowerLoans, previousPoolStats };
-    },
+      if (
+        typeof result.unsignedTxXdr !== "string" ||
+        result.unsignedTxXdr.length === 0 ||
+        typeof result.networkPassphrase !== "string" ||
+        result.networkPassphrase.length === 0
+      ) {
+        throw new Error("Repayment transaction build returned invalid transaction data.");
+      }
 
-    onError: (_error, { loanId, borrowerAddress }, context) => {
-      if (context?.previousLoanDetail !== undefined) {
-        queryClient.setQueryData(
-          queryKeys.loans.detail(String(loanId)),
-          context.previousLoanDetail,
-        );
-      }
-      if (context?.previousBorrowerLoans !== undefined) {
-        queryClient.setQueryData(
-          queryKeys.borrowerLoans.byAddress(borrowerAddress),
-          context.previousBorrowerLoans,
-        );
-      }
-      if (context?.previousPoolStats !== undefined) {
-        queryClient.setQueryData(queryKeys.pool.stats(), context.previousPoolStats);
-      }
-    },
-
-    onSettled: (_data, _error, { loanId, borrowerAddress }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.loans.detail(String(loanId)) });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress),
-      });
-      // Also invalidate paginated borrower loans (borrowerPage) so both namespaces stay in sync (#1219)
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.pool.stats() });
+      return {
+        unsignedTxXdr: result.unsignedTxXdr,
+        networkPassphrase: result.networkPassphrase,
+      };
     },
   });
 }

--- a/frontend/src/app/hooks/useRepaymentOperation.ts
+++ b/frontend/src/app/hooks/useRepaymentOperation.ts
@@ -1,8 +1,8 @@
 /**
  * hooks/useRepaymentOperation.ts
  *
- * Complete repayment operation management with optimistic updates,
- * progress tracking, and automatic state rollback on failure.
+ * Complete repayment operation management with build, wallet-signing,
+ * network submission, and progress tracking.
  *
  * Usage Example:
  * ```tsx
@@ -11,7 +11,7 @@
  * const handleRepay = async () => {
  *   repayment.start("Repaying loan...);
  *   try {
- *     const result = await repayLoan({ loanId: 123, amount: 500 });
+ *     const result = await repayment.executeRepayment({ loanId: 123, amount: 500 });
  *     repayment.success(result.txHash);
  *   } catch (error) {
  *     repayment.error(error.message);
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { useCallback, useId, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTransaction } from "./useOptimisticUI";
 import { useWallet } from "../components/providers/WalletProvider";
@@ -29,6 +29,7 @@ import {
   usePoolStats,
   useRepayLoan,
   useWithdrawFromPool,
+  submitLoanTransaction,
   submitPoolTransaction,
   queryKeys,
 } from "./useApi";
@@ -53,6 +54,8 @@ export function useRepaymentOperation(options?: {
   const transaction = useTransaction(transactionId);
   const [error, setError] = useState<string | null>(null);
   const repayLoan = useRepayLoan();
+  const { signTransaction } = useWallet();
+  const isExecuting = useRef(false);
 
   const executeRepayment = useCallback(
     async ({
@@ -60,19 +63,41 @@ export function useRepaymentOperation(options?: {
       amount,
       borrowerAddress,
     }: RepaymentOperationOptions): Promise<RepaymentOperationResult> => {
+      if (isExecuting.current) {
+        throw new Error("A repayment is already being processed.");
+      }
+
+      isExecuting.current = true;
       transaction.start("Processing repayment...");
       setError(null);
 
       try {
-        transaction.updateProgress(20, "Submitting repayment...");
+        transaction.updateProgress(20, "Building repayment transaction...");
+        const buildResult = await repayLoan.mutateAsync({ loanId, amount, borrowerAddress });
 
-        // useRepayLoan handles the full submit flow with optimistic cache updates
-        const response = await repayLoan.mutateAsync({ loanId, amount, borrowerAddress });
-        const txHash = response.txHash ?? String(loanId);
+        transaction.sign("Waiting for wallet signature...");
+        const signedTxXdr = await signTransaction(buildResult.unsignedTxXdr, {
+          networkPassphrase: buildResult.networkPassphrase,
+        });
+
+        transaction.updateProgress(70, "Submitting repayment to Stellar...");
+        const submitResult = await submitLoanTransaction(signedTxXdr);
+        if (submitResult.status !== "SUCCESS" || !submitResult.txHash) {
+          throw new Error("Stellar did not confirm the repayment transaction.");
+        }
+
+        const txHash = submitResult.txHash;
 
         transaction.submit(txHash, "Transaction submitted, waiting for confirmation...");
         transaction.confirm("Confirming transaction...");
-        transaction.complete(txHash);
+        transaction.complete(txHash, "Repayment successful!");
+
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.loans.detail(String(loanId)) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.pool.stats() }),
+        ]);
 
         const result = { txHash, status: "success" as const };
         options?.onSuccess?.(result);
@@ -83,9 +108,11 @@ export function useRepaymentOperation(options?: {
         setError(errorMessage);
         options?.onError?.(err instanceof Error ? err : new Error(errorMessage));
         throw err;
+      } finally {
+        isExecuting.current = false;
       }
     },
-    [transaction, repayLoan, options],
+    [transaction, repayLoan, signTransaction, queryClient, options],
   );
 
   return {


### PR DESCRIPTION
## Summary

Fixes the broken loan repayment flow where repayment transactions were built but never signed or submitted to the Stellar network.

The repayment flow now follows the correct transaction lifecycle:

**Build transaction → Sign with wallet → Submit to network → Confirm success**

## Changes

* Updated the repayment API contract to handle `unsignedTxXdr` and `networkPassphrase` returned by the backend.
* Refactored the repayment operation to sign transactions through the wallet before submission.
* Removed the placeholder transaction hash that incorrectly used the loan ID.
* Ensured repayment success states are triggered only after successful network submission.
* Prevented gamification XP and success messages from being granted for transactions that were never executed.
* Improved handling of signing, submission, and network errors.

## Problem

Previously, the frontend treated `/loans/:loanId/repay` as a fully executed transaction endpoint even though it only returns an unsigned transaction XDR. This allowed the UI to report a successful repayment without any transaction being signed or submitted to the Stellar network.

## Testing

* Verified the updated repayment flow follows the required build → sign → submit lifecycle.
* Ran the relevant project validation checks and addressed any issues introduced by the changes.

## Related Issue

Closes #1603
