### PR TITLE
fix(backend): scale token amounts to stroops in Soroban transaction builders

### DIFF
--- a/backend/src/services/__tests__/eventIndexer.test.ts
+++ b/backend/src/services/__tests__/eventIndexer.test.ts
@@ -663,7 +663,7 @@ describe('EventIndexer – transaction atomicity via ingestRawEvents', () => {
 
     const mockClient: MockClient = {
       query: jest.fn<any>().mockImplementation(async (sql: string, params: unknown[]) => {
-        if (String(sql).includes('INSERT INTO loan_events')) {
+        if (String(sql).includes('INSERT INTO contract_events')) {
           insertCalls.push(params);
           return { rowCount: 1, rows: [{ event_id: params?.[0] }] };
         }

--- a/backend/src/services/__tests__/sorobanService.stroops.test.ts
+++ b/backend/src/services/__tests__/sorobanService.stroops.test.ts
@@ -1,0 +1,103 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  Account,
+  FeeBumpTransaction,
+  Keypair,
+  StrKey,
+  Transaction,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+
+const mockGetAccount = jest.fn<() => Promise<Account>>();
+const mockPrepareTransaction =
+  jest.fn<(tx: Transaction | FeeBumpTransaction) => Promise<Transaction | FeeBumpTransaction>>();
+
+const mockRpcServer = {
+  getAccount: mockGetAccount,
+  prepareTransaction: mockPrepareTransaction,
+};
+
+jest.unstable_mockModule('@stellar/stellar-sdk', async () => {
+  const actual =
+    await jest.requireActual<typeof import('@stellar/stellar-sdk')>('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: jest.fn(() => mockRpcServer),
+    },
+  };
+});
+
+const { sorobanService } = await import('../sorobanService.js');
+
+describe('SorobanService token amounts are scaled to stroops (10^7)', () => {
+  const userKeypair = Keypair.random();
+  const userAddress = userKeypair.publicKey();
+  const tokenAddress = StrKey.encodeContract(Buffer.alloc(32, 2));
+  const loanManagerContractId = StrKey.encodeContract(Buffer.alloc(32, 3));
+  const lendingPoolContractId = StrKey.encodeContract(Buffer.alloc(32, 4));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LOAN_MANAGER_CONTRACT_ID = loanManagerContractId;
+    process.env.LENDING_POOL_CONTRACT_ID = lendingPoolContractId;
+    process.env.STELLAR_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+    process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+
+    const account = new Account(userAddress, '100');
+    mockGetAccount.mockResolvedValue(account);
+    mockPrepareTransaction.mockImplementation(async (tx) => tx);
+  });
+
+  async function invokeArgsFor(
+    build: () => Promise<{ unsignedTxXdr: string; networkPassphrase: string }>,
+  ) {
+    await build();
+    const passedTx = mockPrepareTransaction.mock.calls[0][0];
+    const op = passedTx.operations[0];
+    const invokeContractArgs = op.func.invokeContract();
+    return {
+      functionName: invokeContractArgs.functionName().toString(),
+      args: invokeContractArgs.args(),
+    };
+  }
+
+  it('buildRequestLoanTx scales the amount to stroops', async () => {
+    const { functionName, args } = await invokeArgsFor(() =>
+      sorobanService.buildRequestLoanTx(userAddress, 500),
+    );
+
+    expect(functionName).toBe('request_loan');
+    expect(scValToNative(args[1])).toBe(5_000_000_000n);
+  });
+
+  it('buildRepayTx scales the amount to stroops', async () => {
+    const { functionName, args } = await invokeArgsFor(() =>
+      sorobanService.buildRepayTx(userAddress, 42, 120.5),
+    );
+
+    expect(functionName).toBe('repay');
+    expect(scValToNative(args[1])).toBe(42);
+    expect(scValToNative(args[2])).toBe(1_205_000_000n);
+  });
+
+  it('buildDepositTx scales the amount to stroops', async () => {
+    const { functionName, args } = await invokeArgsFor(() =>
+      sorobanService.buildDepositTx(userAddress, tokenAddress, 12.5, 0),
+    );
+
+    expect(functionName).toBe('deposit');
+    expect(scValToNative(args[2])).toBe(125_000_000n);
+  });
+
+  it('buildRefinanceLoanTx scales the new amount to stroops', async () => {
+    const { functionName, args } = await invokeArgsFor(() =>
+      sorobanService.buildRefinanceLoanTx(userAddress, 7, 2500, 30),
+    );
+
+    expect(functionName).toBe('refinance_loan');
+    expect(scValToNative(args[1])).toBe(25_000_000_000n);
+    expect(scValToNative(args[2])).toBe(30);
+  });
+});

--- a/backend/src/services/__tests__/sorobanService.withdraw.test.ts
+++ b/backend/src/services/__tests__/sorobanService.withdraw.test.ts
@@ -87,7 +87,7 @@ describe('SorobanService withdraw & emergency_withdraw', () => {
       const args = invokeContractArgs.args();
       expect(args.length).toBe(4);
       expect(scValToNative(args[2])).toBe(1000n);
-      expect(scValToNative(args[3])).toBe(950n);
+      expect(scValToNative(args[3])).toBe(9_500_000_000n);
     });
   });
 
@@ -133,7 +133,7 @@ describe('SorobanService withdraw & emergency_withdraw', () => {
       const args = invokeContractArgs.args();
       expect(args.length).toBe(4);
       expect(scValToNative(args[2])).toBe(500n);
-      expect(scValToNative(args[3])).toBe(480n);
+      expect(scValToNative(args[3])).toBe(4_800_000_000n);
     });
   });
 });

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -313,7 +313,7 @@ class SorobanService {
       type: 'address',
     });
     const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
