### PR TITLE
fix(contracts): block NFT transfer when sender has active loans (#1663)

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1271,6 +1271,38 @@ impl LoanManager {
         Ok(loan)
     }
 
+    /// Return the raw status discriminant of a loan without accruing interest.
+    ///
+    /// This lightweight read is designed for cross-contract callers (e.g.,
+    /// [`RemittanceNFT::transfer`]) that only need to know whether a loan is
+    /// active (Pending = 0, Approved = 1) and do not require a full Loan
+    /// struct with up-to-date accrued interest.
+    ///
+    /// Returns [`LoanError::LoanNotFound`] when `loan_id` is unknown.
+    pub fn get_loan_status(env: Env, loan_id: u32) -> Result<u32, LoanError> {
+        let loan_key = DataKey::Loan(loan_id);
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&loan_key)
+            .ok_or(LoanError::LoanNotFound)?;
+        Self::bump_persistent_ttl(&env, &loan_key);
+        // Map LoanStatus to its u32 discriminant.
+        // This must stay in sync with the LoanStatus enum definition:
+        //   Pending = 0, Approved = 1, Repaid = 2, Defaulted = 3,
+        //   Liquidated = 4, Cancelled = 5, Rejected = 6
+        let discriminant = match loan.status {
+            LoanStatus::Pending => 0,
+            LoanStatus::Approved => 1,
+            LoanStatus::Repaid => 2,
+            LoanStatus::Defaulted => 3,
+            LoanStatus::Liquidated => 4,
+            LoanStatus::Cancelled => 5,
+            LoanStatus::Rejected => 6,
+        };
+        Ok(discriminant)
+    }
+
     /// Repay part or all of an approved loan.
     ///
     /// Requires `borrower` authorization and the loan manager, lending pool,

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -4131,4 +4131,3 @@ fn test_liquidate_decreases_score_and_records_default() {
     assert_eq!(nft_client.get_default_count(&borrower), 1);
     assert!(nft_client.is_seized(&borrower));
 }
-

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -28,6 +28,10 @@ pub enum NftError {
     MinterLimitReached = 19,
     CommitmentMalformed = 20,
     CommitmentMissing = 21,
+    /// Returned by `transfer` when the sender has one or more active loans
+    /// (Pending or Approved) in the registered LoanManager.  Borrowers must
+    /// fully repay or cancel all loans before relocating their reputation NFT.
+    ActiveLoanExists = 22,
 }
 
 #[contracttype]
@@ -65,6 +69,22 @@ pub enum DataKey {
     ProposedAdmin,
     MinRepaymentAmount,
     RecipientCommitment(Address),
+    /// Optional address of the LoanManager contract used to enforce the
+    /// active-loan transfer guard (see `transfer`).
+    LoanManager,
+}
+
+/// Minimal cross-contract interface exposed by the LoanManager contract.
+///
+/// Only the subset of methods required for the active-loan transfer guard is
+/// declared here.  The discriminants match the actual LoanStatus enum in
+/// loan_manager: Pending = 0, Approved = 1.
+#[soroban_sdk::contractclient(name = "LoanManagerClient")]
+pub trait LoanManagerInterface {
+    /// Returns the list of loan IDs associated with the given borrower.
+    fn get_borrower_loans(env: Env, borrower: Address) -> soroban_sdk::Vec<u32>;
+    /// Returns the raw status discriminant of a single loan.
+    fn get_loan_status(env: Env, loan_id: u32) -> u32;
 }
 
 #[contract]
@@ -956,6 +976,29 @@ impl RemittanceNFT {
         from.require_auth();
         Self::require_admin_or_authorized_minter(&env, minter)?;
 
+        // Guard: block transfers while the sender has active loans.
+        //
+        // If a LoanManager address has been registered via `set_loan_manager`,
+        // we cross-call it to verify that none of the borrower's loans are in
+        // an active state (Pending = 0, Approved = 1).  This prevents the
+        // "credit wash" attack where a borrower facing default races to move
+        // their unblemished NFT to a clean address before penalties are applied.
+        if let Some(loan_manager_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::LoanManager)
+        {
+            let loan_manager = LoanManagerClient::new(&env, &loan_manager_addr);
+            let loan_ids = loan_manager.get_borrower_loans(&from);
+            for loan_id in loan_ids.iter() {
+                // LoanStatus::Pending = 0, LoanStatus::Approved = 1
+                let status = loan_manager.get_loan_status(&loan_id);
+                if status == 0 || status == 1 {
+                    return Err(NftError::ActiveLoanExists);
+                }
+            }
+        }
+
         let transfer_cooldown_key = DataKey::TransferCooldown(from.clone());
         if let Some(next_allowed_ledger) = env
             .storage()
@@ -1258,6 +1301,36 @@ impl RemittanceNFT {
             ),
             (current_admin, new_admin),
         );
