### PR TITLE
fix: scale amounts to base units before encoding XDR for loan requests and repayments

### DIFF
--- a/frontend/src/app/[locale]/repay/[loanId]/page.tsx
+++ b/frontend/src/app/[locale]/repay/[loanId]/page.tsx
@@ -91,6 +91,7 @@ export default function RepayLoanPage() {
         loanId,
         amount: amountNumber,
         contractId,
+        decimals,
       });
 
       txPreview.show(

--- a/frontend/src/app/components/loan-wizard/StepFinalSignature.tsx
+++ b/frontend/src/app/components/loan-wizard/StepFinalSignature.tsx
@@ -13,6 +13,7 @@ import { useTransactionPreview } from "../../hooks/useTransactionPreview";
 import { useCreateLoan } from "../../hooks/useApi";
 import { useContractToast } from "../../hooks/useContractToast";
 import { buildUnsignedLoanRequestXdr } from "../../utils/soroban";
+import { getAssetDecimals } from "../../utils/amount";
 import {
   mapTransactionError,
   pollTransactionStatus,
@@ -96,6 +97,7 @@ export function StepFinalSignature({
           amount: principal,
           term: data.termDays * 17280,
           contractId: managerContractId,
+          decimals: getAssetDecimals(data.asset),
         });
         if (!cancelled) setUnsignedXdr(xdr);
       } catch (err) {

--- a/frontend/src/app/utils/soroban.test.ts
+++ b/frontend/src/app/utils/soroban.test.ts
@@ -76,7 +76,7 @@ describe("buildUnsignedLoanRequestXdr", () => {
     }
   });
 
-  it("encodes the full loan amount into the XDR, not a tenth of it", async () => {
+  it("scales amount to base units using decimals (USDC: 2 decimals)", async () => {
     const inputAmount = 1000;
 
     const xdrString = await buildUnsignedLoanRequestXdr({
@@ -84,6 +84,7 @@ describe("buildUnsignedLoanRequestXdr", () => {
       amount: inputAmount,
       term: 12,
       contractId,
+      decimals: 2,
     });
 
     const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
@@ -93,17 +94,42 @@ describe("buildUnsignedLoanRequestXdr", () => {
       const args = op.func.invokeContract().args();
       const amountVal = scValToNative(args[1]);
 
-      expect(amountVal).toBe(BigInt(inputAmount));
-      expect(amountVal).not.toBe(BigInt(inputAmount / 10));
+      // 1000 USDC = 1000 * 10^2 = 100000 base units
+      expect(amountVal).toBe(BigInt(inputAmount) * BigInt(10 ** 2));
+      expect(amountVal).not.toBe(BigInt(inputAmount));
     }
   });
 
-  it("floors fractional amounts before encoding as i128", async () => {
+  it("scales amount to base units using decimals (XLM: 7 decimals)", async () => {
+    const inputAmount = 500;
+
+    const xdrString = await buildUnsignedLoanRequestXdr({
+      borrower,
+      amount: inputAmount,
+      term: 12,
+      contractId,
+      decimals: 7,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      const amountVal = scValToNative(args[1]);
+
+      // 500 XLM = 500 * 10^7 = 5000000000 base units
+      expect(amountVal).toBe(BigInt(inputAmount) * BigInt(10 ** 7));
+    }
+  });
+
+  it("floors fractional amounts before scaling to base units", async () => {
     const xdrString = await buildUnsignedLoanRequestXdr({
       borrower,
       amount: 1000.75,
       term: 12,
       contractId,
+      decimals: 2,
     });
 
     const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
@@ -113,7 +139,8 @@ describe("buildUnsignedLoanRequestXdr", () => {
       const args = op.func.invokeContract().args();
       const amountVal = scValToNative(args[1]);
 
-      expect(amountVal).toBe(BigInt(1000));
+      // Math.floor(1000.75) = 1000, scaled: 1000 * 10^2 = 100000
+      expect(amountVal).toBe(BigInt(1000) * BigInt(10 ** 2));
     }
   });
 });
@@ -174,7 +201,7 @@ describe("buildUnsignedRepaymentXdr", () => {
     }
   });
 
-  it("encodes the full repayment amount into the XDR, not a tenth of it", async () => {
+  it("scales amount to base units using decimals (USDC: 2 decimals)", async () => {
     const inputAmount = 1000;
     const loanId = "42";
 
@@ -183,10 +210,10 @@ describe("buildUnsignedRepaymentXdr", () => {
       loanId,
       amount: inputAmount,
       contractId,
+      decimals: 2,
     });
 
     const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
-
     const op = tx.operations[0];
     expect(op.type).toBe("invokeHostFunction");
 
@@ -197,17 +224,44 @@ describe("buildUnsignedRepaymentXdr", () => {
       const amountVal = scValToNative(args[2]);
 
       expect(loanIdVal).toBe(BigInt(loanId));
-      expect(amountVal).toBe(BigInt(inputAmount));
-      expect(amountVal).not.toBe(BigInt(inputAmount / 10));
+      // 1000 USDC = 1000 * 10^2 = 100000 base units
+      expect(amountVal).toBe(BigInt(inputAmount) * BigInt(10 ** 2));
+      expect(amountVal).not.toBe(BigInt(inputAmount));
     }
   });
 
-  it("floors fractional amounts before encoding as i128", async () => {
+  it("scales amount to base units using decimals (XLM: 7 decimals)", async () => {
+    const inputAmount = 250;
+    const loanId = "7";
+
+    const xdrString = await buildUnsignedRepaymentXdr({
+      borrower,
+      loanId,
+      amount: inputAmount,
+      contractId,
+      decimals: 7,
+    });
+
+    const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
+    const op = tx.operations[0];
+    expect(op.type).toBe("invokeHostFunction");
+
+    if (op.type === "invokeHostFunction") {
+      const args = op.func.invokeContract().args();
+      const amountVal = scValToNative(args[2]);
+
+      // 250 XLM = 250 * 10^7 = 2500000000 base units
+      expect(amountVal).toBe(BigInt(inputAmount) * BigInt(10 ** 7));
+    }
+  });
+
+  it("floors fractional amounts before scaling to base units", async () => {
     const xdrString = await buildUnsignedRepaymentXdr({
       borrower,
       loanId: "42",
       amount: 1000.5,
       contractId,
+      decimals: 2,
     });
 
     const tx = TransactionBuilder.fromXDR(xdrString, NETWORK_PASSPHRASE);
@@ -217,7 +271,8 @@ describe("buildUnsignedRepaymentXdr", () => {
       const args = op.func.invokeContract().args();
       const amountVal = scValToNative(args[2]);
 
-      expect(amountVal).toBe(BigInt(1000));
+      // Math.floor(1000.5) = 1000, scaled: 1000 * 10^2 = 100000
+      expect(amountVal).toBe(BigInt(1000) * BigInt(10 ** 2));
     }
   });
 });

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -8,6 +8,7 @@ import {
   TransactionBuilder,
   xdr,
 } from "@stellar/stellar-sdk";
+import { toStroops, STROOP_DECIMALS } from "./amount";
 
 const DEFAULT_RPC_URL = "https://soroban-testnet.stellar.org";
 const DEFAULT_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
@@ -17,6 +18,7 @@ interface BuildLoanRequestXdrParams {
   amount: number;
   term: number;
   contractId: string;
+  decimals?: number;
   rpcUrl?: string;
   networkPassphrase?: string;
 }
@@ -26,6 +28,7 @@ interface BuildRepaymentXdrParams {
   loanId: string;
   amount: number;
   contractId: string;
+  decimals?: number;
   rpcUrl?: string;
   networkPassphrase?: string;
 }
@@ -35,13 +38,18 @@ export async function buildUnsignedLoanRequestXdr({
   amount,
   term,
   contractId,
+  decimals = STROOP_DECIMALS,
   rpcUrl = process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? DEFAULT_RPC_URL,
   networkPassphrase = process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
     DEFAULT_NETWORK_PASSPHRASE,
 }: BuildLoanRequestXdrParams): Promise<string> {
   const server = new rpc.Server(rpcUrl);
   const source = await server.getAccount(borrower);
-  const amountScVal = nativeToScVal(BigInt(Math.floor(amount)), { type: "i128" });
+  const scaledAmount = toStroops(String(Math.floor(amount)), decimals);
+  if (scaledAmount === null) {
+    throw new Error(`Invalid amount for ${decimals}-decimal asset: ${amount}`);
+  }
+  const amountScVal = nativeToScVal(scaledAmount, { type: "i128" });
   const termScVal = nativeToScVal(term, { type: "u32" });
   const borrowerScVal = new Address(borrower).toScVal();
 
@@ -72,6 +80,7 @@ export async function buildUnsignedRepaymentXdr({
   loanId,
   amount,
   contractId,
+  decimals = STROOP_DECIMALS,
   rpcUrl = process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? DEFAULT_RPC_URL,
   networkPassphrase = process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
     DEFAULT_NETWORK_PASSPHRASE,
@@ -81,7 +90,11 @@ export async function buildUnsignedRepaymentXdr({
 
   const borrowerScVal = new Address(borrower).toScVal();
   const loanIdScVal = nativeToScVal(BigInt(loanId), { type: "u64" });
-  const amountScVal = nativeToScVal(BigInt(Math.floor(amount)), { type: "i128" });
+  const scaledAmount = toStroops(String(Math.floor(amount)), decimals);
+  if (scaledAmount === null) {
+    throw new Error(`Invalid amount for ${decimals}-decimal asset: ${amount}`);
+  }
+  const amountScVal = nativeToScVal(scaledAmount, { type: "i128" });
 
   const tx = new TransactionBuilder(source, {
     fee: "10000",


### PR DESCRIPTION
Closes #1072

## Summary
- Fixed `buildUnsignedRepaymentXdr` and `buildUnsignedLoanRequestXdr` in `soroban.ts` to scale human-entered amounts to base units before encoding as i128
- Previously, raw amounts (e.g. 250) were sent directly to the contract instead of scaled values (e.g. 250 * 10^decimals), causing repayments and loan requests to be off by orders of magnitude
- Both functions now accept an optional `decimals` parameter and use `toStroops()` from `utils/amount.ts` for correct scaling
- The repay page and loan wizard pass the appropriate decimal precision for their assets (USDC: 2, XLM: 7)

## Scope
Does not touch contract-side amount handling, backend-built deposit/withdraw XDR, or any other XDR builders — out of scope for this issue.

## Testing
- Updated unit tests in `soroban.test.ts` to verify amounts are scaled to base units for both 2-decimal (USDC) and 7-decimal (XLM) assets
- Tests confirm fractional amounts are floored before scaling
- Full lint/typecheck/test suite was not run locally (per user request to skip installations)

## Files changed
- `frontend/src/app/utils/soroban.ts` — Core fix: import `toStroops`/`STROOP_DECIMALS`, add `decimals` param, scale amounts before `nativeToScVal`
- `frontend/src/app/utils/soroban.test.ts` — Updated tests to verify scaled amounts for 2-decimal and 7-decimal assets
- `frontend/src/app/[locale]/repay/[loanId]/page.tsx` — Pass `decimals` from `getAssetDecimals("USDC")` to `buildUnsignedRepaymentXdr`
- `frontend/src/app/components/loan-wizard/StepFinalSignature.tsx` — Import `getAssetDecimals`, pass `decimals` to `buildUnsignedLoanRequestXdr`