### PR TITLE
fix: persist and return perTypeOverrides in notification preferences

### DIFF
--- a/backend/migrations/1803000000000_add-per-type-overrides.js
+++ b/backend/migrations/1803000000000_add-per-type-overrides.js
@@ -1,0 +1,27 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+  pgm.addColumns('user_notification_preferences', {
+    per_type_overrides: {
+      type: 'jsonb',
+      notNull: true,
+      default: "'{}'",
+      comment: 'Per-notification-type overrides, e.g. {"repayment_due": true}',
+    },
+  });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+  pgm.dropColumns('user_notification_preferences', ['per_type_overrides']);
+};

--- a/backend/migrations/1803000000000_add-per-type-overrides.js
+++ b/backend/migrations/1803000000000_add-per-type-overrides.js
@@ -12,7 +12,7 @@ export const up = (pgm) => {
     per_type_overrides: {
       type: 'jsonb',
       notNull: true,
-      default: "'{}'",
+      default: pgm.func("'{}'::jsonb"),
       comment: 'Per-notification-type overrides, e.g. {"repayment_due": true}',
     },
   });

--- a/backend/src/__tests__/notificationPreferences.test.ts
+++ b/backend/src/__tests__/notificationPreferences.test.ts
@@ -66,10 +66,35 @@ describe('notification preferences endpoints', () => {
     });
   });
 
+  it('returns persisted perTypeOverrides on GET', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        email_enabled: true,
+        sms_enabled: false,
+        phone: '+15551234567',
+        per_type_overrides: { repayment_due: true, loan_approved: false },
+      }],
+    });
+
+    const response = await request(app)
+      .get('/api/notifications/preferences')
+      .set(bearer('GTESTUSER5555555555555555555555555555555555555555555555555'));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      emailEnabled: true,
+      smsEnabled: false,
+      phone: '+15551234567',
+      perTypeOverrides: { repayment_due: true, loan_approved: false },
+    });
+  });
+
   it('writes valid preferences and returns updated payload', async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ email_enabled: true, sms_enabled: true, phone: '+14155552671' }],
     });
+    // Mock for upsert into user_notification_preferences
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     const response = await request(app)
       .put('/api/notifications/preferences')
@@ -86,7 +111,7 @@ describe('notification preferences endpoints', () => {
       emailEnabled: true,
       smsEnabled: true,
       phone: '+14155552671',
-      perTypeOverrides: {},
+      perTypeOverrides: { repayment_due: true },
     });
   });
 

