### PR TITLE
fix(contracts): reject delay_seconds >= PROPOSAL_TTL_SECONDS in multi…

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -57,8 +57,7 @@ export function validateEnvVars(): void {
 
   // PII encryption requires either a KMS endpoint or a local KEK key.
   // Both missing means PII would be encrypted with a static all-zero key.
-  const hasKmsEndpoint =
-    process.env.PII_KMS_ENDPOINT && process.env.PII_KMS_ENDPOINT.trim() !== '';
+  const hasKmsEndpoint = process.env.PII_KMS_ENDPOINT && process.env.PII_KMS_ENDPOINT.trim() !== '';
   const hasKekKey = process.env.PII_KEK_KEY && process.env.PII_KEK_KEY.trim() !== '';
 
   if (!hasKmsEndpoint && !hasKekKey) {

--- a/backend/src/tests/envValidation.test.ts
+++ b/backend/src/tests/envValidation.test.ts
@@ -7,6 +7,25 @@ describe('Environment Variable Validation', () => {
   const originalEnv = process.env;
   let mockExit: ReturnType<typeof jest.spyOn>;
 
+  function setAllRequiredVars(): void {
+    process.env.DATABASE_URL = 'postgres://localhost';
+    process.env.REDIS_URL = 'redis://localhost';
+    process.env.JWT_SECRET = 'secret';
+    process.env.STELLAR_RPC_URL = 'http://localhost';
+    process.env.STELLAR_NETWORK_PASSPHRASE = 'test';
+    process.env.LOAN_MANAGER_CONTRACT_ID = 'C1';
+    process.env.LENDING_POOL_CONTRACT_ID = 'C2';
+    process.env.REMITTANCE_NFT_CONTRACT_ID = 'C3';
+    process.env.MULTISIG_GOVERNANCE_CONTRACT_ID = 'C4';
+    process.env.POOL_TOKEN_ADDRESS = 'T1';
+    process.env.LOAN_MANAGER_ADMIN_SECRET = 'S1';
+    process.env.INTERNAL_API_KEY = 'K1';
+    process.env.FRONTEND_URL = 'http://localhost:3000';
+    process.env.SCORE_DELTA_REPAY = '15';
+    process.env.SCORE_DELTA_DEFAULT = '50';
+    process.env.SCORE_DELTA_LATE = '5';
+  }
+
   beforeAll(() => {
     mockExit = jest
       .spyOn(process, 'exit')
@@ -27,30 +46,16 @@ describe('Environment Variable Validation', () => {
   });
 
   it('should not exit if all required variables are present', () => {
-    // All required variables are expected to be in originalEnv/process.env
-    // or we set them here for the test
-    process.env.DATABASE_URL = 'postgres://localhost';
-    process.env.REDIS_URL = 'redis://localhost';
-    process.env.JWT_SECRET = 'secret';
-    process.env.STELLAR_RPC_URL = 'http://localhost';
-    process.env.STELLAR_NETWORK_PASSPHRASE = 'test';
-    process.env.LOAN_MANAGER_CONTRACT_ID = 'C1';
-    process.env.LENDING_POOL_CONTRACT_ID = 'C2';
-    process.env.POOL_TOKEN_ADDRESS = 'T1';
-    process.env.LOAN_MANAGER_ADMIN_SECRET = 'S1';
-    process.env.INTERNAL_API_KEY = 'K1';
-    process.env.FRONTEND_URL = 'http://localhost:3000';
-    process.env.SCORE_DELTA_REPAY = '15';
-    process.env.SCORE_DELTA_DEFAULT = '50';
-    process.env.SCORE_DELTA_LATE = '5';
-    process.env.REMITTANCE_NFT_CONTRACT_ID = 'C3';
-    process.env.MULTISIG_GOVERNANCE_CONTRACT_ID = 'C4';
+    setAllRequiredVars();
+    process.env.PII_KMS_ENDPOINT = 'https://kms.example.com';
 
     expect(() => validateEnvVars()).not.toThrow();
     expect(mockExit).not.toHaveBeenCalled();
   });
 
   it('should exit with code 1 if a required variable is missing', () => {
+    setAllRequiredVars();
+    process.env.PII_KMS_ENDPOINT = 'https://kms.example.com';
     delete process.env.DATABASE_URL;
 
     expect(() => validateEnvVars()).toThrow('Process.exit called with 1');
@@ -58,6 +63,8 @@ describe('Environment Variable Validation', () => {
   });
 
   it('should exit with code 1 if a required variable is empty string', () => {
+    setAllRequiredVars();
+    process.env.PII_KMS_ENDPOINT = 'https://kms.example.com';
     process.env.DATABASE_URL = '   ';
 
     expect(() => validateEnvVars()).toThrow('Process.exit called with 1');
@@ -65,6 +72,7 @@ describe('Environment Variable Validation', () => {
   });
 
   it('should exit if neither PII_KEK_KEY nor PII_KMS_ENDPOINT is set', () => {
+    setAllRequiredVars();
     delete process.env.PII_KEK_KEY;
     delete process.env.PII_KMS_ENDPOINT;
 
@@ -73,6 +81,7 @@ describe('Environment Variable Validation', () => {
   });
 
   it('should not exit if PII_KMS_ENDPOINT is set', () => {
+    setAllRequiredVars();
     process.env.PII_KMS_ENDPOINT = 'https://kms.example.com';
     delete process.env.PII_KEK_KEY;
 
@@ -81,6 +90,7 @@ describe('Environment Variable Validation', () => {
   });
 
   it('should not exit if PII_KEK_KEY is set', () => {
+    setAllRequiredVars();
     process.env.PII_KEK_KEY = 'a'.repeat(64);
     delete process.env.PII_KMS_ENDPOINT;
 

--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -59,6 +59,7 @@ pub fn loan_requested(env: &Env, loan_id: u32, borrower: Address, amount: i128) 
 /// A single call to `approve_loan` in `lib.rs` emits **two** events:
 /// 1. `LoanApproved` (emitted here with loan terms and interest rate)
 /// 2. `LoanApprv` (emitted by [`loan_approved_by_admin`] with admin and borrower address)
+///
 /// Indexers should de-duplicate or reconcile both events.
 pub fn loan_approved(
     env: &Env,

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -4131,4 +4131,3 @@ fn test_liquidate_decreases_score_and_records_default() {
     assert_eq!(nft_client.get_default_count(&borrower), 1);
     assert!(nft_client.is_seized(&borrower));
 }
-

--- a/contracts/multisig_governance/src/lib.rs
+++ b/contracts/multisig_governance/src/lib.rs
@@ -18,6 +18,11 @@ const MAX_SIGNERS: u32 = 20;
 /// Time-to-live for proposals before they expire (7 days in seconds).
 const PROPOSAL_TTL_SECONDS: u64 = 604_800;
 
+/// Maximum timelock delay. Must be strictly less than PROPOSAL_TTL_SECONDS
+/// so the finalize window [executable_after, expiry) is always non-empty.
+/// With the default TTL of 7 days this allows delays up to ~6 days 23 h 59 min.
+const MAX_TIMELOCK_SECONDS: u64 = PROPOSAL_TTL_SECONDS - 1;
+
 // ─── Storage keys ─────────────────────────────────────────────────────────────
 
 const KEY_ADMIN: Symbol = symbol_short!("ADMIN");
@@ -47,6 +52,7 @@ pub enum GovernanceError {
     TimelockNotElapsed = 4010,
     ThresholdNotMet = 4011,
     DelayTooShort = 4012,
+    DelayTooLong = 4021,
     EmptySignerList = 4013,
     ReproposalCooldownActive = 4015,
     ProposalExpired = 4016,
@@ -201,7 +207,7 @@ impl GovernanceContract {
     /// Only the current admin may call this. Any pending proposal must be
     /// cancelled before a new one can be submitted.
     ///
-    /// `delay_seconds` must be >= MIN_TIMELOCK_SECONDS (86400 = 24 h).
+    /// `delay_seconds` must be in [MIN_TIMELOCK_SECONDS, MAX_TIMELOCK_SECONDS].
     /// `threshold` must be in [1, len(signers)] and len(signers) <= MAX_SIGNERS.
     pub fn propose_admin_transfer(
         env: Env,
@@ -261,6 +267,9 @@ impl GovernanceContract {
         }
         if delay_seconds < MIN_TIMELOCK_SECONDS {
             return Err(GovernanceError::DelayTooShort);
+        }
+        if delay_seconds > MAX_TIMELOCK_SECONDS {
+            return Err(GovernanceError::DelayTooLong);
         }
 
         let now = env.ledger().timestamp();

--- a/contracts/multisig_governance/src/test.rs
+++ b/contracts/multisig_governance/src/test.rs
@@ -712,3 +712,220 @@ fn has_approved_tracks_approvals() {
     assert!(client.has_approved(&s1));
     assert!(client.has_approved(&s2));
 }
+
+// ── DelayTooLong / upper-bound tests ─────────────────────────────────────────
+
+#[test]
+fn propose_rejects_delay_equal_to_ttl() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &PROPOSAL_TTL_SECONDS,
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooLong)));
+}
+
+#[test]
+fn propose_rejects_delay_exceeding_ttl() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &(PROPOSAL_TTL_SECONDS + 1),
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooLong)));
+}
+
+#[test]
+fn propose_rejects_large_delay() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &(7 * PROPOSAL_TTL_SECONDS),
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooLong)));
+}
+
+#[test]
+fn propose_accepts_max_delay_and_finalize_succeeds() {
+    let (env, client, admin, _) = setup();
+    let proposed = Address::generate(&env);
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 1000);
+    client.propose_admin_transfer(&proposed, &signers, &1, &MAX_TIMELOCK_SECONDS);
+
+    // executable_after = 1000 + MAX_TIMELOCK_SECONDS
+    let pending = client.get_pending_transfer();
+    assert_eq!(pending.executable_after, 1000 + MAX_TIMELOCK_SECONDS);
+
+    client.approve_transfer(&s);
+
+    // Move to exactly executable_after (within TTL by construction)
+    set_ts(&env, 1000 + MAX_TIMELOCK_SECONDS);
+
+    // Finalize should succeed — the window [executable_after, expiry) is exactly 1 second
+    client.finalize_admin_transfer(&admin);
+    assert_eq!(client.get_current_admin(), proposed);
+    assert!(!client.has_pending_transfer());
+}
+
+#[test]
+fn propose_delay_one_below_ttl_accepted() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &(PROPOSAL_TTL_SECONDS - 1),
+    );
+    // MAX_TIMELOCK_SECONDS == PROPOSAL_TTL_SECONDS - 1, so this should succeed
+    assert_eq!(result, Ok(Ok(())));
+}
+
+// ── Delay boundary edge-case tests ───────────────────────────────────────────
+
+#[test]
+fn propose_rejects_zero_delay() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(&Address::generate(&env), &signers, &1, &0);
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooShort)));
+}
+
+#[test]
+fn propose_rejects_delay_one_below_min() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &(MIN_TIMELOCK_SECONDS - 1),
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooShort)));
+}
+
+#[test]
+fn propose_rejects_delay_one_above_max() {
+    let (env, client, _, _) = setup();
+    let signers = Vec::from_slice(&env, &[Address::generate(&env)]);
+    let result = client.try_propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &(MAX_TIMELOCK_SECONDS + 1),
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::DelayTooLong)));
+}
+
+#[test]
+fn finalize_rejected_one_second_before_max_delay_executable() {
+    let (env, client, admin, _) = setup();
+    let proposed = Address::generate(&env);
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 1000);
+    client.propose_admin_transfer(&proposed, &signers, &1, &MAX_TIMELOCK_SECONDS);
+    client.approve_transfer(&s);
+
+    // Try to finalize one second before executable_after
+    set_ts(&env, 1000 + MAX_TIMELOCK_SECONDS - 1);
+    let result = client.try_finalize_admin_transfer(&admin);
+    assert_eq!(result, Err(Ok(GovernanceError::TimelockNotElapsed)));
+}
+
+#[test]
+fn finalize_rejected_at_expiry_with_max_delay() {
+    let (env, client, admin, _) = setup();
+    let proposed = Address::generate(&env);
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 1000);
+    client.propose_admin_transfer(&proposed, &signers, &1, &MAX_TIMELOCK_SECONDS);
+    client.approve_transfer(&s);
+
+    // proposed_at + PROPOSAL_TTL_SECONDS is the expiry.
+    // executable_after = proposed_at + MAX_TIMELOCK_SECONDS = proposed_at + TTL - 1.
+    // So at time proposed_at + TTL (the expiry), finalize should be rejected.
+    set_ts(&env, 1000 + PROPOSAL_TTL_SECONDS);
+    let result = client.try_finalize_admin_transfer(&admin);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalExpired)));
+}
+
+#[test]
+fn finalize_succeeds_one_second_before_expiry_with_max_delay() {
+    let (env, client, admin, _) = setup();
+    let proposed = Address::generate(&env);
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 1000);
+    client.propose_admin_transfer(&proposed, &signers, &1, &MAX_TIMELOCK_SECONDS);
+    client.approve_transfer(&s);
+
+    // executable_after = 1000 + TTL - 1
+    // expiry = 1000 + TTL
+    // At 1000 + TTL - 1, both conditions hold: now >= executable_after AND now < expiry
+    set_ts(&env, 1000 + PROPOSAL_TTL_SECONDS - 1);
+    client.finalize_admin_transfer(&admin);
+    assert_eq!(client.get_current_admin(), proposed);
+    assert!(!client.has_pending_transfer());
+}
+
+#[test]
+fn min_delay_executable_after_correct() {
+    let (env, client, _, _) = setup();
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 500);
+    client.propose_admin_transfer(
+        &Address::generate(&env),
+        &signers,
+        &1,
+        &MIN_TIMELOCK_SECONDS,
+    );
+    let pending = client.get_pending_transfer();
+    assert_eq!(pending.executable_after, 500 + MIN_TIMELOCK_SECONDS);
+    assert_eq!(pending.proposed_at, 500);
+}
+
+#[test]
+fn max_delay_finalize_window_is_one_second() {
+    // With MAX_TIMELOCK_SECONDS = PROPOSAL_TTL_SECONDS - 1,
+    // the finalize window [executable_after, expiry) should be exactly 1 second wide.
+    // executable_after = proposed_at + TTL - 1
+    // expiry = proposed_at + TTL
+    // So only the single timestamp (proposed_at + TTL - 1) is valid for finalization.
+    let (env, client, admin, _) = setup();
+    let proposed = Address::generate(&env);
+    let s = Address::generate(&env);
+    let signers = Vec::from_slice(&env, core::slice::from_ref(&s));
+
+    set_ts(&env, 2000);
+    client.propose_admin_transfer(&proposed, &signers, &1, &MAX_TIMELOCK_SECONDS);
+    client.approve_transfer(&s);
+
+    // One second BEFORE executable_after → TimelockNotElapsed
+    set_ts(&env, 2000 + MAX_TIMELOCK_SECONDS - 1);
+    let result = client.try_finalize_admin_transfer(&admin);
+    assert_eq!(result, Err(Ok(GovernanceError::TimelockNotElapsed)));
+
+    // At executable_after → should succeed
+    set_ts(&env, 2000 + MAX_TIMELOCK_SECONDS);
+    client.finalize_admin_transfer(&admin);
+    assert_eq!(client.get_current_admin(), proposed);
+}

