### PR TITLE
fix(loan_manager): cap how far a single extension can push the due date

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -524,6 +524,23 @@ impl LoanManager {
             .unwrap_or(Self::DEFAULT_DEFAULT_WINDOW_LEDGERS)
     }
 
+    /// Configured ceiling on a loan term, in ledgers.
+    ///
+    /// Falls back to `DEFAULT_TERM_LEDGERS` rather than `u32::MAX` when unset,
+    /// so the ceiling is meaningful on a deployment whose admin has not set
+    /// term limits — a `u32::MAX` fallback would leave the bound inert on
+    /// exactly the deployments least likely to be watching for abuse.
+    ///
+    /// This is the same value `get_max_term_ledgers` reports, so the limit an
+    /// admin reads back is the limit actually enforced.
+    fn max_term_ledgers(env: &Env) -> u32 {
+        Self::bump_instance_ttl(env);
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxTermLedgers)
+            .unwrap_or(Self::DEFAULT_TERM_LEDGERS)
+    }
+
     fn max_loan_amount(env: &Env) -> i128 {
         Self::bump_instance_ttl(env);
         env.storage()
@@ -2536,11 +2553,9 @@ impl LoanManager {
     }
 
     pub fn get_max_term_ledgers(env: Env) -> u32 {
-        Self::bump_instance_ttl(&env);
-        env.storage()
-            .instance()
-            .get(&DataKey::MaxTermLedgers)
-            .unwrap_or(Self::DEFAULT_TERM_LEDGERS)
+        // Delegates so the value read back here and the ceiling enforced by
+        // extend_loan are the same expression, not two copies that can drift.
+        Self::max_term_ledgers(&env)
     }
 
     pub fn propose_admin(env: Env, new_admin: Address) {
@@ -2684,6 +2699,20 @@ impl LoanManager {
             return Err(LoanError::InvalidTerm);
         }
 
+        // A single extension may not exceed the configured term ceiling.
+        //
+        // MAX_EXTENSIONS caps how *many* times a loan can be extended but said
+        // nothing about how *far*, so one call with a huge `extra_ledgers`
+        // could push `due_date` past any realistic horizon and defer default
+        // indefinitely — for a flat 1% fee charged once on remaining
+        // principal. Bounding each extension by the same ceiling that governs
+        // an original term means total extendable time is now bounded by
+        // MAX_EXTENSIONS * max_term rather than being unbounded.
+        let max_term = Self::max_term_ledgers(&env);
+        if extra_ledgers > max_term {
+            return Err(LoanError::InvalidExtension);
+        }
+
         let loan_key = DataKey::Loan(loan_id);
         let mut loan: Loan = env
             .storage()
@@ -2741,11 +2770,16 @@ impl LoanManager {
             token_client.transfer(&borrower, &lending_pool, &extension_fee);
         }
 
-        // Extend the due date
+        // Extend the due date.
+        //
+        // Returns a typed error rather than panicking: a panic here would trap
+        // the borrower's already-transferred extension fee in a reverted
+        // transaction with no diagnosable cause. The bound above makes
+        // overflow unreachable in practice, but the arithmetic stays checked.
         let new_due_date = loan
             .due_date
             .checked_add(extra_ledgers)
-            .expect("due date overflow");
+            .ok_or(LoanError::InvalidExtension)?;
         loan.due_date = new_due_date;
 
         // Increment extension count

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -4440,3 +4440,161 @@ fn test_liquidate_decreases_score_and_records_default() {
     assert_eq!(nft_client.get_default_count(&borrower), 1);
     assert!(nft_client.is_seized(&borrower));
 }
+
+// ── extend_loan term-ceiling tests ─────────────────────────────────────────
+//
+// MAX_EXTENSIONS caps how *many* extensions a loan gets; these cover the
+// missing half — how *far* a single extension may push the due date.
+
+/// Sets up an approved loan and returns its id, so the ceiling tests below
+/// state only what they are actually asserting.
+fn setup_extendable_loan(env: &Env) -> (LoanManagerClient<'static>, Address, u32) {
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _admin) = setup_test(env);
+    let borrower = Address::generate(env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &600,
+        &history_hash,
+        &String::from_str(env, "ipfs://QmTest"),
+        &create_test_commitment(env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(env, &token_id);
+    stellar_token.mint(&pool_client, &10_000);
+
+    let loan_id = manager.request_loan(&borrower, &1000, &17280);
+    manager.approve_loan(&loan_id);
+
+    (manager, borrower, loan_id)
+}
+
+#[test]
+fn test_extend_loan_rejects_extension_longer_than_max_term() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    let max_term = manager.get_max_term_ledgers();
+    let loan_before = manager.get_loan(&loan_id);
+
+    // One ledger past the ceiling is the whole exploit in miniature: without
+    // the bound this would be accepted for the same flat fee as any other
+    // extension.
+    let result = manager.try_extend_loan(&borrower, &loan_id, &(max_term + 1));
+    assert_eq!(result, Err(Ok(LoanError::InvalidExtension)));
+
+    // Rejected before any state change — due date and count are untouched.
+    let loan_after = manager.get_loan(&loan_id);
+    assert_eq!(loan_after.due_date, loan_before.due_date);
+    assert_eq!(loan_after.extension_count, 0);
+}
+
+#[test]
+fn test_extend_loan_accepts_extension_exactly_at_max_term() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    let max_term = manager.get_max_term_ledgers();
+    let original_due_date = manager.get_loan(&loan_id).due_date;
+
+    // The bound is inclusive: exactly max_term is a legitimate extension.
+    manager.extend_loan(&borrower, &loan_id, &max_term);
+
+    let loan_after = manager.get_loan(&loan_id);
+    assert_eq!(loan_after.due_date, original_due_date + max_term);
+    assert_eq!(loan_after.extension_count, 1);
+}
+
+#[test]
+fn test_extend_loan_rejects_far_future_extension() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    // The reported attack: push the due date so far out that the default
+    // window can never be reached, for one 1% fee.
+    let result = manager.try_extend_loan(&borrower, &loan_id, &u32::MAX);
+    assert_eq!(result, Err(Ok(LoanError::InvalidExtension)));
+
+    // And the near-overflow case, which previously reached the checked_add
+    // and panicked rather than returning an error.
+    let result = manager.try_extend_loan(&borrower, &loan_id, &(u32::MAX - 1));
+    assert_eq!(result, Err(Ok(LoanError::InvalidExtension)));
+
+    assert_eq!(manager.get_loan(&loan_id).extension_count, 0);
+}
+
+#[test]
+fn test_extend_loan_ceiling_follows_configured_max_term() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    // The bound is derived from configuration, not a constant: lowering the
+    // admin's ceiling immediately narrows what an extension may request.
+    manager.set_max_term_ledgers(&5_000);
+    assert_eq!(manager.get_max_term_ledgers(), 5_000);
+
+    let result = manager.try_extend_loan(&borrower, &loan_id, &5_001);
+    assert_eq!(result, Err(Ok(LoanError::InvalidExtension)));
+
+    manager.extend_loan(&borrower, &loan_id, &5_000);
+    assert_eq!(manager.get_loan(&loan_id).extension_count, 1);
+}
+
+#[test]
+fn test_extend_loan_raising_max_term_widens_the_ceiling() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    let default_ceiling = manager.get_max_term_ledgers();
+    let beyond = default_ceiling + 1_000;
+
+    // Rejected at the default ceiling...
+    let result = manager.try_extend_loan(&borrower, &loan_id, &beyond);
+    assert_eq!(result, Err(Ok(LoanError::InvalidExtension)));
+
+    // ...and accepted once an admin raises it, so the check tracks policy
+    // rather than hard-coding a horizon.
+    manager.set_max_term_ledgers(&beyond);
+    manager.extend_loan(&borrower, &loan_id, &beyond);
+
+    assert_eq!(manager.get_loan(&loan_id).extension_count, 1);
+}
+
+#[test]
+fn test_extend_loan_total_extension_is_bounded_by_count_and_ceiling() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    let max_term = manager.get_max_term_ledgers();
+    let original_due_date = manager.get_loan(&loan_id).due_date;
+
+    // Three maximal extensions — the most the contract now permits.
+    manager.extend_loan(&borrower, &loan_id, &max_term);
+    manager.extend_loan(&borrower, &loan_id, &max_term);
+    manager.extend_loan(&borrower, &loan_id, &max_term);
+
+    // A fourth is refused by the count cap, which this change leaves intact.
+    let result = manager.try_extend_loan(&borrower, &loan_id, &1_000);
+    assert_eq!(result, Err(Ok(LoanError::InvalidConfiguration)));
+
+    // Total deferral is now bounded by MAX_EXTENSIONS * max_term, where it
+    // used to be unbounded.
+    let loan_after = manager.get_loan(&loan_id);
+    assert_eq!(loan_after.extension_count, 3);
+    assert_eq!(loan_after.due_date, original_due_date + max_term * 3);
+}
+
+#[test]
+fn test_extend_loan_still_rejects_zero_after_ceiling_added() {
+    let env = Env::default();
+    let (manager, borrower, loan_id) = setup_extendable_loan(&env);
+
+    // The pre-existing non-zero check keeps its own error code — the new
+    // ceiling did not absorb it.
+    let result = manager.try_extend_loan(&borrower, &loan_id, &0);
+    assert_eq!(result, Err(Ok(LoanError::InvalidTerm)));
+}


