### PR TITLE
documentations and tests

### DIFF
--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -1,10 +1,65 @@
+//! Event emission module for the `loan_manager` contract.
+//!
+//! This module defines all event emitters published by the `loan_manager` contract.
+//! Indexers and off-chain service listeners rely on these schemas for tracking on-chain state changes.
+//!
+//! # Event Catalog
+//!
+//! | Event | Topics (`Topic 0`, `Topic 1`, ...) | Data Payload |
+//! |---|---|---|
+//! | `LoanRequested` | `("LoanRequested", loan_id: u32, borrower: Address)` | `amount: i128` |
+//! | `LoanApproved` | `("LoanApproved", loan_id: u32, borrower: Address)` | `(interest_rate_bps: u32, term_ledgers: u32)` |
+//! | `LoanRefinanced` | `("LoanRefinanced", loan_id: u32, borrower: Address)` | `(new_amount: i128, new_term: u32)` |
+//! | `LoanExtended` | `("LoanExtended", loan_id: u32, borrower: Address)` | `(new_due_ledger: u32, fee_amount: i128, extension_count: u32)` |
+//! | `LoanRepaid` | `("LoanRepaid", borrower: Address, loan_id: u32)` | `amount: i128` |
+//! | `LoanCancelled` | `("LoanCancelled", borrower: Address)` | `loan_id: u32` |
+//! | `LoanRejected` | `("LoanRejected", loan_id: u32)` | `reason: String` |
+//! | `LateFeeCharged` | `("LateFeeCharged", loan_id: u32)` | `fee_amount: i128` |
+//! | `MinScoreUpdated` | `("MinScoreUpdated", admin: Address)` | `(old_score: u32, new_score: u32)` |
+//! | `Paused` | `("Paused",)` | `paused_at_ledger: u32` |
+//! | `Unpaused` | `("Unpaused",)` | `unpaused_at_ledger: u32` |
+//! | `InterestRateUpdated` | `("InterestRateUpdated",)` | `(old_rate: u32, new_rate: u32)` |
+//! | `DefaultTermUpdated` | `("DefaultTermUpdated",)` | `(old_term: u32, new_term: u32)` |
+//! | `LoanDefaulted` | `("LoanDefaulted", loan_id: u32)` | `borrower: Address` |
+//! | `TermLimitsUpdated` | `("TermLimitsUpdated",)` | `(min_term: u32, max_term: u32)` |
+//! | `RateOracleUpdated` | `("RateOracleUpdated",)` | `(old_oracle: Option<Address>, new_oracle: Address)` |
+//! | `CollateralReturned` | `("CollateralReturned", borrower: Address, loan_id: u32)` | `amount: i128` |
+//! | `CollateralDeposited` | `("CollateralDeposited", borrower: Address, loan_id: u32)` | `amount: i128` |
+//! | `CollateralReleased` | `("CollateralReleased", borrower: Address, loan_id: u32)` | `()` |
+//! | `LateFeeRateUpdated` | `("LateFeeRateUpdated", admin: Address)` | `(old_rate: u32, new_rate: u32)` |
+//! | `GracePeriodUpdated` | `("GracePeriodUpdated", admin: Address)` | `(old_ledgers: u32, new_ledgers: u32)` |
+//! | `DefaultWindowUpdated` | `("DefaultWindowUpdated", admin: Address)` | `(old_ledgers: u32, new_ledgers: u32)` |
+//! | `MaxLoanAmountUpdated` | `("MaxLoanAmountUpdated", admin: Address)` | `(old_amount: i128, new_amount: i128)` |
+//! | `MinRepaymentUpdated` | `("MinRepaymentUpdated", admin: Address)` | `(old_amount: i128, new_amount: i128)` |
+//! | `MaxLoansPerBorrower` | `("MaxLoansPerBorrower", admin: Address)` | `(old_max: u32, new_max: u32)` |
+//! | `LoanApprv` | `(symbol_short!("LoanApprv"), admin: Address)` | `(loan_id: u32, borrower: Address)` |
+//! | `CollateralLiquidated` | `("CollateralLiquidated", loan_id: u32)` | `amount: i128` |
+//! | `LoanLiquidated` | `("LoanLiquidated", loan_id: u32, borrower: Address, liquidator: Address)` | `(debt_repaid: i128, liquidator_bonus: i128, borrower_refund: i128)` |
+//! | `MinRateBpsUpdated` | `("MinRateBpsUpdated", admin: Address)` | `(old_rate: u32, new_rate: u32)` |
+//! | `MaxRateBpsUpdated` | `("MaxRateBpsUpdated", admin: Address)` | `(old_rate: u32, new_rate: u32)` |
+//! | `LoanPurged` | `("LoanPurged",)` | `loan_id: u32` |
+
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
+/// Emits event when a borrower requests a new loan.
+///
+/// - **Topics**: `("LoanRequested", loan_id: u32, borrower: Address)`
+/// - **Data**: `amount: i128`
 pub fn loan_requested(env: &Env, loan_id: u32, borrower: Address, amount: i128) {
     let topics = (Symbol::new(env, "LoanRequested"), loan_id, borrower);
     env.events().publish(topics, amount);
 }
 
