### PR TITLE
fix(security): require PII_KEK_KEY or PII_KMS_ENDPOINT to prevent zer…

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -55,5 +55,31 @@ export function validateEnvVars(): void {
     process.exit(1);
   }
 
+  // PII encryption requires either a KMS endpoint or a local KEK key.
+  // Both missing means PII would be encrypted with a static all-zero key.
+  const hasKmsEndpoint =
+    process.env.PII_KMS_ENDPOINT && process.env.PII_KMS_ENDPOINT.trim() !== '';
+  const hasKekKey = process.env.PII_KEK_KEY && process.env.PII_KEK_KEY.trim() !== '';
+
+  if (!hasKmsEndpoint && !hasKekKey) {
+    const boldRed = (msg: string) => `\x1b[1;31m${msg}\x1b[0m`;
+    const bold = (msg: string) => `\x1b[1m${msg}\x1b[0m`;
+
+    const errorPrefix = boldRed('FATAL ERROR: PII encryption misconfiguration');
+    const msg = `PII_KEK_KEY or PII_KMS_ENDPOINT must be provided. ${bold('Both are missing.')}`;
+    const actionMsg =
+      'Set PII_KMS_ENDPOINT for remote KMS encryption or PII_KEK_KEY for local envelope encryption.';
+
+    console.error(`\n${errorPrefix}\n${msg}\n${actionMsg}\n`);
+
+    logger.error('PII encryption env validation failure', {
+      hasKmsEndpoint,
+      hasKekKey,
+      node_env: process.env.NODE_ENV,
+    });
+
+    process.exit(1);
+  }
+
   logger.info('Environment variables validated successfully.');
 }

--- a/backend/src/services/piiCrypto.ts
+++ b/backend/src/services/piiCrypto.ts
@@ -25,7 +25,9 @@ async function unwrapDek(dekWrapped: Buffer, kekId: string): Promise<Buffer> {
     const { plaintext } = (await resp.json()) as { plaintext: string };
     return Buffer.from(plaintext, 'base64');
   }
-  const kek = Buffer.from(process.env.PII_KEK_KEY ?? '0'.repeat(64), 'hex');
+  const kekHex = process.env.PII_KEK_KEY;
+  if (!kekHex) throw new Error('PII_KEK_KEY is required for local KEK unwrapping but is not set');
+  const kek = Buffer.from(kekHex, 'hex');
   const decipher = crypto.createDecipheriv('aes-256-gcm', kek, dekWrapped.subarray(0, 12));
   decipher.setAuthTag(dekWrapped.subarray(12, 28));
   const decrypted = Buffer.concat([decipher.update(dekWrapped.subarray(28)), decipher.final()]);
@@ -43,7 +45,9 @@ async function wrapDek(dek: Buffer): Promise<Buffer> {
     const { wrapped_key } = (await resp.json()) as { wrapped_key: string };
     return Buffer.from(wrapped_key, 'base64');
   }
-  const kek = Buffer.from(process.env.PII_KEK_KEY ?? '0'.repeat(64), 'hex');
+  const kekHex = process.env.PII_KEK_KEY;
+  if (!kekHex) throw new Error('PII_KEK_KEY is required for local KEK wrapping but is not set');
+  const kek = Buffer.from(kekHex, 'hex');
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv('aes-256-gcm', kek, iv);
   const encrypted = Buffer.concat([cipher.update(dek), cipher.final()]);

--- a/backend/src/tests/envValidation.test.ts
+++ b/backend/src/tests/envValidation.test.ts
@@ -63,4 +63,28 @@ describe('Environment Variable Validation', () => {
     expect(() => validateEnvVars()).toThrow('Process.exit called with 1');
     expect(mockExit).toHaveBeenCalledWith(1);
   });
+
+  it('should exit if neither PII_KEK_KEY nor PII_KMS_ENDPOINT is set', () => {
+    delete process.env.PII_KEK_KEY;
+    delete process.env.PII_KMS_ENDPOINT;
+
+    expect(() => validateEnvVars()).toThrow('Process.exit called with 1');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should not exit if PII_KMS_ENDPOINT is set', () => {
+    process.env.PII_KMS_ENDPOINT = 'https://kms.example.com';
+    delete process.env.PII_KEK_KEY;
+
+    expect(() => validateEnvVars()).not.toThrow();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should not exit if PII_KEK_KEY is set', () => {
+    process.env.PII_KEK_KEY = 'a'.repeat(64);
+    delete process.env.PII_KMS_ENDPOINT;
+
+    expect(() => validateEnvVars()).not.toThrow();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

This PR fixes a critical security vulnerability where  silently falls back to a static all-zero encryption key when  is not configured.

## Changes

- ****: Removed the  fallback in both  and . Both functions now throw an explicit error if  is missing when no KMS endpoint is configured.

- ****: Added startup validation requiring either  or  to be set. The server will now exit immediately with a clear error message if neither is configured.

- ****: Added 3 new tests covering the PII encryption env validation logic.

## Impact

Before this fix, omitting  from the environment would cause all PII (e.g., remittance recipient metadata) to be encrypted with a known public key of all zeroes, exposing borrower information to compromise.

After this fix, the server will refuse to start without proper PII encryption configuration.

Closes #1625
Closes #1626
Closes #1627
Closes #1628