### PR DESCRIPTION
extend_loan capped how *many* times a loan could be extended (MAX_EXTENSIONS = 3) but said nothing about how *far*. extra_ledgers was only checked for non-zero and for u32 overflow, so one call with a huge value pushed due_date past any realistic horizon and deferred default indefinitely — for a flat 1% fee charged once on remaining principal. Total extendable time was unbounded.

A single extension may now be at most the configured term ceiling, rejected with LoanError::InvalidExtension. Total deferral is consequently bounded by MAX_EXTENSIONS * max_term instead of being open-ended.

The bound is derived from configuration, not a constant. New internal helper max_term_ledgers() reads DataKey::MaxTermLedgers, and get_max_term_ledgers() now delegates to it so the ceiling an admin reads back is the same expression as the one enforced, rather than two copies that can drift.

The helper falls back to DEFAULT_TERM_LEDGERS when the key is unset, not to u32::MAX. refinance uses a u32::MAX fallback for the same key; copying that here would have left the new bound inert on any deployment whose admin had not configured term limits — precisely the deployments least likely to notice the abuse. refinance's own fallback is left alone as out of scope.

Also converts the due-date checked_add from .expect() to a typed error. The issue asked for overflow-safe math with no unwrap/panic, and a panic there would revert the transaction after the borrower's extension fee had already transferred, with no diagnosable cause. The new ceiling makes overflow unreachable in practice; the arithmetic stays checked regardless.

Preserved unchanged: the MAX_EXTENSIONS count cap, the non-zero check and its distinct InvalidTerm code, and the 1% fee formula (out of scope).

No lower bound was added. It is listed as optional, and rejecting dust extensions would refuse legitimate short ones while preventing no abuse — a 1-ledger extension costs the borrower a full fee and burns one of three slots, so it only ever harms them.

7 new tests: over-long rejected with no state change, exactly-at-ceiling accepted, u32::MAX and u32::MAX-1 rejected (the latter previously reached checked_add), the ceiling tracking set_max_term_ledgers in both directions, three maximal extensions then the count cap refusing a fourth, and the non-zero check still returning InvalidTerm.

137 tests pass; cargo fmt --check and clippy clean (the one clippy warning is pre-existing in events.rs, untouched here).

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.

closes #1126 
