### PR TITLE
fix(backend): add in-flight guard to webhook retry processor (Closes #1065)

### DIFF
--- a/backend/src/services/__tests__/webhookRetryProcessor.test.ts
+++ b/backend/src/services/__tests__/webhookRetryProcessor.test.ts
@@ -39,7 +39,8 @@ jest.unstable_mockModule('../jobMetricsService.js', () => ({
 }));
 
 const { WebhookService, getRetryDelayMs } = await import('../webhookService.js');
-const { startWebhookRetryProcessor, stopWebhookRetryProcessor } = await import('../webhookRetryProcessor.js');
+const { startWebhookRetryProcessor, stopWebhookRetryProcessor } =
+  await import('../webhookRetryProcessor.js');
 
 const MAX_RETRY_ATTEMPTS = 4;
 
@@ -325,9 +326,9 @@ describe('WebhookRetryProcessor', () => {
       mockQuery.mockImplementation(slowQuery);
 
       // Mock refreshWebhookRetryQueueDepth to succeed immediately
-      const { refreshWebhookRetryQueueDepth } = (await import(
-        '../../middleware/metrics.js',
-      )) as { refreshWebhookRetryQueueDepth: jest.Mock };
+      const { refreshWebhookRetryQueueDepth } = (await import('../../middleware/metrics.js')) as {
+        refreshWebhookRetryQueueDepth: jest.Mock;
+      };
       refreshWebhookRetryQueueDepth.mockResolvedValue(undefined);
 
       startWebhookRetryProcessor();
@@ -376,9 +377,9 @@ describe('WebhookRetryProcessor', () => {
         return { rows: [] };
       });
 
-      const { refreshWebhookRetryQueueDepth } = (await import(
-        '../../middleware/metrics.js',
-      )) as { refreshWebhookRetryQueueDepth: jest.Mock };
+      const { refreshWebhookRetryQueueDepth } = (await import('../../middleware/metrics.js')) as {
+        refreshWebhookRetryQueueDepth: jest.Mock;
+      };
       refreshWebhookRetryQueueDepth.mockResolvedValue(undefined);
 
       startWebhookRetryProcessor();

--- a/backend/src/services/__tests__/webhookRetryProcessor.test.ts
+++ b/backend/src/services/__tests__/webhookRetryProcessor.test.ts
@@ -20,6 +20,17 @@ jest.unstable_mockModule('../../middleware/metrics.js', () => ({
   refreshWebhookRetryQueueDepth: jest.fn(),
 }));
 
+jest.unstable_mockModule('../../utils/logger.js', () => ({
+  default: {
+    withContext: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
 jest.unstable_mockModule('../jobMetricsService.js', () => ({
   jobMetricsService: {
     recordSuccess: jest.fn(),
@@ -28,6 +39,7 @@ jest.unstable_mockModule('../jobMetricsService.js', () => ({
 }));
 
 const { WebhookService, getRetryDelayMs } = await import('../webhookService.js');
+const { startWebhookRetryProcessor, stopWebhookRetryProcessor } = await import('../webhookRetryProcessor.js');
 
 const MAX_RETRY_ATTEMPTS = 4;
 
@@ -284,6 +296,108 @@ describe('WebhookRetryProcessor', () => {
         (call[0] as string).includes('UPDATE webhook_deliveries'),
       );
       expect(updateCalls).toHaveLength(2);
+    });
+  });
+
+  describe('overlap guard (in-flight)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      stopWebhookRetryProcessor();
+      jest.useRealTimers();
+    });
+
+    it('skips a tick when the previous run is still in-flight', async () => {
+      // First call resolves slowly
+      const firstCallResolvers: Array<() => void> = [];
+      const slowQuery: jest.MockedFunction<
+        (text: string, params?: unknown[]) => Promise<MockQueryResult>
+      > = jest.fn(async () => {
+        return new Promise<MockQueryResult>((resolve) => {
+          firstCallResolvers.push(() => resolve({ rows: [] }));
+        });
+      });
+
+      // Replace the mocked query used by processRetries
+      // The mock is hoisted, so we override the shared mockQuery's implementation
+      mockQuery.mockImplementation(slowQuery);
+
+      // Mock refreshWebhookRetryQueueDepth to succeed immediately
+      const { refreshWebhookRetryQueueDepth } = (await import(
+        '../../middleware/metrics.js',
+      )) as { refreshWebhookRetryQueueDepth: jest.Mock };
+      refreshWebhookRetryQueueDepth.mockResolvedValue(undefined);
+
+      startWebhookRetryProcessor();
+
+      // Trigger first tick — starts processRetries which is awaiting
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      // processRetries is now in-flight; trigger second tick
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      // processRetries should have been called exactly once
+      expect(slowQuery).toHaveBeenCalledTimes(1);
+
+      // Resolve the in-flight call
+      firstCallResolvers[0]!();
+      // Flush any pending microtasks
+      await jest.advanceTimersByTimeAsync(0);
+
+      // Now a subsequent tick should be able to run
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValue({ rows: [] });
+      await jest.advanceTimersByTimeAsync(10_000);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send duplicate deliveries when two ticks overlap', async () => {
+      const row = deliveryRow({ attempt_count: 1 });
+      const fetchMock = jest.fn(async () => ({
+        ok: true,
+        status: 200,
+      })) as unknown as jest.MockedFunction<typeof fetch>;
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      let resolveFirst: (() => void) | null = null;
+      let callCount = 0;
+
+      mockQuery.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // First SELECT returns a row but hangs before processing completes
+          return new Promise<MockQueryResult>((resolve) => {
+            resolveFirst = () => resolve({ rows: [row] });
+          });
+        }
+        // Subsequent calls (second tick would be blocked, but if it weren't...)
+        return { rows: [] };
+      });
+
+      const { refreshWebhookRetryQueueDepth } = (await import(
+        '../../middleware/metrics.js',
+      )) as { refreshWebhookRetryQueueDepth: jest.Mock };
+      refreshWebhookRetryQueueDepth.mockResolvedValue(undefined);
+
+      startWebhookRetryProcessor();
+
+      // Trigger first tick
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      // Trigger second tick — should be blocked by inFlight
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      // fetch should NOT have been called yet (first tick is still pending)
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      // Resolve the first tick
+      resolveFirst!();
+      await jest.advanceTimersByTimeAsync(0);
+
+      // Now fetch was called exactly once for the delivery
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/services/webhookRetryProcessor.ts
+++ b/backend/src/services/webhookRetryProcessor.ts
@@ -4,6 +4,7 @@ import { WebhookService } from './webhookService.js';
 import { jobMetricsService } from './jobMetricsService.js';
 
 let retryProcessorInterval: NodeJS.Timeout | null = null;
+let inFlight = false;
 
 /**
  * Starts the webhook retry processor.
@@ -29,22 +30,29 @@ export function startWebhookRetryProcessor(): void {
   logger.withContext().info('Starting webhook retry processor');
 
   // Run retry processor every 10 seconds
-  retryProcessorInterval = setInterval(async () => {
-    const startTime = Date.now();
-    const jobName = 'webhookRetryProcessor';
+  retryProcessorInterval = setInterval(() => {
+    void (async () => {
+      if (inFlight) return;
+      inFlight = true;
 
-    try {
-      await refreshWebhookRetryQueueDepth();
-      await WebhookService.processRetries();
-      await refreshWebhookRetryQueueDepth();
+      const startTime = Date.now();
+      const jobName = 'webhookRetryProcessor';
 
-      const durationMs = Date.now() - startTime;
-      jobMetricsService.recordSuccess(jobName, durationMs);
-    } catch (error) {
-      const durationMs = Date.now() - startTime;
-      jobMetricsService.recordFailure(jobName, error as Error | string, durationMs);
-      logger.withContext().error('Error in webhook retry processor interval', { error });
-    }
+      try {
+        await refreshWebhookRetryQueueDepth();
+        await WebhookService.processRetries();
+        await refreshWebhookRetryQueueDepth();
+
+        const durationMs = Date.now() - startTime;
+        jobMetricsService.recordSuccess(jobName, durationMs);
+      } catch (error) {
+        const durationMs = Date.now() - startTime;
+        jobMetricsService.recordFailure(jobName, error as Error | string, durationMs);
+        logger.withContext().error('Error in webhook retry processor interval', { error });
+      } finally {
+        inFlight = false;
+      }
+    })();
   }, 10 * 1000);
 }
 


### PR DESCRIPTION
## Summary

Fixes duplicate concurrent webhook deliveries caused by overlapping retry processor ticks.

## Problem

The webhook retry processor (`webhookRetryProcessor`) fires `WebhookService.processRetries` on a 10-second `setInterval` with no in-flight guard. Each `processRetries` call selects up to 100 due deliveries and processes them one at a time — each an HTTP POST that can run up to `WEBHOOK_REQUEST_TIMEOUT_MS` (30s default). When a slow batch takes longer than 10s, the next tick fires and re-selects the same rows (since `next_retry_at` hasn't been updated yet), causing duplicate concurrent deliveries to subscribers. This breaks any non-idempotent consumer and piles on load.

The SQL query already uses `FOR UPDATE OF wd SKIP LOCKED` for atomic row claiming, but without an application-level in-flight guard, overlapping ticks still start new batch runs while the previous one is mid-flight.

## Fix

**`backend/src/services/webhookRetryProcessor.ts`** — Added a boolean `inFlight` flag that mirrors the existing `DefaultChecker` pattern ([`defaultChecker.ts`](backend/src/services/defaultChecker.ts#L649-L688)):

- Set `inFlight = true` at the start of each tick's async work
- Check `if (inFlight) return;` before entering the critical section
- Clear `inFlight = false` in a `finally` block so it's always released

This guarantees that at most one `processRetries` invocation runs at a time, preventing overlapping batches from re-sending in-progress deliveries.

**`backend/src/services/__tests__/webhookRetryProcessor.test.ts`** — Added two new tests:

1. **`skips a tick when the previous run is still in-flight`** — Fires two ticks while the first is pending; asserts `processRetries` is called exactly once, then asserts a subsequent tick works after the first completes.
2. **`does not send duplicate deliveries when two ticks overlap`** — Same pattern but verifies `fetch` is called exactly once for a delivery, proving no duplicate HTTP POSTs are sent.

## What's in scope / out of scope

- ✅ In-flight guard (application-level overlap protection)
- ✅ Overlapping invocation test
- ✅ Atomic row claiming via `FOR UPDATE SKIP LOCKED` (already present)
- ❌ HMAC signing changes (out of scope per issue)
- ❌ Payload size limit changes (out of scope per issue)

## Verification

- `npm test` — 11/11 tests pass (including 2 new overlap guard tests)
- `npm run typecheck` — clean
- `npm run lint` — clean

Closes #1065