### PR TITLE
docs(frontend): document service worker update flow

### DIFF
--- a/docs/FOLLOWUP-sw-update-prompt.md
+++ b/docs/FOLLOWUP-sw-update-prompt.md
@@ -1,0 +1,57 @@
+# Follow-Up: User-Facing Service Worker Update Prompt
+
+**Created:** 2026-09-01
+**Related Issue:** #1511
+**Status:** Open — Not yet implemented
+
+## Problem
+
+After a production deployment, users who have an open tab do not automatically
+receive the updated application. The service worker (`frontend/src/app/sw.ts`)
+installs and activates immediately thanks to `skipWaiting` and `clientsClaim`,
+but **there is no UI to inform the user that a new version is available** and
+prompt them to refresh.
+
+This means:
+
+- A tab that has been open since before the deploy continues serving the old
+  precached code.
+- The user has no visual indication that they are on a stale version.
+- Only a manual page refresh or navigating to a new route picks up the update.
+
+## Proposed Solution (not yet implemented)
+
+Add a lightweight "update available" banner or toast that:
+
+1. Listens for the `controllerchange` event on the `navigator.serviceWorker`
+   controller (fired when a new SW activates and claims the page).
+2. Shows a non-intrusive notification (e.g., a toast via Sonner) saying
+   "A new version is available — refresh to update."
+3. Optionally offers a "Refresh now" button that calls `window.location.reload()`.
+
+### Implementation Notes
+
+- The `controllerchange` event is the most reliable signal because it fires
+  exactly when a new SW takes over the page.
+- Serwist also provides a `useServiceWorkerUpdate` hook (from
+  `@serwist/react`) that can be used in React components to detect pending
+  or waiting updates.
+- The banner should be dismissible and should not block interaction with the
+  page.
+
+## Files to Modify
+
+- `frontend/src/app/components/global_ui/` — Add an `UpdateBanner` component
+- `frontend/src/app/[locale]/layout.tsx` — Mount the banner in the app shell
+- `frontend/src/app/sw.ts` — Potentially add a `postMessage` to notify clients
+
+## Acceptance Criteria
+
+- [ ] User sees a non-blocking notification when a new SW version activates
+- [ ] Notification offers a "Refresh now" action
+- [ ] Notification can be dismissed without refreshing
+- [ ] No regression in offline behavior or cache performance
+
+---
+
+> This follow-up was tracked as part of Issue #1511 documentation.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -321,6 +321,21 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 ```
 
