### PR TITLE
test(contracts): regression tests for liquidate TotalOutstanding accounting (#1084)

### DIFF
--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -59,6 +59,7 @@ pub fn loan_requested(env: &Env, loan_id: u32, borrower: Address, amount: i128) 
 /// A single call to `approve_loan` in `lib.rs` emits **two** events:
 /// 1. `LoanApproved` (emitted here with loan terms and interest rate)
 /// 2. `LoanApprv` (emitted by [`loan_approved_by_admin`] with admin and borrower address)
+///
 /// Indexers should de-duplicate or reconcile both events.
 pub fn loan_approved(
     env: &Env,

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -4170,6 +4170,132 @@ fn test_get_total_outstanding_decreases_on_check_default() {
 }
 
 #[test]
+fn test_get_total_outstanding_returns_to_baseline_after_liquidation() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower,
+        &650,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTest"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &20_000);
+    stellar_token.mint(&borrower, &20_000);
+
+    manager.set_liquidation_threshold(&14_500);
+
+    let baseline = manager.get_total_outstanding(&token_id);
+    assert_eq!(baseline, 0);
+
+    let loan_id = manager.request_loan(&borrower, &1_000, &17_280);
+    manager.approve_loan(&loan_id);
+    assert_eq!(manager.get_total_outstanding(&token_id), baseline + 1_000);
+
+    manager.deposit_collateral(&loan_id, &1_400);
+    manager.liquidate(&liquidator, &loan_id);
+
+    assert_eq!(
+        manager.get_total_outstanding(&token_id),
+        baseline,
+        "liquidation must return TotalOutstanding exactly to its pre-loan baseline"
+    );
+}
+
+#[test]
+fn test_repeated_liquidations_do_not_shrink_available_liquidity() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (manager, nft_client, pool_client, token_id, _token_admin) = setup_test(&env);
+    let borrower_a = Address::generate(&env);
+    let borrower_b = Address::generate(&env);
+    let borrower_c = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let history_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    nft_client.mint(
+        &borrower_a,
+        &650,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTestA"),
+        &create_test_commitment(&env, 1),
+        &None,
+    );
+    nft_client.mint(
+        &borrower_b,
+        &650,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTestB"),
+        &create_test_commitment(&env, 2),
+        &None,
+    );
+    nft_client.mint(
+        &borrower_c,
+        &650,
+        &history_hash,
+        &String::from_str(&env, "ipfs://QmTestC"),
+        &create_test_commitment(&env, 3),
+        &None,
+    );
+
+    let stellar_token = StellarAssetClient::new(&env, &token_id);
+    stellar_token.mint(&pool_client, &20_000);
+    stellar_token.mint(&borrower_a, &20_000);
+    stellar_token.mint(&borrower_b, &20_000);
+    stellar_token.mint(&borrower_c, &20_000);
+
+    manager.set_liquidation_threshold(&14_500);
+
+    let baseline = manager.get_total_outstanding(&token_id);
+    assert_eq!(baseline, 0);
+
+    // Approve + liquidate loan A: outstanding must return to baseline (not stay
+    // inflated), otherwise liquidity is permanently starved.
+    let loan_a = manager.request_loan(&borrower_a, &1_000, &17_280);
+    manager.approve_loan(&loan_a);
+    manager.deposit_collateral(&loan_a, &1_400);
+    manager.liquidate(&liquidator, &loan_a);
+    assert_eq!(
+        manager.get_total_outstanding(&token_id),
+        baseline,
+        "TotalOutstanding must return to baseline after the first liquidation"
+    );
+
+    // Approve + liquidate loan B: the bug compounded across multiple loans, so
+    // verify the second liquidation also returns outstanding to baseline.
+    let loan_b = manager.request_loan(&borrower_b, &1_000, &17_280);
+    manager.approve_loan(&loan_b);
+    manager.deposit_collateral(&loan_b, &1_400);
+    manager.liquidate(&liquidator, &loan_b);
+    assert_eq!(
+        manager.get_total_outstanding(&token_id),
+        baseline,
+        "repeated liquidations must not compound TotalOutstanding inflation"
+    );
+
+    // Because outstanding is genuinely back to baseline, available_liquidity is
+    // the full pool balance: a subsequent approve_loan must still succeed. (A
+    // and B are marked seized by their liquidations, so use a fresh borrower
+    // for loan C.)
+    let loan_c = manager.request_loan(&borrower_c, &1_000, &17_280);
+    assert_eq!(
+        manager.try_approve_loan(&loan_c),
+        Ok(Ok(())),
+        "a later approve_loan must not see starved available_liquidity"
+    );
+}
+
+#[test]
 fn test_is_liquidatable_healthy_loan() {
     let env = Env::default();
     env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
Closes #1084

## Summary

This PR closes #1084 by adding the regression tests required by the issue's
"done when" checklist, verifying that `liquidate()` correctly retires
`TotalOutstanding` so it never permanently inflates and starves new loans of
liquidity.

**Important context:** the core code fix is **already merged** into `main`
(line 1714 of `contracts/loan_manager/src/lib.rs`):

```rust
Self::adjust_total_outstanding(&env, &token, -loan.amount);
```

was added inside `liquidate()` (merged via #1460, commit `b225859`),
mirroring the `+loan.amount` recorded at `approve_loan` time. The only unmet
"done when" items were the regression tests, which this PR adds.

## Changed files

- `contracts/loan_manager/src/test.rs` — adds two new regression tests:
  - `test_get_total_outstanding_returns_to_baseline_after_liquidation`
  - `test_repeated_liquidations_do_not_shrink_available_liquidity`
- `contracts/loan_manager/src/events.rs` — 1-line doc-comment fix for a
  pre-existing, unrelated `clippy::doc-lazy-continuation` warning that was
  failing the `contracts` CI job on `main` (would otherwise block this PR's
  check). No behavior change.

## "done when" checklist

1. **`liquidate()` decrements `TotalOutstanding` exactly once** — satisfied by
   the already-merged code: `adjust_total_outstanding(&env, &token, -loan.amount)`
   is called in `liquidate()` alongside the other terminal state mutations
   (status → `Liquidated`, `collateral_amount = 0`), before the storage commit
   and external transfers, in the same CEI transaction. `liquidate()` has a
   single execution path to `Liquidated`, so there is no double-decrement (a
   double decrement would underflow-panic in `adjust_total_outstanding`) and no
   missed decrement. The new repeated-liquidation test asserts
   `get_total_outstanding()` equals the baseline after each of two liquidations,
   catching either a missing or a double decrement.
2. **Overflow/underflow-safe** — `adjust_total_outstanding` uses
   `checked_add(delta)` and panics on negative `updated` (underflow), matching
   `repay`, `check_default`, and `check_defaults` exactly. No `unwrap` on the
   adjustment and no changes to caller-side arithmetic were needed or added.
3. **Does not touch LendingPool's internal accounting** — the change is
   confined to `loan_manager`'s own `TotalOutstanding` instance storage via
   `liquidate()`. `LendingPool`'s `pool_balance`/accounting is untouched. (Note:
   the already-merged fix likewise only touches loan_manager storage.)
4. **Test: liquidation returns TotalOutstanding to pre-loan baseline** — new
   `test_get_total_outstanding_returns_to_baseline_after_liquidation`: approves
   a loan, asserts outstanding rose by the loan amount, liquidates, and asserts
   `get_total_outstanding()` returns **exactly** to its pre-loan baseline (0),
   not merely "decreased."
5. **Test: repeated liquidations don't shrink available liquidity** — new
   `test_repeated_liquidations_do_not_shrink_available_liquidity`: approve →
   liquidate for loan A, then approve → liquidate for loan B, asserting
   `get_total_outstanding()` returns to baseline after each (proving the
   compounding bug is fixed, not just a single isolated liquidation), and a
   subsequent `approve_loan` still succeeds against non-starved
   `available_liquidity` (which is `pool_balance - total_outstanding` in
   `approve_loan`).
6. **Test: full lifecycle (repay, default, liquidate) returns to baseline** —
   the existing `test_get_total_outstanding_tracks_approve_and_repay` (repay → 0)
   and `test_get_total_outstanding_decreases_on_check_default` (default → 0)
   cover the repay and default legs; the new liquidate test above covers the
   third leg. Together all three terminal paths are verified to restore
   `TotalOutstanding` to baseline, matching the issue's cross-path invariant.

These tests genuinely catch the original bug: if the `liquidate()` decrement is
removed, the outstanding-after-liquidation assertions (`assert_eq!(
get_total_outstanding, baseline)`) fail because `TotalOutstanding` stays
inflated by the full loan amount (1000 / 2000 in the two tests).

## Local verification

Environment note: this is a Windows host. The contract test harness links the
soroban contract cdylibs as Windows DLLs, and those cdylibs exceed the Windows
PE export table limit (max 65,535 symbols), so `cargo test` cannot link/run the
contract unit tests locally — a hard, pre-existing, environment-specific
limitation. CI runs the same suite on Linux (`ubuntu-24.04`) where it passes.
I validated the change with the equivalent compile/check/lint commands that CI
runs (CI's exact commands per `.github/workflows/ci.yml`):

```
cargo fmt --all -- --check          # exit 0
cargo check --tests -p loan_manager # exit 0 — new tests type-check
cargo clippy --tests -p loan_manager -- -D warnings  # exit 0 — zero warnings
```

`cargo clippy` before the events.rs fix surfaced the pre-existing
`clippy::doc-lazy-continuation` warning at `events.rs:62`; after the 1-line fix
clippy passes with zero warnings. `cargo test` will be exercised by CI on Linux.