+    }
+
+    /// Register (or replace) the LoanManager contract address used by the
+    /// active-loan transfer guard.
+    ///
+    /// Must be called by the admin.  Once set, every call to `transfer` will
+    /// cross-call the LoanManager to ensure the sender has no Pending or
+    /// Approved loans.  Pass the zero-address or call with a subsequent
+    /// `set_loan_manager` to replace the address.
+    ///
+    /// Reverts with `ContractPaused` if the contract is paused.
+    pub fn set_loan_manager(env: Env, loan_manager: Address) -> Result<(), NftError> {
+        Self::admin(&env).require_auth();
+        Self::assert_not_paused(&env)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::LoanManager, &loan_manager);
+        Self::bump_instance_ttl(&env);
+
+        env.events()
+            .publish((Symbol::new(&env, "LoanMgrSet"),), loan_manager);
+        Ok(())
+    }
+
+    /// Return the currently registered LoanManager contract address, or
+    /// `None` if no address has been set.
+    pub fn get_loan_manager(env: Env) -> Option<Address> {
+        Self::bump_instance_ttl(&env);
+        env.storage().instance().get(&DataKey::LoanManager)
     }
 }
 

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -2482,9 +2482,7 @@ impl MockLoanManager {
 }
 
 // Helper to build the NFT client with a registered mock loan manager.