--- a/backend/src/__tests__/notificationPreferences.test.ts
+++ b/backend/src/__tests__/notificationPreferences.test.ts
@@ -68,12 +68,14 @@ describe('notification preferences endpoints', () => {
 
   it('returns persisted perTypeOverrides on GET', async () => {
     mockQuery.mockResolvedValueOnce({
-      rows: [{
-        email_enabled: true,
-        sms_enabled: false,
-        phone: '+15551234567',
-        per_type_overrides: { repayment_due: true, loan_approved: false },
-      }],
+      rows: [
+        {
+          email_enabled: true,
+          sms_enabled: false,
+          phone: '+15551234567',
+          per_type_overrides: { repayment_due: true, loan_approved: false },
+        },
+      ],
     });
 
     const response = await request(app)

--- a/backend/src/controllers/notificationController.ts
+++ b/backend/src/controllers/notificationController.ts
@@ -101,6 +101,7 @@ export const updateNotificationPreferences = asyncHandler(async (req: Request, r
     emailEnabled: parsed.emailEnabled,
     smsEnabled: parsed.smsEnabled,
     phone,
+    perTypeOverrides: parsed.perTypeOverrides ?? {},
   });
 
   res.json(preferences);

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -176,9 +176,12 @@ async function sendSMS(phone: string, message: string) {
 class NotificationService {
   async getNotificationPreferences(userId: string): Promise<NotificationPreferences> {
     const result = await query(
-      `SELECT email_enabled, sms_enabled, phone
-       FROM user_profiles
-       WHERE public_key = $1
+      `SELECT up.email_enabled, up.sms_enabled, up.phone,
+             unp.per_type_overrides
+       FROM user_profiles up
+       LEFT JOIN user_notification_preferences unp
+         ON unp.user_id = up.public_key
+       WHERE up.public_key = $1
        LIMIT 1`,
       [userId],
     );
@@ -197,13 +200,13 @@ class NotificationService {
       emailEnabled: Boolean(row.email_enabled),
       smsEnabled: Boolean(row.sms_enabled),
       phone: (row.phone as string | null) ?? null,
-      perTypeOverrides: {},
+      perTypeOverrides: (row.per_type_overrides as Record<string, boolean>) ?? {},
     };
   }
 
   async updateNotificationPreferences(
     userId: string,
-    payload: Pick<NotificationPreferences, 'emailEnabled' | 'smsEnabled' | 'phone'>,
+    payload: Pick<NotificationPreferences, 'emailEnabled' | 'smsEnabled' | 'phone' | 'perTypeOverrides'>,
   ): Promise<NotificationPreferences> {
     const result = await query(
       `UPDATE user_profiles
@@ -221,11 +224,21 @@ class NotificationService {
       phone: payload.phone,
     };
 
+    const perTypeOverrides = payload.perTypeOverrides ?? {};
+
+    // Upsert per-type overrides into user_notification_preferences
+    await query(
+      `INSERT INTO user_notification_preferences (user_id, per_type_overrides)
+       VALUES ($1, $2)
+       ON CONFLICT (user_id) DO UPDATE SET per_type_overrides = $2`,
+      [userId, JSON.stringify(perTypeOverrides)],
+    );
+
     return {
       emailEnabled: Boolean(row.email_enabled),
       smsEnabled: Boolean(row.sms_enabled),
       phone: (row.phone as string | null) ?? null,
-      perTypeOverrides: {},
+      perTypeOverrides,
     };
   }
 

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -206,7 +206,10 @@ class NotificationService {
 
   async updateNotificationPreferences(
     userId: string,
-    payload: Pick<NotificationPreferences, 'emailEnabled' | 'smsEnabled' | 'phone' | 'perTypeOverrides'>,
+    payload: Pick<
+      NotificationPreferences,
+      'emailEnabled' | 'smsEnabled' | 'phone' | 'perTypeOverrides'
+    >,
   ): Promise<NotificationPreferences> {
     const result = await query(
       `UPDATE user_profiles


### PR DESCRIPTION
Closes #1491

## Problem Statement (The Bug)

The `updateNotificationPreferencesSchema` accepts `perTypeOverrides` and the response schema documents it, but the controller never forwarded it to the service, and the service hard-coded `perTypeOverrides: {}` in both read and write paths. Users could submit per-type overrides but they were silently dropped and the API always reported an empty object.

This is a silent data loss bug that cannot be fixed with a local patch because the schema/API contract promises `perTypeOverrides` persistence but the implementation never stores or retrieves it.

## Solution Comparison and Decision

**Option A: Store in user_profiles.metadata JSONB column**
- Requires manual JSON path queries and no schema enforcement
- Would mix concerns with other metadata

**Option B: Add dedicated per_type_overrides column to user_notification_preferences**
- Clean separation of notification-specific data
- Schema enforced at database level
- Consistent with existing digest_frequency column in same table

**Option C: Store in a new table**
- Over-engineered for a single JSONB field
- Adds unnecessary join complexity

**Chosen: Option B** - Adding a `per_type_overrides` JSONB column to `user_notification_preferences` is the cleanest approach. It keeps notification preferences together and uses proper schema enforcement.

## The Change (Code modifications)

1. **Migration**: Added `per_type_overrides` JSONB column to `user_notification_preferences` with default `{}`

2. **Service layer** (`notificationService.ts`):
   - `getNotificationPreferences`: Now LEFT JOINs `user_notification_preferences` to read the stored overrides
   - `updateNotificationPreferences`: Now accepts and persists `perTypeOverrides` via UPSERT into `user_notification_preferences`
   - Updated type signature to include `perTypeOverrides` in payload

3. **Controller layer** (`notificationController.ts`):
   - `updateNotificationPreferences`: Now forwards `parsed.perTypeOverrides` to the service

## Compatibility Note

No interface version modification needed. The schema already documented `perTypeOverrides` in both request and response - this change simply makes the implementation match the documented contract.

## Incidental Fixes

- The GET endpoint now returns stored overrides instead of empty object (matches documented API behavior)

## Testing

New test: `returns persisted perTypeOverrides on GET` - verifies that persisted per-type overrides are returned on GET.

Updated test: `writes valid preferences and returns updated payload` - now mocks the UPSERT query and verifies the PUT round-trips non-empty `perTypeOverrides`.

Test results: All 5 tests in notificationPreferences.test.ts pass.

```bash
PASS src/__tests__/notificationPreferences.test.ts
  notification preferences endpoints
    ✓ returns empty defaults when no profile row exists
    ✓ returns persisted perTypeOverrides on GET
    ✓ writes valid preferences and returns updated payload
    ✓ returns 400 when phone format is invalid
    ✓ returns 400 when sms is enabled without a phone number
```

Pre-existing type errors in other test files are unrelated to this change.