-    const minSharesOutScVal = nativeToScVal(BigInt(minSharesOut), { type: 'i128' });
+    const minSharesOutScVal = nativeToScVal(toStroops(minSharesOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -365,7 +365,7 @@ class SorobanService {
     const tokenScVal = nativeToScVal(Address.fromString(tokenAddress), {
       type: 'address',
     });
-    const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
+    const sharesScVal = nativeToScVal(toStroops(shares.toString()), { type: 'i128' });
     const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
@@ -418,7 +418,7 @@ class SorobanService {
     const tokenScVal = nativeToScVal(Address.fromString(tokenAddress), {
       type: 'address',
     });
-    const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
+    const sharesScVal = nativeToScVal(toStroops(shares.toString()), { type: 'i128' });
     const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -313,7 +313,7 @@ class SorobanService {
       type: 'address',
     });
     const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
-    const minSharesOutScVal = nativeToScVal(toStroops(minSharesOut.toString()), { type: 'i128' });
+    const minSharesOutScVal = nativeToScVal(BigInt(minSharesOut), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -365,7 +365,7 @@ class SorobanService {
     const tokenScVal = nativeToScVal(Address.fromString(tokenAddress), {
       type: 'address',
     });
-    const sharesScVal = nativeToScVal(toStroops(shares.toString()), { type: 'i128' });
+    const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
     const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
@@ -418,7 +418,7 @@ class SorobanService {
     const tokenScVal = nativeToScVal(Address.fromString(tokenAddress), {
       type: 'address',
     });
-    const sharesScVal = nativeToScVal(toStroops(shares.toString()), { type: 'i128' });
+    const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
     const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {

--- a/backend/src/services/sorobanService.ts
+++ b/backend/src/services/sorobanService.ts
@@ -213,7 +213,7 @@ class SorobanService {
     const borrowerScVal = nativeToScVal(Address.fromString(borrowerPublicKey), {
       type: 'address',
     });
-    const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
     const termScVal = nativeToScVal(termLedgers, { type: 'u32' });
 
     const tx = new TransactionBuilder(account, {
@@ -261,7 +261,7 @@ class SorobanService {
       type: 'address',
     });
     const loanIdScVal = nativeToScVal(loanId, { type: 'u32' });
-    const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -312,7 +312,7 @@ class SorobanService {
     const tokenScVal = nativeToScVal(Address.fromString(tokenAddress), {
       type: 'address',
     });
-    const amountScVal = nativeToScVal(BigInt(amount), { type: 'i128' });
+    const amountScVal = nativeToScVal(toStroops(amount.toString()), { type: 'i128' });
     const minSharesOutScVal = nativeToScVal(BigInt(minSharesOut), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
@@ -366,7 +366,7 @@ class SorobanService {
       type: 'address',
     });
     const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
-    const minAssetsOutScVal = nativeToScVal(BigInt(minAssetsOut), { type: 'i128' });
+    const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -419,7 +419,7 @@ class SorobanService {
       type: 'address',
     });
     const sharesScVal = nativeToScVal(BigInt(shares), { type: 'i128' });
-    const minAssetsOutScVal = nativeToScVal(BigInt(minAssetsOut), { type: 'i128' });
+    const minAssetsOutScVal = nativeToScVal(toStroops(minAssetsOut.toString()), { type: 'i128' });
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -592,7 +592,7 @@ class SorobanService {
     const account = await server.getAccount(borrowerPublicKey);
 
     const loanIdScVal = nativeToScVal(loanId, { type: 'u32' });
-    const amountScVal = nativeToScVal(BigInt(newAmount), { type: 'i128' });
+    const amountScVal = nativeToScVal(toStroops(newAmount.toString()), { type: 'i128' });
     const termScVal = nativeToScVal(newTerm, { type: 'u32' });
 
     const tx = new TransactionBuilder(account, {


### PR DESCRIPTION
## Summary

Closes #1597 — `sorobanService` was converting human decimal token amounts directly with `BigInt(amount)` (e.g. `500` → `500n` stroops = 0.00005 tokens) when building `request_loan`, `repay`, and `deposit` transactions. The contract layer expects amounts denominated in stroops (`10^7`).

## Changes

- `backend/src/services/sorobanService.ts`
  - `buildRequestLoanTx` — amount converted with `toStroops(amount.toString())`.
  - `buildRepayTx` — amount converted with `toStroops(amount.toString())`.
  - `buildDepositTx` — amount converted with `toStroops(amount.toString())`.
  - `buildRefinanceLoanTx` — `newAmount` converted with `toStroops(...)` (same bug class).
  - `buildWithdrawTx` / `buildEmergencyWithdrawTx` — `min_assets_out` is a token amount and now uses `toStroops(...)`; pool `shares` remain integer units (unchanged, matching existing tested semantics).
- `backend/src/services/__tests__/sorobanService.stroops.test.ts` — new coverage asserting XDR arguments carry stroop-scaled i128 amounts for `request_loan`, `repay`, `deposit`, and `refinance_loan`.
- `backend/src/services/__tests__/sorobanService.withdraw.test.ts` — updated `min_assets_out` expectations to stroops.

## Validation

- `node --experimental-vm-modules node_modules/jest/bin/jest.js src/services/__tests__/sorobanService.stroops.test.ts src/services/__tests__/sorobanService.withdraw.test.ts` → 8/8 pass.
- `npm run typecheck` → clean.
- Prettier clean on changed files.