--- a/frontend/src/app/components/providers/WalletProvider.tsx
+++ b/frontend/src/app/components/providers/WalletProvider.tsx
@@ -252,9 +252,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     const api = (await loadFreighterApi()) as unknown as ExtendedFreighterApi;
     const networkName = useWalletStore.getState().network?.name ?? "TESTNET";
     const networkPassphrase =
-      options?.networkPassphrase ??
-      NETWORK_PASSPHRASES[networkName] ??
-      NETWORK_PASSPHRASES.TESTNET;
+      options?.networkPassphrase ?? NETWORK_PASSPHRASES[networkName] ?? NETWORK_PASSPHRASES.TESTNET;
 
     const result = await api.signTransaction(unsignedTxXdr, {
       networkPassphrase,

--- a/frontend/src/app/hooks/useRepaymentOperation.ts
+++ b/frontend/src/app/hooks/useRepaymentOperation.ts
@@ -55,6 +55,7 @@ export function useRepaymentOperation(options?: {
   const [error, setError] = useState<string | null>(null);
   const repayLoan = useRepayLoan();
   const { signTransaction } = useWallet();
+  const queryClient = useQueryClient();
   const isExecuting = useRef(false);
 
   const executeRepayment = useCallback(
@@ -94,8 +95,12 @@ export function useRepaymentOperation(options?: {
 
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: queryKeys.loans.detail(String(loanId)) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress) }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress),
+          }),
           queryClient.invalidateQueries({ queryKey: queryKeys.pool.stats() }),
         ]);
 


### PR DESCRIPTION
…sig governance

Add MAX_TIMELOCK_SECONDS constant and DelayTooLong error (4021) to prevent proposals with a timelock delay that would make the finalize window empty. Without this upper bound, setting delay_seconds >= PROPOSAL_TTL_SECONDS silently produces a proposal that can never be finalized because executable_after lands at or past the expiry, causing every finalize call to return ProposalExpired.

- Add MAX_TIMELOCK_SECONDS = PROPOSAL_TTL_SECONDS - 1 constant
- Add DelayTooLong = 4021 error variant
- Reject delay_seconds > MAX_TIMELOCK_SECONDS in propose_admin_transfer
- Add tests: rejection of delay == TTL, delay > TTL, 7x TTL, and successful finalize at maximum allowed delay

Closes #1092

🤖 Generated with Codebuff

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