+/// Emits event when a pending loan is approved.
+///
+/// - **Topics**: `("LoanApproved", loan_id: u32, borrower: Address)`
+/// - **Data**: `(interest_rate_bps: u32, term_ledgers: u32)`
+///
+/// # De-duplication Note
+/// A single call to `approve_loan` in `lib.rs` emits **two** events:
+/// 1. `LoanApproved` (emitted here with loan terms and interest rate)
+/// 2. `LoanApprv` (emitted by [`loan_approved_by_admin`] with admin and borrower address)
+/// Indexers should de-duplicate or reconcile both events.
 pub fn loan_approved(
     env: &Env,
     loan_id: u32,
@@ -17,6 +72,10 @@ pub fn loan_approved(
         .publish(topics, (interest_rate_bps, term_ledgers));
 }
 
+/// Emits event when an active loan is refinanced with a new principal amount or term.
+///
+/// - **Topics**: `("LoanRefinanced", loan_id: u32, borrower: Address)`
+/// - **Data**: `(new_amount: i128, new_term: u32)`
 pub fn loan_refinanced(
     env: &Env,
     loan_id: u32,
@@ -28,6 +87,10 @@ pub fn loan_refinanced(
     env.events().publish(topics, (new_amount, new_term));
 }
 
+/// Emits event when a loan's due date is extended.
+///
+/// - **Topics**: `("LoanExtended", loan_id: u32, borrower: Address)`
+/// - **Data**: `(new_due_ledger: u32, fee_amount: i128, extension_count: u32)`
 pub fn loan_extended(
     env: &Env,
     loan_id: u32,
@@ -41,126 +104,229 @@ pub fn loan_extended(
         .publish(topics, (new_due_ledger, fee_amount, extension_count));
 }
 
+/// Emits event when a borrower repays part or all of a loan.
+///
+/// - **Topics**: `("LoanRepaid", borrower: Address, loan_id: u32)`
+/// - **Data**: `amount: i128`
 pub fn loan_repaid(env: &Env, borrower: Address, loan_id: u32, amount: i128) {
     let topics = (Symbol::new(env, "LoanRepaid"), borrower, loan_id);
     env.events().publish(topics, amount);
 }
 
+/// Emits event when a borrower cancels a pending loan request.
+///
+/// - **Topics**: `("LoanCancelled", borrower: Address)`
+/// - **Data**: `loan_id: u32`
+///
+/// # Payload Quirk
+/// Note that `loan_cancelled` places `loan_id` in the **data payload** (with `borrower` in topics),
+/// whereas [`loan_rejected`] places `loan_id` in the **topics** (with `reason` in data).
 pub fn loan_cancelled(env: &Env, borrower: Address, loan_id: u32) {
     let topics = (Symbol::new(env, "LoanCancelled"), borrower);
     env.events().publish(topics, loan_id);
 }
 
+/// Emits event when an admin rejects a pending loan request.
+///
+/// - **Topics**: `("LoanRejected", loan_id: u32)`
+/// - **Data**: `reason: String`
+///
+/// # Payload Quirk
+/// Note that `loan_rejected` places `loan_id` in the **topics** (with `reason` in data),
+/// whereas [`loan_cancelled`] places `loan_id` in the **data payload** (with `borrower` in topics).
 pub fn loan_rejected(env: &Env, loan_id: u32, reason: String) {
     let topics = (Symbol::new(env, "LoanRejected"), loan_id);
     env.events().publish(topics, reason);
 }
 
+/// Emits event when a late fee is charged to a past-due loan.
+///
+/// - **Topics**: `("LateFeeCharged", loan_id: u32)`
+/// - **Data**: `fee_amount: i128`
 pub fn late_fee_charged(env: &Env, loan_id: u32, fee_amount: i128) {
     let topics = (Symbol::new(env, "LateFeeCharged"), loan_id);
     env.events().publish(topics, fee_amount);
 }
 
+/// Emits event when minimum credit score requirement is updated by admin.
+///
+/// - **Topics**: `("MinScoreUpdated", admin: Address)`
+/// - **Data**: `(old_score: u32, new_score: u32)`
 pub fn min_score_updated(env: &Env, admin: Address, old_score: u32, new_score: u32) {
     let topics = (Symbol::new(env, "MinScoreUpdated"), admin);
     env.events().publish(topics, (old_score, new_score));
 }
 
+/// Emits event when the contract is paused.
+///
+/// - **Topics**: `("Paused",)`
+/// - **Data**: `paused_at_ledger: u32`
 pub fn paused(env: &Env, paused_at_ledger: u32) {
     let topics = (Symbol::new(env, "Paused"),);
     env.events().publish(topics, paused_at_ledger);
 }
 
+/// Emits event when the contract is unpaused.
+///
+/// - **Topics**: `("Unpaused",)`
+/// - **Data**: `unpaused_at_ledger: u32`
 pub fn unpaused(env: &Env, unpaused_at_ledger: u32) {
     let topics = (Symbol::new(env, "Unpaused"),);
     env.events().publish(topics, unpaused_at_ledger);
 }
 
-// pub fn min_score_updated(env: &Env, old_score: u32, new_score: u32) {
-//     let topics = (Symbol::new(env, "MinScoreUpdated"),);
-//     env.events().publish(topics, (old_score, new_score));
-// }
-
+/// Emits event when the base interest rate is updated.
+///
+/// - **Topics**: `("InterestRateUpdated",)`
+/// - **Data**: `(old_rate: u32, new_rate: u32)`
 pub fn interest_rate_updated(env: &Env, old_rate: u32, new_rate: u32) {
     let topics = (Symbol::new(env, "InterestRateUpdated"),);
     env.events().publish(topics, (old_rate, new_rate));
 }
 
+/// Emits event when the default term duration is updated.
+///
+/// - **Topics**: `("DefaultTermUpdated",)`
+/// - **Data**: `(old_term: u32, new_term: u32)`
 pub fn default_term_updated(env: &Env, old_term: u32, new_term: u32) {
     let topics = (Symbol::new(env, "DefaultTermUpdated"),);
     env.events().publish(topics, (old_term, new_term));
 }
 
+/// Emits event when a loan is marked as defaulted.
+///
+/// - **Topics**: `("LoanDefaulted", loan_id: u32)`
+/// - **Data**: `borrower: Address`
 pub fn loan_defaulted(env: &Env, loan_id: u32, borrower: Address) {
     let topics = (Symbol::new(env, "LoanDefaulted"), loan_id);
     env.events().publish(topics, borrower);
 }
 
+/// Emits event when allowed loan term limits are updated.
+///
+/// - **Topics**: `("TermLimitsUpdated",)`
+/// - **Data**: `(min_term: u32, max_term: u32)`
 pub fn term_limits_updated(env: &Env, min_term: u32, max_term: u32) {
     let topics = (Symbol::new(env, "TermLimitsUpdated"),);
     env.events().publish(topics, (min_term, max_term));
 }
 
+/// Emits event when the interest rate oracle address is updated.
+///
+/// - **Topics**: `("RateOracleUpdated",)`
+/// - **Data**: `(old_oracle: Option<Address>, new_oracle: Address)`
 pub fn rate_oracle_updated(env: &Env, old_oracle: Option<Address>, new_oracle: Address) {
     let topics = (Symbol::new(env, "RateOracleUpdated"),);
     env.events().publish(topics, (old_oracle, new_oracle));
 }
 
+/// Emits event when collateral is returned to a borrower.
+///
+/// - **Topics**: `("CollateralReturned", borrower: Address, loan_id: u32)`
+/// - **Data**: `amount: i128`
 pub fn collateral_returned(env: &Env, borrower: Address, loan_id: u32, amount: i128) {
     let topics = (Symbol::new(env, "CollateralReturned"), borrower, loan_id);
     env.events().publish(topics, amount);
 }
 
+/// Emits event when collateral is deposited for a loan.
+///
+/// - **Topics**: `("CollateralDeposited", borrower: Address, loan_id: u32)`
+/// - **Data**: `amount: i128`
 pub fn collateral_deposited(env: &Env, borrower: Address, loan_id: u32, amount: i128) {
     let topics = (Symbol::new(env, "CollateralDeposited"), borrower, loan_id);
     env.events().publish(topics, amount);
 }
 
+/// Emits event when collateral is released.
+///
+/// - **Topics**: `("CollateralReleased", borrower: Address, loan_id: u32)`
+/// - **Data**: `()`
 pub fn collateral_released(env: &Env, borrower: Address, loan_id: u32) {
     let topics = (Symbol::new(env, "CollateralReleased"), borrower, loan_id);
     env.events().publish(topics, ());
 }
 
+/// Emits event when the late fee rate BPS is updated by admin.
+///
+/// - **Topics**: `("LateFeeRateUpdated", admin: Address)`
+/// - **Data**: `(old_rate: u32, new_rate: u32)`
 pub fn late_fee_rate_updated(env: &Env, admin: Address, old_rate: u32, new_rate: u32) {
     let topics = (Symbol::new(env, "LateFeeRateUpdated"), admin);
     env.events().publish(topics, (old_rate, new_rate));
 }
 
+/// Emits event when grace period ledgers setting is updated by admin.
+///
+/// - **Topics**: `("GracePeriodUpdated", admin: Address)`
+/// - **Data**: `(old_ledgers: u32, new_ledgers: u32)`
 pub fn grace_period_updated(env: &Env, admin: Address, old_ledgers: u32, new_ledgers: u32) {
     let topics = (Symbol::new(env, "GracePeriodUpdated"), admin);
     env.events().publish(topics, (old_ledgers, new_ledgers));
 }
 
+/// Emits event when default window ledgers setting is updated by admin.
+///
+/// - **Topics**: `("DefaultWindowUpdated", admin: Address)`
+/// - **Data**: `(old_ledgers: u32, new_ledgers: u32)`
 pub fn default_window_updated(env: &Env, admin: Address, old_ledgers: u32, new_ledgers: u32) {
     let topics = (Symbol::new(env, "DefaultWindowUpdated"), admin);
     env.events().publish(topics, (old_ledgers, new_ledgers));
 }
 
+/// Emits event when maximum allowed loan amount is updated by admin.
+///
+/// - **Topics**: `("MaxLoanAmountUpdated", admin: Address)`
+/// - **Data**: `(old_amount: i128, new_amount: i128)`
 pub fn max_loan_amount_updated(env: &Env, admin: Address, old_amount: i128, new_amount: i128) {
     let topics = (Symbol::new(env, "MaxLoanAmountUpdated"), admin);
     env.events().publish(topics, (old_amount, new_amount));
 }
 
+/// Emits event when minimum repayment amount is updated by admin.
+///
+/// - **Topics**: `("MinRepaymentUpdated", admin: Address)`
+/// - **Data**: `(old_amount: i128, new_amount: i128)`
 pub fn min_repayment_updated(env: &Env, admin: Address, old_amount: i128, new_amount: i128) {
     let topics = (Symbol::new(env, "MinRepaymentUpdated"), admin);
     env.events().publish(topics, (old_amount, new_amount));
 }
 
+/// Emits event when maximum loans per borrower limit is updated by admin.
+///
+/// - **Topics**: `("MaxLoansPerBorrower", admin: Address)`
+/// - **Data**: `(old_max: u32, new_max: u32)`
 pub fn max_loans_per_borrower_updated(env: &Env, admin: Address, old_max: u32, new_max: u32) {
     let topics = (Symbol::new(env, "MaxLoansPerBorrower"), admin);
     env.events().publish(topics, (old_max, new_max));
 }
 
+/// Emits admin loan approval event.
+///
+/// - **Topics**: `(symbol_short!("LoanApprv"), admin: Address)`
+/// - **Data**: `(loan_id: u32, borrower: Address)`
+///
+/// # Truncation & De-duplication Quirks
+/// 1. **Truncated Symbol**: Uses `symbol_short!("LoanApprv")` instead of full `Symbol::new(env, "LoanApprovedByAdmin")` due to Soroban's 9-character symbol limit for `symbol_short!`.
+/// 2. **Dual Emission**: Emitted during `approve_loan` alongside [`loan_approved`]. Indexers should de-duplicate or correlate appropriately.
 pub fn loan_approved_by_admin(env: &Env, admin: Address, loan_id: u32, borrower: Address) {
     let topics = (symbol_short!("LoanApprv"), admin);
     env.events().publish(topics, (loan_id, borrower));
 }
 
+/// Emits event when loan collateral is liquidated.
+///
+/// - **Topics**: `("CollateralLiquidated", loan_id: u32)`
+/// - **Data**: `amount: i128`
 pub fn collateral_liquidated(env: &Env, loan_id: u32, amount: i128) {
     let topics = (Symbol::new(env, "CollateralLiquidated"), loan_id);
     env.events().publish(topics, amount);
 }
 
+/// Emits event when a defaulted loan is liquidated.
+///
+/// - **Topics**: `("LoanLiquidated", loan_id: u32, borrower: Address, liquidator: Address)`
+/// - **Data**: `(debt_repaid: i128, liquidator_bonus: i128, borrower_refund: i128)`
 pub fn loan_liquidated(
     env: &Env,
     loan_id: u32,
@@ -180,16 +346,28 @@ pub fn loan_liquidated(
         .publish(topics, (debt_repaid, liquidator_bonus, borrower_refund));
 }
 
+/// Emits event when minimum interest rate BPS bound is updated by admin.
+///
+/// - **Topics**: `("MinRateBpsUpdated", admin: Address)`
+/// - **Data**: `(old_rate: u32, new_rate: u32)`
 pub fn min_rate_bps_updated(env: &Env, admin: Address, old_rate: u32, new_rate: u32) {
     let topics = (Symbol::new(env, "MinRateBpsUpdated"), admin);
     env.events().publish(topics, (old_rate, new_rate));
 }
 
+/// Emits event when maximum interest rate BPS bound is updated by admin.
+///
+/// - **Topics**: `("MaxRateBpsUpdated", admin: Address)`
+/// - **Data**: `(old_rate: u32, new_rate: u32)`
 pub fn max_rate_bps_updated(env: &Env, admin: Address, old_rate: u32, new_rate: u32) {
     let topics = (Symbol::new(env, "MaxRateBpsUpdated"), admin);
     env.events().publish(topics, (old_rate, new_rate));
 }
 
+/// Emits event when a loan in a terminal state is purged from storage by admin.
+///
+/// - **Topics**: `("LoanPurged",)`
+/// - **Data**: `loan_id: u32`
 pub fn loan_purged(env: &Env, loan_id: u32) {
     let topics = (Symbol::new(env, "LoanPurged"),);
     env.events().publish(topics, loan_id);

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1905,11 +1905,28 @@ impl LoanManager {
         Ok(())
     }
 
-    /// Refinance an active loan in good standing (not past due).
-    /// Settles all accrued interest and late fees, adjusts the principal to
-    /// new_amount (drawing from or returning funds to the pool), and resets
-    /// the due date to current_ledger + new_term.
-    /// Requires both borrower auth and admin auth.
+    /// Refinance an active loan.
+    ///
+    /// Refinancing is allowed for an active loan ([`LoanStatus::Approved`]) until the end of
+    /// its default window (`due_date + default_window`). Settles all accrued interest and
+    /// late fees, adjusts the principal to `new_amount` (drawing from or returning funds to
+    /// the lending pool), re-validates borrower credit score, and resets the due date to
+    /// `current_ledger + new_term`.
+    ///
+    /// # Authorization Requirements
+    /// Requires authorization from both the contract **admin** (`admin.require_auth()`) and the **borrower** (`loan.borrower.require_auth()`).
+    ///
+    /// # Error Conditions
+    /// - [`LoanError::ContractPaused`]: If the loan manager contract is paused.
+    /// - [`LoanError::LoanNotFound`]: If no loan matches `loan_id`.
+    /// - [`LoanError::LoanNotActive`]: If the loan status is not [`LoanStatus::Approved`].
+    /// - [`LoanError::LoanPastDue`]: If the current ledger sequence exceeds the end of the default window (`due_date + default_window`).
+    /// - [`LoanError::InvalidAmount`]: If `new_amount <= 0` or exceeds `max_loan_amount`.
+    /// - [`LoanError::InvalidTerm`]: If `new_term` is outside the configured `[min_term, max_term]` bounds.
+    /// - [`LoanError::NotInitialized`]: If the NFT contract reference is not configured in storage.
+    /// - [`LoanError::InsufficientScore`]: If the borrower's credit score falls below `min_score`.
+    /// - [`LoanError::InsufficientCollateral`]: If recorded collateral is strictly less than `new_amount`.
+    /// - [`LoanError::InsufficientPoolLiquidity`]: When refinancing to a higher principal, if available pool liquidity cannot cover the increase.
     pub fn refinance_loan(
         env: Env,
         loan_id: u32,

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -3356,6 +3356,315 @@ fn test_refinance_loan_fails_when_score_drops_below_minimum() {
     assert_eq!(manager.get_loan(&loan_id).status, LoanStatus::Approved);
 }
 
+#[test]
+fn test_refinance_loan_equal_amount_leaves_principal_and_outstanding_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    let token_client = TokenClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    // Set collateral to 1_000
+    stellar_token.mint(&manager.address, &1_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 1_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let borrower_balance_before = token_client.balance(&borrower);
+    let pool_balance_before = token_client.balance(&pool_client);
+    let total_outstanding_before = manager.get_total_outstanding(&token_id);
+
+    // Refinance to the exact same amount (1_000)
+    let res = manager.try_refinance_loan(&loan_id, &1_000, &17_280);
+    assert_eq!(res, Ok(Ok(())));
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.amount, 1_000);
+    assert_eq!(loan.principal_paid, 0);
+    assert_eq!(loan.status, LoanStatus::Approved);
+
+    // Verify balances and total_outstanding are unchanged
+    assert_eq!(token_client.balance(&borrower), borrower_balance_before);
+    assert_eq!(token_client.balance(&pool_client), pool_balance_before);
+    assert_eq!(
+        manager.get_total_outstanding(&token_id),
+        total_outstanding_before
+    );
+}
+
+#[test]
+fn test_refinance_loan_fails_when_pool_liquidity_insufficient() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    let token_client = TokenClient::new(&env, &token_id);
+
+    // Mint just 1_000 for pool (exact amount for loan approval)
+    stellar_token.mint(&pool_client, &1_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    // Pool balance is now 0 after funding loan
+    assert_eq!(token_client.balance(&pool_client), 0);
+
+    // Set collateral to 5_000 so collateral check passes
+    stellar_token.mint(&manager.address, &5_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 5_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let borrower_balance_before = token_client.balance(&borrower);
+    let total_outstanding_before = manager.get_total_outstanding(&token_id);
+
+    // Attempt to refinance increase to 2_000 when pool liquidity is insufficient
+    let result = manager.try_refinance_loan(&loan_id, &2_000, &17_280);
+    assert_eq!(result, Err(Ok(LoanError::InsufficientPoolLiquidity)));
+
+    // Verify state remains unchanged
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.amount, 1_000);
+    assert_eq!(token_client.balance(&borrower), borrower_balance_before);
+    assert_eq!(
+        manager.get_total_outstanding(&token_id),
+        total_outstanding_before
+    );
+}
+
+#[test]
+fn test_refinance_loan_fails_past_default_window() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    // Set collateral to 2_000
+    stellar_token.mint(&manager.address, &2_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 2_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let loan = manager.get_loan(&loan_id);
+    let default_window = manager.get_default_window_ledgers();
+
+    // Past due_date but within default_window -> refinancing succeeds
+    env.ledger().set_sequence_number(loan.due_date + 100);
+    let ok_res = manager.try_refinance_loan(&loan_id, &1_000, &17_280);
+    assert!(
+        ok_res.is_ok(),
+        "Refinancing within default window must succeed"
+    );
+
+    // Past updated due_date + default_window -> refinancing fails with LoanPastDue
+    let updated_loan = manager.get_loan(&loan_id);
+    env.ledger()
+        .set_sequence_number(updated_loan.due_date + default_window + 1);
+    let result = manager.try_refinance_loan(&loan_id, &1_000, &17_280);
+    assert_eq!(result, Err(Ok(LoanError::LoanPastDue)));
+
+    assert_eq!(manager.get_loan(&loan_id).amount, 1_000);
+}
+
+#[test]
+fn test_refinance_loan_fails_when_collateral_below_new_amount() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    // Set collateral to 1_200, which is strictly less than target refinance amount of 2_000
+    stellar_token.mint(&manager.address, &1_200);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 1_200;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    let result = manager.try_refinance_loan(&loan_id, &2_000, &17_280);
+    assert_eq!(result, Err(Ok(LoanError::InsufficientCollateral)));
+
+    // Loan amount remains unchanged at 1_000
+    assert_eq!(manager.get_loan(&loan_id).amount, 1_000);
+}
+
+#[test]
+fn test_refinance_loan_fails_when_term_outside_bounds() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &700,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &50_000);
+
+    // Set term bounds: [1_000, 20_000]
+    manager.set_min_term_ledgers(&1_000);
+    manager.set_max_term_ledgers(&20_000);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+
+    // Set collateral
+    stellar_token.mint(&manager.address, &1_000);
+    env.as_contract(&manager.address, || {
+        let key = DataKey::Loan(loan_id);
+        let mut loan: Loan = env.storage().persistent().get(&key).unwrap();
+        loan.collateral_amount = 1_000;
+        env.storage().persistent().set(&key, &loan);
+    });
+
+    // Test new_term below min (500 < 1_000)
+    let res_below = manager.try_refinance_loan(&loan_id, &1_000, &500);
+    assert_eq!(res_below, Err(Ok(LoanError::InvalidTerm)));
+
+    // Test new_term above max (25_000 > 20_000)
+    let res_above = manager.try_refinance_loan(&loan_id, &1_000, &25_000);
+    assert_eq!(res_above, Err(Ok(LoanError::InvalidTerm)));
+
+    // Loan term remains 17_280
+    assert_eq!(manager.get_loan(&loan_id).term_ledgers, 17_280);
+}
+
+// ── set_grace_period_ledgers tests ───────────────────────────────────────────
+
+#[test]
+fn test_set_grace_period_ledgers_success_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _admin) = setup_test(&env);
+
+    let old_grace = manager.get_grace_period_ledgers();
+    let new_grace = 5_000; // default window is 17_280 by default
+
+    manager.set_grace_period_ledgers(&new_grace);
+
+    let events = env.events().all();
+    let event = events.get(events.len() - 1).unwrap();
+    let topic_0 = soroban_sdk::Symbol::from_val(&env, &event.1.get(0).unwrap());
+    let (old_val, new_val) = <(u32, u32)>::from_val(&env, &event.2);
+
+    assert_eq!(
+        topic_0,
+        soroban_sdk::Symbol::new(&env, "GracePeriodUpdated")
+    );
+    assert_eq!((old_val, new_val), (old_grace, new_grace));
+    assert_eq!(manager.get_grace_period_ledgers(), new_grace);
+}
+
+#[test]
+fn test_set_grace_period_ledgers_fails_when_exceeding_default_window() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, _nft_client, _pool, _token, _admin) = setup_test(&env);
+
+    let current_default_window = manager.get_default_window_ledgers();
+    let invalid_grace = current_default_window + 1;
+
+    let result = manager.try_set_grace_period_ledgers(&invalid_grace);
+    assert_eq!(result, Err(Ok(LoanError::InvalidConfiguration)));
+
+    // Verify grace period remained unchanged
+    assert_ne!(manager.get_grace_period_ledgers(), invalid_grace);
+}
+
+#[test]
+#[should_panic]
+fn test_set_grace_period_ledgers_requires_admin() {
+    let env = Env::default();
+    let (manager, _nft_client, _pool, _token, _admin) = setup_test(&env);
+
+    env.mock_auths(&[]);
+    manager.set_grace_period_ledgers(&5_000);
+}
+
 // ── Pause functionality tests ──────────────────────────────────────────────
 
 #[test]