+## Service Worker Update Strategy
+
+This application uses [Serwist](https://serwist-docs.vercel.app/) (PWA) to pre-cache assets and serve them offline. The service worker configuration lives in `src/app/sw.ts`.
+
+### How updates reach users after a deployment
+
+1. **New precache manifest** — Every production build generates a fresh `__SW_MANIFEST` with content-hashed URLs. When the browser fetches the updated HTML, it discovers the new manifest and detects that the cached assets no longer match.
+2. **Immediate activation** — `skipWaiting: true` and `clientsClaim: true` ensure the new service worker activates and takes over all open tabs without requiring the user to close the browser.
+3. **Next navigation is fresh** — After the new SW activates, the next page navigation or fetch request goes through the updated precache, so users receive the latest code.
+4. **Runtime cache bypass** — API (`/api/`), SSE (`/sse/`), and Next.js internal (`/_next/`) requests are always fetched from the network (`bypassCdn`) to prevent stale data.
+
+### Known limitation
+
+There is currently **no user-facing "update available" prompt**. Users only receive new code when they refresh the page or navigate to a new route. Tabs that have been open for a long time will continue serving the old cached version until the user refreshes. See `docs/FOLLOWUP-sw-update-prompt.md` for tracking this gap.
+
 ## Troubleshooting
 
 ```bash

--- a/frontend/src/app/sw.ts
+++ b/frontend/src/app/sw.ts
@@ -6,12 +6,87 @@ declare const self: WorkerGlobalScope & {
   __SW_MANIFEST: PrecacheEntry[];
 };
 
+/**
+ * Cache Invalidation & Update Strategy
+ * =====================================
+ *
+ * This service worker uses Serwist's precaching model to ensure users receive
+ * updated assets after a new deployment. Here is how the cache invalidation
+ * and update flow works end-to-end:
+ *
+ * 1. PRECACHE MANIFEST
+ * --------------------
+ * `self.__SW_MANIFEST` is auto-generated at build time by Serwist/Next.js.
+ * Every file in the manifest is hashed (content-addressed URLs), so a new
+ * build produces new URLs. When the browser encounters a new manifest entry
+ * that doesn't exist in the current cache, it downloads the fresh asset.
+ *
+ * 2. UPDATES AND ACTIVATION
+ * -------------------------
+ * - `skipWaiting: true` — the new service worker activates immediately on
+ *   installation, without waiting for existing tabs to close. This ensures
+ *   the latest precache manifest takes effect as soon as possible.
+ * - `clientsClaim: true` — once activated, the new service worker takes
+ *   control of all open client pages right away, so subsequent navigations
+ *   and fetches go through the updated worker.
+ *
+ * Together these two flags mean: after a user refreshes or revisits the page,
+ * the browser installs the new SW, it activates immediately, claims all tabs,
+ * and the next navigation or fetch will use fresh cached assets.
+ *
+ * 3. RUNTIME CACHING (non-precached requests)
+ * -------------------------------------------
+ * `defaultCache` from `@serwist/next/worker` applies network-first or
+ * cache-first strategies to runtime requests (fonts, images, API calls, etc.)
+ * depending on the request type. These caches are independent of the
+ * precache; they are overwritten when a new SW version processes the same
+ * request because the precache entries (with hashed URLs) take priority.
+ *
+ * 4. CDN BYPASS
+ * ------------
+ * The `bypassCdn` predicate prevents Serwist from serving cached API, SSE,
+ * and Next.js internal (`/_next/`) responses from cache when the CDN is
+ * in the way. These requests always go to the network so that stale data
+ * is never served.
+ *
+ * 5. WHAT IS CURRENTLY MISSING
+ * ----------------------------
+ * There is no user-facing "update available" prompt or notification. The
+ * user only gets the new version on their next page refresh/navigation. If
+ * a tab has been open for a long time, it will keep serving the old
+ * precached assets until the user refreshes or the browser recycles the tab.
+ * See docs/FOLLOWUP-sw-update-prompt.md for tracking this gap.
+ */
+
 const serwist = new Serwist({
+  // Precache entries are generated at build time by Serwist + Next.js.
+  // Each entry has a content-hashed URL, so a new build naturally
+  // produces a different manifest and invalidates old cache entries.
   precacheEntries: self.__SW_MANIFEST,
+
+  // Activate the new service worker immediately without waiting for
+  // existing tabs to close. This ensures the updated precache manifest
+  // is live as soon as the new SW installs.
   skipWaiting: true,
+
+  // Once activated, claim all open client pages so they begin using
+  // the new service worker right away — no "refresh required" delay
+  // for navigation requests.
   clientsClaim: true,
+
+  // Enable navigation preload so that navigation requests hit the network
+  // immediately instead of waiting for the SW to spin up; the response is
+  // used if the network is fast, otherwise the cached version is served.
   navigationPreload: true,
+
+  // Runtime caching rules for requests not in the precache manifest.
+  // Default strategies (network-first for pages, cache-first for static
+  // assets, etc.) are provided by @serwist/next/worker.
   runtimeCaching: defaultCache,
+
+  // Prevent Serwist from serving stale cached responses for API, SSE,
+  // and Next.js internal requests. These should always hit the network
+  // to avoid returning outdated data.
   bypassCdn: ({ request }: { request: Request }) => {
     if (
       request.url.includes("/api/") ||
@@ -26,4 +101,6 @@ const serwist = new Serwist({
   bypassCdn: (context: { request: Request }) => boolean;
 });
 
+// Register all event listeners (install, activate, fetch, message, etc.)
+// that Serwist needs to manage the service worker lifecycle.
 serwist.addEventListeners();


### PR DESCRIPTION
## Summary

Closes #1511

This PR documents the service worker cache invalidation and update strategy in the frontend.

### Changes

- **`frontend/src/app/sw.ts`** — Added comprehensive inline comments explaining:
  - How the precache manifest works with content-hashed URLs
  - The `skipWaiting` and `clientsClaim` behavior for immediate activation
  - Runtime caching and CDN bypass rules
  - The current lack of a user-facing update prompt

- **`frontend/README.md`** — Added a "Service Worker Update Strategy" section that details how users receive updated code after a deployment.

- **`docs/FOLLOWUP-sw-update-prompt.md`** — Created a follow-up tracking note for the missing user-facing "update available" prompt UI, with proposed implementation details.

### Verification

- Ran `npx prettier --check` on all modified files — all pass.
- No functional code changes; documentation only.