-fn setup_nft_with_loan_manager<'a>(
-    env: &'a Env,
-) -> (RemittanceNFTClient<'a>, Address, Address, Address) {
+fn setup_nft_with_loan_manager(env: &Env) -> (RemittanceNFTClient<'_>, Address, Address, Address) {
     env.mock_all_auths();
 
     let admin = Address::generate(env);

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use soroban_sdk::{
-    testutils::Address as _, testutils::Events as _, testutils::Ledger as _, Address, BytesN, Env,
-    FromVal, String, Symbol,
+    contract, contractimpl, testutils::Address as _, testutils::Events as _,
+    testutils::Ledger as _, Address, BytesN, Env, FromVal, String, Symbol, Vec,
 };
 
 fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
@@ -2418,4 +2418,186 @@ fn test_admin_remint_rejects_bad_commitment() {
     // Verify new commitment is stored
     let stored = client.get_recipient_commitment(&user);
     assert_eq!(stored, new_commitment);
+}
+
+// ---------------------------------------------------------------------------
+// MockLoanManager – used exclusively by the issue-1663 transfer-guard tests.
+//
+// The mock is keyed by borrower address in instance storage:
+//   "loans":<borrower> -> Vec<u32>   (loan IDs)
+//   "status":<u32>     -> u32         (status discriminant for that loan ID)
+//
+// Status discriminants mirror the real LoanStatus enum:
+//   0 = Pending, 1 = Approved, 2 = Repaid, 3 = Defaulted,
+//   4 = Liquidated, 5 = Cancelled, 6 = Rejected
+// ---------------------------------------------------------------------------
+#[contract]
+pub struct MockLoanManager;
+
+#[contractimpl]
+impl MockLoanManager {
+    /// Record `loan_id` as belonging to `borrower` with the given `status`.
+    pub fn set_loan(env: Env, borrower: Address, loan_id: u32, status: u32) {
+        // Append to borrower's loan list
+        let mut loans: Vec<u32> = env
+            .storage()
+            .instance()
+            .get::<(soroban_sdk::Symbol, Address), Vec<u32>>(&(
+                soroban_sdk::Symbol::new(&env, "loans"),
+                borrower.clone(),
+            ))
+            .unwrap_or(Vec::new(&env));
+        loans.push_back(loan_id);
+        env.storage()
+            .instance()
+            .set(&(soroban_sdk::Symbol::new(&env, "loans"), borrower), &loans);
+        // Store status for this loan ID
+        env.storage().instance().set(
+            &(soroban_sdk::Symbol::new(&env, "status"), loan_id),
+            &status,
+        );
+    }
+
+    /// LoanManagerInterface::get_borrower_loans
+    pub fn get_borrower_loans(env: Env, borrower: Address) -> Vec<u32> {
+        env.storage()
+            .instance()
+            .get::<(soroban_sdk::Symbol, Address), Vec<u32>>(&(
+                soroban_sdk::Symbol::new(&env, "loans"),
+                borrower,
+            ))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// LoanManagerInterface::get_loan_status
+    pub fn get_loan_status(env: Env, loan_id: u32) -> u32 {
+        env.storage()
+            .instance()
+            .get::<(soroban_sdk::Symbol, u32), u32>(&(
+                soroban_sdk::Symbol::new(&env, "status"),
+                loan_id,
+            ))
+            .unwrap_or(2) // default: Repaid (terminal)
+    }
+}
+
+// Helper to build the NFT client with a registered mock loan manager.
+fn setup_nft_with_loan_manager<'a>(
+    env: &'a Env,
+) -> (RemittanceNFTClient<'a>, Address, Address, Address) {
+    env.mock_all_auths();
+
+    let admin = Address::generate(env);
+    let nft_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(env, &nft_id);
+    client.initialize(&admin);
+
+    let mock_lm_id = env.register(MockLoanManager, ());
+    client.set_loan_manager(&mock_lm_id);
+
+    let borrower = Address::generate(env);
+    client.mint(
+        &borrower,
+        &600,
+        &create_test_hash(env, 55),
+        &create_test_uri(env),
+        &create_test_commitment(env, 1),
+        &None,
+    );
+
+    (client, mock_lm_id, borrower, admin)
+}
+
+/// Issue #1663 regression: transfer must be blocked when the sender has a
+/// *Pending* loan (status discriminant 0).
+#[test]
+fn test_transfer_blocked_when_sender_has_pending_loan() {
+    let env = Env::default();
+    let (client, mock_lm_id, borrower, _admin) = setup_nft_with_loan_manager(&env);
+    let new_wallet = Address::generate(&env);
+
+    // Register a Pending loan (status = 0) for the borrower
+    let mock_lm = MockLoanManagerClient::new(&env, &mock_lm_id);
+    mock_lm.set_loan(&borrower, &1, &0);
+
+    let result = client.try_transfer(&borrower, &new_wallet, &None);
+    assert_eq!(
+        result,
+        Err(Ok(NftError::ActiveLoanExists)),
+        "transfer must be blocked when the sender has a Pending loan"
+    );
+}
+
+/// Issue #1663 regression: transfer must be blocked when the sender has an
+/// *Approved* (disbursed) loan (status discriminant 1).
+#[test]
+fn test_transfer_blocked_when_sender_has_approved_loan() {
+    let env = Env::default();
+    let (client, mock_lm_id, borrower, _admin) = setup_nft_with_loan_manager(&env);
+    let new_wallet = Address::generate(&env);
+
+    // Register an Approved loan (status = 1)
+    let mock_lm = MockLoanManagerClient::new(&env, &mock_lm_id);
+    mock_lm.set_loan(&borrower, &42, &1);
+
+    let result = client.try_transfer(&borrower, &new_wallet, &None);
+    assert_eq!(
+        result,
+        Err(Ok(NftError::ActiveLoanExists)),
+        "transfer must be blocked when the sender has an Approved loan"
+    );
+}
+
+/// Transfer must succeed when all of the sender's loans are in a terminal
+/// state (Repaid = 2, Cancelled = 5, etc.).
+#[test]
+fn test_transfer_allowed_when_all_loans_are_terminal() {
+    let env = Env::default();
+    let (client, mock_lm_id, borrower, _admin) = setup_nft_with_loan_manager(&env);
+    let new_wallet = Address::generate(&env);
+
+    // Register only terminal-state loans
+    let mock_lm = MockLoanManagerClient::new(&env, &mock_lm_id);
+    mock_lm.set_loan(&borrower, &10, &2); // Repaid
+    mock_lm.set_loan(&borrower, &11, &5); // Cancelled
+
+    let result = client.try_transfer(&borrower, &new_wallet, &None);
+    assert!(
+        result.is_ok(),
+        "transfer must be allowed when all loans are terminal"
+    );
+    // Verify NFT moved to new wallet
+    assert!(client.get_metadata(&new_wallet).is_some());
+    assert!(client.get_metadata(&borrower).is_none());
+}
+
+/// Transfer guard must be a no-op (transparent) when no LoanManager has
+/// been registered — preserving backwards-compatibility.
+#[test]
+fn test_transfer_succeeds_without_loan_manager_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let nft_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &nft_id);
+    client.initialize(&admin);
+
+    // No set_loan_manager call — guard must be skipped entirely.
+    let borrower = Address::generate(&env);
+    let new_wallet = Address::generate(&env);
+    client.mint(
+        &borrower,
+        &600,
+        &create_test_hash(&env, 77),
+        &create_test_uri(&env),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let result = client.try_transfer(&borrower, &new_wallet, &None);
+    assert!(
+        result.is_ok(),
+        "transfer must succeed when no LoanManager is registered"
+    );
 }

--- a/frontend/src/app/components/providers/WalletProvider.tsx
+++ b/frontend/src/app/components/providers/WalletProvider.tsx
@@ -252,9 +252,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     const api = (await loadFreighterApi()) as unknown as ExtendedFreighterApi;
     const networkName = useWalletStore.getState().network?.name ?? "TESTNET";
     const networkPassphrase =
-      options?.networkPassphrase ??
-      NETWORK_PASSPHRASES[networkName] ??
-      NETWORK_PASSPHRASES.TESTNET;
+      options?.networkPassphrase ?? NETWORK_PASSPHRASES[networkName] ?? NETWORK_PASSPHRASES.TESTNET;
 
     const result = await api.signTransaction(unsignedTxXdr, {
       networkPassphrase,

--- a/frontend/src/app/hooks/useRepaymentOperation.ts
+++ b/frontend/src/app/hooks/useRepaymentOperation.ts
@@ -49,6 +49,7 @@ export function useRepaymentOperation(options?: {
   onSuccess?: (result: RepaymentOperationResult) => void;
   onError?: (error: Error) => void;
 }) {
+  const queryClient = useQueryClient();
   const uid = useId();
   const transactionId = `repayment-${uid}`;
   const transaction = useTransaction(transactionId);

--- a/frontend/src/app/hooks/useRepaymentOperation.ts
+++ b/frontend/src/app/hooks/useRepaymentOperation.ts
@@ -94,8 +94,12 @@ export function useRepaymentOperation(options?: {
 
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: queryKeys.loans.detail(String(loanId)) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress) }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress) }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.borrowerLoans.byAddress(borrowerAddress),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.loans.borrowerPagePrefix(borrowerAddress),
+          }),
           queryClient.invalidateQueries({ queryKey: queryKeys.pool.stats() }),
         ]);
 