@@ -4131,4 +4440,3 @@ fn test_liquidate_decreases_score_and_records_default() {
     assert_eq!(nft_client.get_default_count(&borrower), 1);
     assert!(nft_client.is_seized(&borrower));
 }
-


### PR DESCRIPTION
Closes #1129
Closes #1130
Closes #1131
Closes #1132

### Summary of Completed Work

#### 1. Event Emitter Rustdocs & Catalog (`contracts/loan_manager/src/events.rs`)
- **Module Catalog**: Added a comprehensive rustdoc module header documenting the complete event catalog, topic tuples (`Topic 0`, `Topic 1`, ...), and data payload structures.
- **Event Emitters Documentation**: Added rustdoc comments to all ~30 public event emitter functions in `events.rs`, explicitly detailing their topic layout and data payload types.
- **Indexer Integration & De-duplication Quirks**:
  - Documented `loan_approved_by_admin`'s use of the truncated symbol `symbol_short!("LoanApprv")` (due to Soroban's 9-character symbol short limit).
  - Documented that `approve_loan` in [`lib.rs`](file:///Users/marvellous/Desktop/remitlend/contracts/loan_manager/src/lib.rs#L1250-L1257) emits dual events (`LoanApproved` and `LoanApprv`) for a single loan approval so indexer authors can de-duplicate events properly.
  - Highlighted schema differences between `loan_cancelled` (`loan_id` in data payload, `borrower` in topics) and `loan_rejected` (`loan_id` in topics, `reason` in data payload).

#### 2. Refinance Eligibility Rustdoc (`contracts/loan_manager/src/lib.rs`)
- Updated the rustdoc for [`refinance_loan`](file:///Users/marvellous/Desktop/remitlend/contracts/loan_manager/src/lib.rs#L1908-L1930) to accurately reflect the actual guard logic: refinancing is permitted for active loans up until the end of the default window (`due_date + default_window`), rather than restricting it strictly to non-overdue loans.
- Outlined authorization requirements (both admin and borrower signatures required) and documented all return error paths (`LoanError::LoanPastDue`, `LoanError::InsufficientScore`, `LoanError::InsufficientCollateral`, `LoanError::InsufficientPoolLiquidity`, etc.).

#### 3. `refinance_loan` Branch Unit Tests (`contracts/loan_manager/src/test.rs`)
Added 5 deterministic unit tests covering previously unexercised branches in `refinance_loan`:
- `test_refinance_loan_equal_amount_leaves_principal_and_outstanding_unchanged`: Asserts refinancing to the exact same amount acts as a no-op on principal, leaving total outstanding debt and pool balances unchanged.
- `test_refinance_loan_fails_when_pool_liquidity_insufficient`: Asserts refinancing to a higher principal reverts with `LoanError::InsufficientPoolLiquidity` when the pool lacks sufficient available funds.
- `test_refinance_loan_fails_past_default_window`: Verifies refinancing succeeds past `due_date` within the default window, but fails with `LoanError::LoanPastDue` when sequence is strictly past `due_date + default_window`.
- `test_refinance_loan_fails_when_collateral_below_new_amount`: Asserts requests with collateral below the new target principal revert with `LoanError::InsufficientCollateral`.
- `test_refinance_loan_fails_when_term_outside_bounds`: Asserts requested new terms below `min_term_ledgers` or above `max_term_ledgers` revert with `LoanError::InvalidTerm`.

#### 4. `set_grace_period_ledgers` Unit Tests (`contracts/loan_manager/src/test.rs`)
Added 3 dedicated unit tests for `set_grace_period_ledgers`:
- `test_set_grace_period_ledgers_success_emits_event`: Verifies setting a valid grace period updates storage and emits the `GracePeriodUpdated` event carrying `old_ledgers` and `new_ledgers`.
- `test_set_grace_period_ledgers_fails_when_exceeding_default_window`: Asserts attempting to set a grace period greater than the current `default_window_ledgers` reverts with `LoanError::InvalidConfiguration`.
- `test_set_grace_period_ledgers_requires_admin`: Asserts non-admin callers trigger an authorization error.

---

### Verification
- **Unit Tests**: Executed `cargo test -p loan_manager` — all 130 tests passed (130 passed, 0 failed).
- **Code Formatting**: Executed `cargo fmt --check -p loan_manager` — clean with zero diffs.
- **Documentation**: Executed `cargo doc -p loan_manager --no-deps` — documentation generated cleanly.
