### PR TITLE
docs: document lending_pool PoolError variants and events

### DIFF
--- a/contracts/lending_pool/src/events.rs
+++ b/contracts/lending_pool/src/events.rs
@@ -1,16 +1,31 @@
 use crate::DataKey;
 use soroban_sdk::{Address, Env, Symbol};
 
+/// Emitted when a provider deposits assets and receives LP shares.
+///
+/// **Topics**: `(Deposit, provider, token)`
+/// **Data**: `(amount, shares_minted)`
 pub fn deposit(env: &Env, provider: Address, token: Address, amount: i128, shares_minted: i128) {
     let topics = (Symbol::new(env, "Deposit"), provider, token);
     env.events().publish(topics, (amount, shares_minted));
 }
 
+/// Emitted when a provider burns LP shares and receives the proportional underlying assets.
+///
+/// **Topics**: `(Withdraw, provider, token)`
+/// **Data**: `(amount, shares_burned)`
 pub fn withdraw(env: &Env, provider: Address, token: Address, amount: i128, shares_burned: i128) {
     let topics = (Symbol::new(env, "Withdraw"), provider, token);
     env.events().publish(topics, (amount, shares_burned));
 }
 
+/// Emitted when yield is explicitly distributed to the pool, increasing the share price.
+///
+/// **Topics**: `(YieldDistributed, token)`
+/// **Data**: `amount`
+///
+/// Increments `TotalYieldDistributed` storage for the token and updates `total_managed_assets`,
+/// raising the share price for all existing holders.
 #[allow(dead_code)]
 pub fn yield_distributed(env: &Env, token: Address, amount: i128) {
     if amount > 0 {
@@ -30,31 +45,57 @@ pub fn yield_distributed(env: &Env, token: Address, amount: i128) {
     env.events().publish(topics, amount);
 }
 
+/// Emitted when the max pool size cap is updated for a token.
+///
+/// **Topics**: `(DepositCapUpdated, token)`
+/// **Data**: `(old_cap, new_cap)`
 pub fn deposit_cap_updated(env: &Env, token: Address, old_cap: i128, new_cap: i128) {
     let topics = (Symbol::new(env, "DepositCapUpdated"), token);
     env.events().publish(topics, (old_cap, new_cap));
 }
 
+/// Emitted when the pool is paused, blocking deposits, withdrawals, and yield distribution.
+///
+/// **Topics**: `(PoolPaused,)`
+/// **Data**: `()`
 pub fn pool_paused(env: &Env) {
     let topics = (Symbol::new(env, "PoolPaused"),);
     env.events().publish(topics, ());
 }
 
+/// Emitted when the pool is unpaused, allowing deposits, withdrawals, and yield distribution to resume.
+///
+/// **Topics**: `(PoolUnpaused,)`
+/// **Data**: `()`
 pub fn pool_unpaused(env: &Env) {
     let topics = (Symbol::new(env, "PoolUnpaused"),);
     env.events().publish(topics, ());
 }
 
+/// Emitted when the withdrawal cooldown duration is updated.
+///
+/// **Topics**: `(WithdrawalCooldownUpdated,)`
+/// **Data**: `(old_cooldown, new_cooldown)`
 pub fn withdrawal_cooldown_updated(env: &Env, old_cooldown: u32, new_cooldown: u32) {
     let topics = (Symbol::new(env, "WithdrawalCooldownUpdated"),);
     env.events().publish(topics, (old_cooldown, new_cooldown));
 }
 
+/// Emitted when a new admin is proposed by the current admin.
+///
+/// **Topics**: `(AdminProposed, current_admin)`
+/// **Data**: `proposed_admin`
 pub fn admin_proposed(env: &Env, current_admin: Address, proposed_admin: Address) {
     let topics = (Symbol::new(env, "AdminProposed"), current_admin);
     env.events().publish(topics, proposed_admin);
 }
 
+/// Emitted when admin privileges are transferred to a new admin.
+///
+/// **Topics**: `(AdminTransferred, via)`
+/// **Data**: `(previous_admin, new_admin)`
+///
+/// `via` is either "accept" (proposed admin accepted transfer) or "govern" (current admin force-transferred).
 pub fn admin_transferred(env: &Env, previous_admin: Address, new_admin: Address, via: Symbol) {
     let topics = (Symbol::new(env, "AdminTransferred"), via);
     env.events().publish(topics, (previous_admin, new_admin));
@@ -63,7 +104,10 @@ pub fn admin_transferred(env: &Env, previous_admin: Address, new_admin: Address,
 /// Emitted on every mutation of a token pool's share-pricing state
 /// (`deposit`, `withdraw`/`emergency_withdraw`, `distribute_yield`) so that
 /// off-chain indexers can reconcile quoted prices against the last settled
-/// on-chain price and detect ledger skew (#1380).
+/// on-chain price and detect ledger skew.
+///
+/// **Topics**: `(PriceUpdated, token)`
+/// **Data**: `(ledger_seq, total_managed_assets, total_shares)`
 pub fn price_updated(
     env: &Env,
     token: Address,

--- a/contracts/lending_pool/src/lib.rs
+++ b/contracts/lending_pool/src/lib.rs
@@ -1,4 +1,43 @@
 #![no_std]
+//! # Lending Pool: Share-Based Liquidity Management
+//!
+//! ## Overview
+//! The lending pool is a liquidity contract that allows depositors to earn yield by providing tokens
+//! to borrowers. It uses an LP-token (shares) model where yield is implicit in the exchange rate
+//! between shares and underlying assets, eliminating the need for explicit claim or distribution steps.
+//!
+//! ## Share-Based Accounting
+//! Depositors receive LP shares proportional to the deposited amount and the current share price.
+//! The share price is `total_managed_assets / total_shares`, both inflated by virtual offsets
+//! (`VIRTUAL_ASSETS` and `VIRTUAL_SHARES`) to prevent rounding attacks. When withdrawing, depositors
+//! burn shares to receive the proportional underlying assets at the current exchange rate.
+//!
+//! ## Implicit Yield
+//! Yield enters the pool in two ways:
+//! - **Via LoanManager**: When borrowers repay loans with interest, the LoanManager contract
+//!   transfers tokens to the pool (interest component). This increases `total_managed_assets`,
+//!   raising the share price without minting new shares or requiring an explicit distribute call.
+//! - **Via distribute_yield**: Authorized callers can explicitly transfer yield via `distribute_yield`,
+//!   which also increases `total_managed_assets` and the share price.
+//!
+//! Since the share price automatically incorporates yield, a depositor's asset value grows
+//! over time simply by holding shares—no separate yield claim mechanism is needed.
+//!
+//! ## Loan/Utilization Relationship
+//! `total_managed_assets` (share price input) tracks the total value the pool has under management:
+//! idle balance plus outstanding loans. `total_outstanding` tracks how much principal is deployed
+//! in active loans. Utilization is the fraction of `total_managed_assets` currently out on loan.
+//!
+//! When borrowers repay with interest, `total_managed_assets` grows (yield captured) while
+//! `total_outstanding` shrinks (principal returned), raising the share price and lowering utilization.
+//! If a borrower defaults, `total_outstanding` may drop below actual pool balance, leaving
+//! the difference as a shortfall absorbed by remaining depositors.
+//!
+//! ## Multi-Token Keying
+//! A single contract instance serves multiple token pools. Storage keys (`DataKey`) include
+//! the token address, allowing independent accounting per token. For example, one instance
+//! can manage USDC, USDT, and BRL pools simultaneously with separate share prices and balances.
+
 // Lending pool contract for RemitLend.
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::{
@@ -11,23 +50,31 @@ use events::*;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PoolError {
+    /// The contract has already been initialized with an admin.
     AlreadyInitialized = 1,
+    /// The contract has not been initialized yet.
     NotInitialized = 2,
+    /// The pool is paused; deposits, withdrawals, and yield distribution are blocked.
     ContractPaused = 3,
+    /// The amount provided is invalid (zero or negative).
     InvalidAmount = 4,
+    /// Depositing the requested amount would exceed the max pool size cap for this token.
     PoolSizeExceeded = 5,
+    /// The provider does not have enough shares to burn for a withdrawal.
     InsufficientBalance = 6,
+    /// The pool does not have enough idle balance to satisfy the withdrawal.
     InsufficientLiquidity = 7,
+    /// The max pool size value is invalid (negative). Discriminant 8 is intentionally skipped for historical compatibility.
     InvalidMaxPoolSize = 9,
+    /// No admin has been proposed, so `accept_admin` cannot proceed.
     NoProposedAdmin = 10,
+    /// The requested withdrawal cooldown exceeds the maximum allowed duration.
     CooldownTooLong = 11,
-    /// `deposit` would mint fewer shares than the caller's `min_shares_out`.
+    /// `deposit` would mint fewer shares than the caller's `min_shares_out` (slippage protection).
     MinSharesNotMet = 12,
-    /// `redeem`/`withdraw` would return fewer assets than the caller's
-    /// `min_assets_out`.
+    /// `redeem`/`withdraw` would return fewer assets than the caller's `min_assets_out` (slippage protection).
     MinAssetsNotMet = 13,
-    /// The computed share/asset amount for an operation rounded down to
-    /// zero, so no value would actually move.
+    /// The computed share/asset amount for an operation rounded down to zero, so no value would actually move.
     ZeroShares = 14,
 }
 


### PR DESCRIPTION
Addresses #1139 and #1138 with minimal documentation-only changes:

- Add crate-level rustdoc explaining share-based accounting, implicit yield, loan/utilization relationship, and multi-token keying. Documents how interest enters the pool via LoanManager token transfers.

- Add per-variant rustdoc to PoolError enum, documenting the condition that triggers each error. Explain discriminant 8 skip for historical compatibility.

- Add rustdoc to each event helper function documenting exact topic and data tuples for integrators and indexers. Topics and data tuples match current code.


Closes #1139 
Closes #1138 
## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