### PR DESCRIPTION
Closes #1663 

---

## Summary

`RemittanceNFT::transfer` previously allowed any NFT holder to migrate their reputation identity to a fresh address at any time without verifying whether the sender currently has an active loan in `LoanManager`.

A malicious borrower facing imminent default could exploit this to transfer their unblemished credit NFT to a clean wallet immediately before a loan defaulted, leaving the original borrower address without an NFT so that subsequent default penalties (`record_default`, `seize_collateral`) fail to apply to the transferred identity.

This PR closes the vulnerability by introducing an **active-loan transfer guard**: if a `LoanManager` contract address is registered with the `RemittanceNFT` contract, `transfer` cross-calls `LoanManager` to verify that none of the borrower's loans are in an active state (`Pending` or `Approved`) before allowing the transfer.

---

## Root Cause

In `contracts/remittance_nft/src/lib.rs` (lines 947–975), `transfer()` checked sender auth, recipient occupancy, and cooldown ledgers, but had no verification against active loans in `LoanManager`.

---

## Proposed Changes

### `contracts/remittance_nft/src/lib.rs`

- **New Error:** Added `NftError::ActiveLoanExists = 22` when transfer is attempted by a borrower with `Pending` (0) or `Approved` (1) loans.
- **New Storage Key:** Added `DataKey::LoanManager` in instance storage.
- **Cross-Contract Client:** Defined `LoanManagerInterface` with `#[contractclient(name = "LoanManagerClient")]` declaring `get_borrower_loans` and `get_loan_status`.
- **Admin Configuration:** Added `set_loan_manager(loan_manager: Address)` and `get_loan_manager() -> Option<Address>`.
- **Transfer Guard:** `transfer()` queries the sender's loan IDs if `LoanManager` is configured, preventing transfers if any active loan exists.
- **Backwards Compatibility:** If no `LoanManager` is registered, the transfer proceeds without error.

### `contracts/loan_manager/src/lib.rs`

- **Lightweight Status Query:** Added `get_loan_status(loan_id: u32) -> Result<u32, LoanError>` returning the status discriminant directly without triggering interest recalculation.

### `contracts/remittance_nft/src/test.rs`

- Added `MockLoanManager` contract to test cross-contract interaction without circular dependencies.
- Added regression tests covering:
  - `test_transfer_blocked_when_sender_has_pending_loan` (reverts with `ActiveLoanExists`)
  - `test_transfer_blocked_when_sender_has_approved_loan` (reverts with `ActiveLoanExists`)
  - `test_transfer_allowed_when_all_loans_are_terminal` (succeeds when loans are `Repaid`, `Cancelled`, etc.)
  - `test_transfer_succeeds_without_loan_manager_configured` (backwards-compatibility check)

---

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [x] I have read the `CONTRIBUTING.md` document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] I have verified the changes locally.

