### PR TITLE
refactor(backend): remove dead updateUserScore and unreachable throw

### DIFF
--- a/backend/src/services/eventIndexer.ts
+++ b/backend/src/services/eventIndexer.ts
@@ -12,7 +12,6 @@ import { eventStreamService } from './eventStreamService.js';
 import { notificationService, type NotificationType } from './notificationService.js';
 import { sorobanService } from './sorobanService.js';
 import { updateUserScoresBulk } from './scoresService.js';
-import { AppError } from '../errors/AppError.js';
 import { recordIndexerLedgers } from '../middleware/metrics.js';
 import { setPauseState } from '../middleware/pauseGuard.js';
 import { fromStroops } from '../money/decimal.js';
@@ -454,9 +453,6 @@ export class EventIndexer {
           fetchedEvents: 0,
           insertedEvents: 0,
         };
-        throw AppError.badRequest(
-          `Invalid ledger range: endLedger (${endLedger}) cannot be less than startLedger (${startLedger})`,
-        );
       }
 
       try {
@@ -1023,27 +1019,6 @@ export class EventIndexer {
       ...(borrowerRefund !== undefined ? { borrowerRefund } : {}),
     };
   }
-
-  /* private async _updateUserScore(userId: string, delta: number): Promise<void> {
-    if (!userId) return;
-    try {
-      await query(
-        `INSERT INTO scores (borrower, score)
-         VALUES ($1, $2)
-         ON CONFLICT (borrower)
-         DO UPDATE SET
-           score = LEAST(850, GREATEST(300, scores.score + $3)),
-           updated_at = CURRENT_TIMESTAMP`,
-        [userId, 500 + delta, delta],
-      );
-      logger.withContext().info('Updated user score from indexed event', {
-        userId,
-        delta,
-      });
-    } catch (error) {
-      logger.withContext().error('Failed to update user score', { userId, error });
-    }
-  } */
 
   private async triggerNotification(event: ContractEvent): Promise<void> {
     if (!event.address) return;


### PR DESCRIPTION
## Summary

Closes #1070

This PR removes dead code from the backend event indexer (`backend/src/services/eventIndexer.ts`).

### Changes

- **Removed the commented-out `_updateUserScore` private method** — This method was unused dead code that was superseded by the batch `updateUserScoresBulk` path. It had been commented out entirely.

- **Removed the unreachable `throw AppError.badRequest(...)`** — In `processChunk`, there was a `throw` statement immediately following an early `return` block when `endLedger < startLedger`. Since the `return` always executes first, the `throw` was never reachable.

- **Removed the unused `AppError` import** — After removing the unreachable throw, the `AppError` import was no longer referenced anywhere in the file.

### What was NOT changed

- The `endLedger < startLedger` validation check is preserved exactly as before and still rejects invalid intervals.
- No active score-update loops, ledger-range validations, or database semantics were modified.

### Verification

- **TypeScript**: `npm run typecheck` passes (`tsc -p tsconfig.build.json --noEmit`)
- **Lint**: `npm run lint` passes (0 errors, only pre-existing warnings)
- **Tests**: All eventIndexer-related test suites pass:
  - `src/__tests__/eventIndexer.test.ts`
  - `src/services/__tests__/eventIndexer.test.ts`
  - `src/services/__tests__/eventIndexerCheckpoints.test.ts`